### PR TITLE
fix migration folder path in appsettings

### DIFF
--- a/src/Altinn.Notifications/appsettings.json
+++ b/src/Altinn.Notifications/appsettings.json
@@ -5,7 +5,7 @@
     "ProfileSubscriptionKey": "obtained at runtime"
   },
   "PostgreSQLSettings": {
-    "WorkspacePath": "Altinn.Notifications.Persistence/Migration",
+    "WorkspacePath": "Migration",
     "AdminConnectionString": "Host=localhost;Port=5432;Username=platform_notifications_admin;Password={0};Database=notificationsdb",
     "ConnectionString": "Host=localhost;Port=5432;Username=platform_notifications;Password={0};Database=notificationsdb",
     "notificationsDbAdminPwd": "Password",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Pods fail on startup in AT due to the migration folder not being found. Fixed value in appsettings to reflect actual path for migration folder in docker container.