### PR TITLE
return object on post of order

### DIFF
--- a/src/Altinn.Notifications/Controllers/EmailNotificationOrdersController.cs
+++ b/src/Altinn.Notifications/Controllers/EmailNotificationOrdersController.cs
@@ -66,6 +66,6 @@ public class EmailNotificationOrdersController : ControllerBase
         }
 
         string selfLink = registeredOrder!.GetSelfLink();
-        return Accepted(selfLink, registeredOrder!.Id.ToString());
+        return Accepted(selfLink, new OrderIdExt(registeredOrder!.Id));
     }
 }

--- a/src/Altinn.Notifications/Models/OrderIdExt.cs
+++ b/src/Altinn.Notifications/Models/OrderIdExt.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Altinn.Notifications.Models
+{
+    /// <summary>
+    /// A class representing a container for an order id.
+    /// </summary>
+    /// <remarks>
+    /// External representaion to be used in the API.
+    /// </remarks>
+    public class OrderIdExt
+    {
+        /// <summary>
+        /// The order id
+        /// </summary>
+        [JsonPropertyName("orderId")]
+        public Guid OrderId { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderIdExt"/> class.
+        /// </summary>
+        public OrderIdExt(Guid orderId)
+        {
+            OrderId = orderId;
+        }
+    }
+}

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
@@ -201,8 +201,8 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
         // Assert
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         Assert.NotNull(orderIdObjectExt);
-        Assert.Equal("http://localhost:5090/notifications/api/v1/orders/" + _order.Id, response.Headers?.Location?.ToString());
         Assert.Equal(_order.Id, orderIdObjectExt.OrderId);
+        Assert.Equal("http://localhost:5090/notifications/api/v1/orders/" + _order.Id, response.Headers?.Location?.ToString());
 
         serviceMock.VerifyAll();
     }

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
@@ -256,12 +256,13 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
 
         // Act
         HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-        string actualOrderId = await response.Content.ReadAsStringAsync();
+        string respoonseString = await response.Content.ReadAsStringAsync();
+        OrderIdExt? orderIdObjectExt = JsonSerializer.Deserialize<OrderIdExt>(respoonseString);
 
         // Assert
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
         Assert.Equal("http://localhost:5090/notifications/api/v1/orders/" + _order.Id, response.Headers?.Location?.ToString());
-        Assert.Equal($"{_order.Id}", actualOrderId);
+        Assert.Equal(_order.Id, orderIdObjectExt.OrderId);
 
         serviceMock.VerifyAll();
     }

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
@@ -261,8 +261,10 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
 
         // Assert
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-        Assert.Equal("http://localhost:5090/notifications/api/v1/orders/" + _order.Id, response.Headers?.Location?.ToString());
+        Assert.NotNull(orderIdObjectExt);
         Assert.Equal(_order.Id, orderIdObjectExt.OrderId);
+
+        Assert.Equal("http://localhost:5090/notifications/api/v1/orders/" + _order.Id, response.Headers?.Location?.ToString());
 
         serviceMock.VerifyAll();
     }

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
@@ -195,12 +195,14 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
 
         // Act
         HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-        string actualOrderId = await response.Content.ReadAsStringAsync();
+        string respoonseString = await response.Content.ReadAsStringAsync();
+        OrderIdExt? orderIdObjectExt = JsonSerializer.Deserialize<OrderIdExt>(respoonseString);
 
         // Assert
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.NotNull(orderIdObjectExt);
         Assert.Equal("http://localhost:5090/notifications/api/v1/orders/" + _order.Id, response.Headers?.Location?.ToString());
-        Assert.Equal($"{_order.Id}", actualOrderId);
+        Assert.Equal(_order.Id, orderIdObjectExt.OrderId);
 
         serviceMock.VerifyAll();
     }

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/PostTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/PostTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
 
 using Altinn.Notifications.Controllers;
 using Altinn.Notifications.Core.Enums;
@@ -75,12 +76,13 @@ public class PostTests : IClassFixture<IntegrationTestWebApplicationFactory<Emai
 
         // Act
         HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-        string orderId = await response.Content.ReadAsStringAsync();
+        string respoonseString = await response.Content.ReadAsStringAsync();
+        OrderIdExt? orderIdObjectExt = JsonSerializer.Deserialize<OrderIdExt>(respoonseString);
 
         // Assert
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-        Guid.Parse(orderId);
-        Assert.Equal("http://localhost:5090/notifications/api/v1/orders/" + orderId, response.Headers?.Location?.ToString());
+        Assert.NotNull(orderIdObjectExt);
+        Assert.Equal("http://localhost:5090/notifications/api/v1/orders/" + orderIdObjectExt.OrderId, response.Headers?.Location?.ToString());
     }
 
     [Fact]
@@ -97,12 +99,13 @@ public class PostTests : IClassFixture<IntegrationTestWebApplicationFactory<Emai
 
         // Act
         HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-        string orderId = await response.Content.ReadAsStringAsync();
+        string respoonseString = await response.Content.ReadAsStringAsync();
+        OrderIdExt? orderIdObjectExt = JsonSerializer.Deserialize<OrderIdExt>(respoonseString);
 
         // Assert
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-        Guid.Parse(orderId);
-        Assert.Equal("http://localhost:5090/notifications/api/v1/orders/" + orderId, response.Headers?.Location?.ToString());
+        Assert.NotNull(orderIdObjectExt);
+        Assert.Equal("http://localhost:5090/notifications/api/v1/orders/" + orderIdObjectExt.OrderId, response.Headers?.Location?.ToString());
     }
 
     public async void Dispose()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Using a json object to return the created order id on post of notification order request

## Related Issue(s)
- #247 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
