### PR TITLE
Validating `requestedSendTime` to check if it has zone specified or not

### DIFF
--- a/src/Altinn.Notifications/Mappers/OrderMapper.cs
+++ b/src/Altinn.Notifications/Mappers/OrderMapper.cs
@@ -29,7 +29,7 @@ public static class OrderMapper
             extRequest.SendersReference,
             creator,
             new List<INotificationTemplate>() { emailTemplate },
-            extRequest.RequestedSendTime,
+            extRequest.RequestedSendTime.ToUniversalTime(),
             NotificationChannel.Email,
             recipients);
     }

--- a/src/Altinn.Notifications/Validators/EmailNotificationOrderRequestValidator.cs
+++ b/src/Altinn.Notifications/Validators/EmailNotificationOrderRequestValidator.cs
@@ -23,7 +23,7 @@ public class EmailNotificationOrderRequestValidator : AbstractValidator<EmailNot
             .WithMessage("A valid email address must be provided for all recipients.");
 
         RuleFor(order => order.RequestedSendTime)
-            .Must(sendTime => HasTimeZone(sendTime))
+            .Must(sendTime => sendTime.Kind != DateTimeKind.Unspecified)
             .WithMessage("No time zone specified.")
             .Must(sendTime => sendTime >= DateTime.UtcNow.AddMinutes(-5))
             .WithMessage("Send time must be in the future. Leave blank to send immediately.");
@@ -51,15 +51,5 @@ public class EmailNotificationOrderRequestValidator : AbstractValidator<EmailNot
         Match match = regex.Match(email);
 
         return match.Success;
-    }
-
-    /// <summary>
-    /// Validated whether the DateTime object has time zone
-    /// </summary>
-    /// <param name="sendTime">The DateTime object which need to be verified whether it has time zone or not</param>
-    /// <returns>A boolean indicating that the DateTime object has time zone or not</returns>
-    internal static bool HasTimeZone(DateTime sendTime)
-    {
-        return sendTime.Kind != DateTimeKind.Unspecified;
     }
 }

--- a/src/Altinn.Notifications/Validators/EmailNotificationOrderRequestValidator.cs
+++ b/src/Altinn.Notifications/Validators/EmailNotificationOrderRequestValidator.cs
@@ -50,4 +50,14 @@ public class EmailNotificationOrderRequestValidator : AbstractValidator<EmailNot
 
         return match.Success;
     }
+
+    /// <summary>
+    /// Validated whether the DateTime object has time zone
+    /// </summary>
+    /// <param name="sendTime">The DateTime object which need to be verified whether it has time zone or not</param>
+    /// <returns>A boolean indicating that the DateTime object has time zone or not</returns>
+    internal static bool HasTimeZone(DateTime sendTime)
+    {
+        return sendTime.Kind != DateTimeKind.Unspecified;
+    }
 }

--- a/src/Altinn.Notifications/Validators/EmailNotificationOrderRequestValidator.cs
+++ b/src/Altinn.Notifications/Validators/EmailNotificationOrderRequestValidator.cs
@@ -24,7 +24,7 @@ public class EmailNotificationOrderRequestValidator : AbstractValidator<EmailNot
 
         RuleFor(order => order.RequestedSendTime)
             .Must(sendTime => sendTime.Kind != DateTimeKind.Unspecified)
-            .WithMessage("No time zone specified.")
+            .WithMessage("The requested send time value must have specified a time zone.")
             .Must(sendTime => sendTime >= DateTime.UtcNow.AddMinutes(-5))
             .WithMessage("Send time must be in the future. Leave blank to send immediately.");
 

--- a/src/Altinn.Notifications/Validators/EmailNotificationOrderRequestValidator.cs
+++ b/src/Altinn.Notifications/Validators/EmailNotificationOrderRequestValidator.cs
@@ -23,8 +23,10 @@ public class EmailNotificationOrderRequestValidator : AbstractValidator<EmailNot
             .WithMessage("A valid email address must be provided for all recipients.");
 
         RuleFor(order => order.RequestedSendTime)
-          .Must(sendTime => sendTime >= DateTime.UtcNow.AddMinutes(-5))
-          .WithMessage("Send time must be in the future. Leave blank to send immediately.");
+            .Must(sendTime => HasTimeZone(sendTime))
+            .WithMessage("No time zone specified.")
+            .Must(sendTime => sendTime >= DateTime.UtcNow.AddMinutes(-5))
+            .WithMessage("Send time must be in the future. Leave blank to send immediately.");
 
         RuleFor(order => order.Body).NotEmpty();
         RuleFor(order => order.Subject).NotEmpty();

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -141,6 +141,42 @@ public class OrderMapperTests
     }
 
     [Fact]
