### PR TITLE
removed from address prop from ext model

### DIFF
--- a/src/Altinn.Notifications/Mappers/OrderMapper.cs
+++ b/src/Altinn.Notifications/Mappers/OrderMapper.cs
@@ -18,7 +18,7 @@ public static class OrderMapper
     /// </summary>
     public static NotificationOrderRequest MapToOrderRequest(this EmailNotificationOrderRequestExt extRequest, string creator)
     {
-        var emailTemplate = new EmailTemplate(extRequest.FromAddress, extRequest.Subject, extRequest.Body, extRequest.ContentType);
+        var emailTemplate = new EmailTemplate(null, extRequest.Subject, extRequest.Body, extRequest.ContentType);
 
         var recipients = new List<Recipient>();
 

--- a/src/Altinn.Notifications/Models/EmailNotificationOrderRequestExt.cs
+++ b/src/Altinn.Notifications/Models/EmailNotificationOrderRequestExt.cs
@@ -14,12 +14,6 @@ namespace Altinn.Notifications.Models;
 public class EmailNotificationOrderRequestExt
 {
     /// <summary>
-    /// Gets or sets the from address to use as sender of the email
-    /// </summary>
-    [JsonPropertyName("fromAddress")]
-    public string? FromAddress { get; set; }
-
-    /// <summary>
     /// Gets or sets the subject of the email 
     /// </summary>
     [JsonPropertyName("subject")]

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
@@ -55,7 +55,6 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
         {
             Body = "email-body",
             ContentType = EmailContentType.Html,
-            FromAddress = "sender@domain.com",
             Recipients = new List<RecipientExt>() { new RecipientExt() { EmailAddress = "recipient1@domain.com" }, new RecipientExt() { EmailAddress = "recipient2@domain.com" } },
             SendersReference = "senders-reference",
             RequestedSendTime = DateTime.UtcNow,
@@ -181,8 +180,6 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
     public async Task Post_ServiceReturnsOrder_Accepted()
     {
         // Arrange
-        string expectedFromAddress = "sender@domain.com";
-
         Mock<IEmailNotificationOrderService> serviceMock = new();
         serviceMock.Setup(s => s.RegisterEmailNotificationOrder(It.IsAny<NotificationOrderRequest>()))
               .Callback<NotificationOrderRequest>(orderRequest =>
@@ -192,7 +189,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
                       .FirstOrDefault();
 
                   Assert.NotNull(emailTemplate);
-                  Assert.Equal(expectedFromAddress, emailTemplate.FromAddress);
+                  Assert.Equal(string.Empty, emailTemplate.FromAddress);
               })
             .ReturnsAsync((_order, null));
 

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/PostTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/PostTests.cs
@@ -39,7 +39,6 @@ public class PostTests : IClassFixture<IntegrationTestWebApplicationFactory<Emai
         {
             Body = "email-body",
             ContentType = EmailContentType.Html,
-            FromAddress = "sender@domain.com",
             Recipients = new List<RecipientExt>()
             {
                 new RecipientExt

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -128,7 +128,6 @@ public class OrderMapperTests
         {
             Body = "email-body",
             ContentType = EmailContentType.Html,
-            FromAddress = "sender@domain.com",
             Recipients = new List<RecipientExt>() { new RecipientExt() { EmailAddress = "recipient1@domain.com" }, new RecipientExt() { EmailAddress = "recipient2@domain.com" } },
             SendersReference = "senders-reference",
             RequestedSendTime = sendTime,
@@ -142,7 +141,7 @@ public class OrderMapperTests
             Templates = new List<INotificationTemplate>()
             {
                 new EmailTemplate(
-                    "sender@domain.com",
+                    string.Empty,
                     "email-subject",
                     "email-body",
                     EmailContentType.Html)

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
@@ -27,7 +27,6 @@ public class EmailNotificationOrderRequestValidatorTests
         var order = new EmailNotificationOrderRequestExt()
         {
             Subject = "This is an email subject",
-            FromAddress = "sender@domain.com",
             Recipients = new List<RecipientExt>() { new RecipientExt() { Id = "16069412345", EmailAddress = "recipient2@domain.com" } },
             Body = "This is an email body"
         };
@@ -42,7 +41,6 @@ public class EmailNotificationOrderRequestValidatorTests
         var order = new EmailNotificationOrderRequestExt()
         {
             Subject = "This is an email subject",
-            FromAddress = "sender@domain.com",
             Recipients = new List<RecipientExt>() { new RecipientExt() { Id = "16069412345" } },
             Body = "This is an email body"
         };
@@ -59,7 +57,6 @@ public class EmailNotificationOrderRequestValidatorTests
         var order = new EmailNotificationOrderRequestExt()
         {
             Subject = "This is an email subject",
-            FromAddress = "sender@domain.com",
             Recipients = new List<RecipientExt>() { new RecipientExt() { Id = "16069412345", EmailAddress = "recipient2@domain.com" } },
             Body = "This is an email body",
             RequestedSendTime = DateTime.UtcNow.AddDays(-1)
@@ -76,7 +73,6 @@ public class EmailNotificationOrderRequestValidatorTests
     {
         var order = new EmailNotificationOrderRequestExt()
         {
-            FromAddress = "sender@domain.com",
             Recipients = new List<RecipientExt>() { new RecipientExt() { Id = "16069412345", EmailAddress = "recipient2@domain.com" } },
             Body = "This is an email body"
         };
@@ -92,7 +88,6 @@ public class EmailNotificationOrderRequestValidatorTests
         var order = new EmailNotificationOrderRequestExt()
         {
             Subject = "This is an email subject",
-            FromAddress = "sender@domain.com",
             Recipients = new List<RecipientExt>() { new RecipientExt() { Id = "16069412345", EmailAddress = "recipient2@domain.com" } },
         };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
From address is no longer included in the email notification order request external model. 
Default from address will be used for all email notifications for now. 

## Related Issue(s)
- #264 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
