### PR TITLE
adjust grace period to 1 min

### DIFF
--- a/src/Altinn.Notifications.Persistence/Migration/v0.08/01-setup-functions.sql
+++ b/src/Altinn.Notifications.Persistence/Migration/v0.08/01-setup-functions.sql
@@ -6,10 +6,10 @@ BEGIN
 RETURN QUERY
 	UPDATE notifications.orders
 	SET processedstatus = 'Processing'
-	WHERE _id IN (select _id 
-				 from notifications.orders 
-				 where processedstatus = 'Registered' 
-				 and requestedsendtime <= now() + INTERVAL '30 seconds'
+	WHERE _id IN (select _id
+				 from notifications.orders
+				 where processedstatus = 'Registered'
+				 and requestedsendtime <= now() + INTERVAL '1 minute'
 				 limit 50)
 	RETURNING notificationorder AS notificationorders;
 END;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Edited existing release, will run script manually in AT envs to save number of migration version. 

1 minute makes more sense wr.t. to the schedule of the cron-jobs. 

## Related Issue(s)
- #262