+    public void MapToOrderRequest_SendTimeLocalConvertedToUtc_AreEquivalent()
+    {
+        DateTime sendTime = DateTime.Now; // Setting the time in Local time zone
+
+        // Arrange
+        EmailNotificationOrderRequestExt orderRequestExt = new()
+        {
+            Body = "email-body",
+            ContentType = EmailContentTypeExt.Html,
+            RequestedSendTime = sendTime, // Local time zone
+            Subject = "email-subject"
+        };
+
+        NotificationOrderRequest expected = new()
+        {
+            Creator = new Creator("ttd"),
+            Templates = new List<INotificationTemplate>()
+            {
+                new EmailTemplate(
+                    string.Empty,
+                    "email-subject",
+                    "email-body",
+                    EmailContentType.Html)
+            },
+            RequestedSendTime = sendTime.ToUniversalTime(),  // Expecting the time in UTC time zone
+            NotificationChannel = NotificationChannel.Email
+        };
+
+        // Act
+        var actual = orderRequestExt.MapToOrderRequest("ttd");
+
+        // Assert
+        Assert.Equivalent(expected, actual, true);
+    }
+
+    [Fact]
     public void MapToNotificationOrderWithStatusExt_EmailStatusProvided_AreEquivalent()
     {
         // Arrange

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
@@ -112,7 +112,7 @@ public class EmailNotificationOrderRequestValidatorTests
         var actual = _validator.Validate(order);
 
         Assert.False(actual.IsValid);
-        Assert.Contains(actual.Errors, a => a.ErrorMessage.Equals("No time zone specified."));
+        Assert.Contains(actual.Errors, a => a.ErrorMessage.Equals("The requested send time value must have specified a time zone."));
     }
 
     [Fact]

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
@@ -67,6 +67,55 @@ public class EmailNotificationOrderRequestValidatorTests
     }
 
     [Fact]
+    public void Validate_SendTimeHasLocalZone_ReturnsTrue()
+    {
+        var order = new EmailNotificationOrderRequestExt()
+        {
+            Subject = "This is an email subject",
+            Recipients = new List<RecipientExt>() { new RecipientExt() { EmailAddress = "recipient2@domain.com" } },
+            Body = "This is an email body",
+            RequestedSendTime = DateTime.Now
+        };
+
+        var actual = _validator.Validate(order);
+
+        Assert.True(actual.IsValid);
+    }
+
+    [Fact]
+    public void Validate_SendTimeHasUtcZone_ReturnsTrue()
+    {
+        var order = new EmailNotificationOrderRequestExt()
+        {
+            Subject = "This is an email subject",
+            Recipients = new List<RecipientExt>() { new RecipientExt() { EmailAddress = "recipient2@domain.com" } },
+            Body = "This is an email body",
+            RequestedSendTime = DateTime.UtcNow
+        };
+
+        var actual = _validator.Validate(order);
+
+        Assert.True(actual.IsValid);
+    }
+
+    [Fact]
+    public void Validate_SendTimeHasNoZone_ReturnsFalse()
+    {
+        var order = new EmailNotificationOrderRequestExt()
+        {
+            Subject = "This is an email subject",
+            Recipients = new List<RecipientExt>() { new RecipientExt() { EmailAddress = "recipient2@domain.com" } },
+            Body = "This is an email body",
+            RequestedSendTime = new DateTime(2023, 06, 16, 08, 50, 00, DateTimeKind.Unspecified)
+        };
+
+        var actual = _validator.Validate(order);
+
+        Assert.False(actual.IsValid);
+        Assert.Contains(actual.Errors, a => a.ErrorMessage.Equals("No time zone specified."));
+    }
+
+    [Fact]
     public void Validate_SendTimePassed_ReturnsFalse()
     {
         var order = new EmailNotificationOrderRequestExt()


### PR DESCRIPTION
Validating `requestedSendTime` to check if it has zone specified or not.

## Description
Introduced a method name `HasTimeZone` in the `EmailNotificationOrderRequestValidator` validator and implemented validator with this method. If the zone isn't specified then it'll throw a 400 HTTP error.

## Related Issue(s)
- FIX #275 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added
- [x] All tests run green