### PR TITLE
#336 Implementation of core logic for placing an sms notification order

### DIFF
--- a/src/Altinn.Notifications.Core/Configuration/NotificationOrderConfig.cs
+++ b/src/Altinn.Notifications.Core/Configuration/NotificationOrderConfig.cs
@@ -13,5 +13,5 @@ public class NotificationOrderConfig
     /// <summary>
     /// Default sender number for sms notifications
     /// </summary>
-    public string DefaultSenderNumber { get; set; } = string.Empty;
+    public string DefaultSmsSender { get; set; } = string.Empty;
 }

--- a/src/Altinn.Notifications.Core/Configuration/NotificationOrderConfig.cs
+++ b/src/Altinn.Notifications.Core/Configuration/NotificationOrderConfig.cs
@@ -13,5 +13,5 @@ public class NotificationOrderConfig
     /// <summary>
     /// Default sender number for sms notifications
     /// </summary>
-    public string DefaultSmsSender { get; set; } = string.Empty;
+    public string DefaultSmsSenderNumber { get; set; } = string.Empty;
 }

--- a/src/Altinn.Notifications.Core/Configuration/NotificationOrderConfig.cs
+++ b/src/Altinn.Notifications.Core/Configuration/NotificationOrderConfig.cs
@@ -9,4 +9,9 @@ public class NotificationOrderConfig
     /// Default from address for email notifications
     /// </summary>
     public string DefaultEmailFromAddress { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Default sender number for sms notifications
+    /// </summary>
+    public string DefaultSenderNumber { get; set; } = string.Empty;
 }

--- a/src/Altinn.Notifications.Core/Enums/NotificationChannel.cs
+++ b/src/Altinn.Notifications.Core/Enums/NotificationChannel.cs
@@ -8,5 +8,10 @@ public enum NotificationChannel
     /// <summary>
     /// The selected channel for the notification is email.
     /// </summary>
-    Email
+    Email,
+
+    /// <summary>
+    /// The selected channel for the notification is SMS.
+    /// </summary>
+    Sms
 }

--- a/src/Altinn.Notifications.Core/Enums/NotificationTemplateType.cs
+++ b/src/Altinn.Notifications.Core/Enums/NotificationTemplateType.cs
@@ -6,6 +6,7 @@
 /// </summary>
 public enum NotificationTemplateType
 {
-    Email
+    Email,
+    Sms
 }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/Altinn.Notifications.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.Notifications.Core/Extensions/ServiceCollectionExtensions.cs
@@ -32,7 +32,7 @@ public static class ServiceCollectionExtensions
             .AddSingleton<IDateTimeService, DateTimeService>()
             .AddSingleton<IOrderProcessingService, OrderProcessingService>()
             .AddSingleton<IGetOrderService, GetOrderService>()
-            .AddSingleton<IEmailNotificationOrderService, EmailNotificationOrderService>()
+            .AddSingleton<IOrderRequestService, OrderRequestService>()
             .AddSingleton<INotificationSummaryService, NotificationSummaryService>()
             .AddSingleton<IEmailNotificationService, EmailNotificationService>()
             .AddSingleton<IAltinnServiceUpdateService, AltinnServiceUpdateService>()

--- a/src/Altinn.Notifications.Core/Models/NotificationTemplate/INotificationTemplate.cs
+++ b/src/Altinn.Notifications.Core/Models/NotificationTemplate/INotificationTemplate.cs
@@ -8,6 +8,7 @@ namespace Altinn.Notifications.Core.Models.NotificationTemplate;
 /// Base class for a notification template
 /// </summary>
 [JsonDerivedType(typeof(EmailTemplate), "email")]
+[JsonDerivedType(typeof(SmsTemplate), "sms")]
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "$")]
 public interface INotificationTemplate
 {

--- a/src/Altinn.Notifications.Core/Models/NotificationTemplate/SmsTemplate.cs
+++ b/src/Altinn.Notifications.Core/Models/NotificationTemplate/SmsTemplate.cs
@@ -16,7 +16,7 @@ public class SmsTemplate : INotificationTemplate
     public string SenderNumber { get; internal set; } = string.Empty;
 
     /// <summary>
-    /// Gets the body of emails created by the template    
+    /// Gets the body of SMSs created by the template    
     /// </summary>
     public string Body { get; internal set; } = string.Empty;
 

--- a/src/Altinn.Notifications.Core/Models/NotificationTemplate/SmsTemplate.cs
+++ b/src/Altinn.Notifications.Core/Models/NotificationTemplate/SmsTemplate.cs
@@ -13,7 +13,7 @@ public class SmsTemplate : INotificationTemplate
     /// <summary>
     /// Gets the number from which the SMS is created by the template    
     /// </summary>
-    public string SenderHandle { get; internal set; } = string.Empty;
+    public string SenderNumber { get; internal set; } = string.Empty;
 
     /// <summary>
     /// Gets the body of SMSs created by the template    
@@ -23,9 +23,9 @@ public class SmsTemplate : INotificationTemplate
     /// <summary>
     /// Initializes a new instance of the <see cref="SmsTemplate"/> class.
     /// </summary>
-    public SmsTemplate(string? senderHandle, string body)
+    public SmsTemplate(string? senderNumber, string body)
     {
-        SenderHandle = senderHandle ?? string.Empty;
+        SenderNumber = senderNumber ?? string.Empty;
         Body = body;
         Type = NotificationTemplateType.Sms;
     }

--- a/src/Altinn.Notifications.Core/Models/NotificationTemplate/SmsTemplate.cs
+++ b/src/Altinn.Notifications.Core/Models/NotificationTemplate/SmsTemplate.cs
@@ -3,7 +3,7 @@ using Altinn.Notifications.Core.Enums;
 namespace Altinn.Notifications.Core.Models.NotificationTemplate;
 
 /// <summary>
-/// Template for a SMS notification
+/// Template for an SMS notification
 /// </summary>
 public class SmsTemplate : INotificationTemplate
 {

--- a/src/Altinn.Notifications.Core/Models/NotificationTemplate/SmsTemplate.cs
+++ b/src/Altinn.Notifications.Core/Models/NotificationTemplate/SmsTemplate.cs
@@ -13,7 +13,7 @@ public class SmsTemplate : INotificationTemplate
     /// <summary>
     /// Gets the number from which the SMS is created by the template    
     /// </summary>
-    public string SenderNumber { get; internal set; } = string.Empty;
+    public string SenderHandle { get; internal set; } = string.Empty;
 
     /// <summary>
     /// Gets the body of SMSs created by the template    
@@ -23,9 +23,9 @@ public class SmsTemplate : INotificationTemplate
     /// <summary>
     /// Initializes a new instance of the <see cref="SmsTemplate"/> class.
     /// </summary>
-    public SmsTemplate(string? senderNumber, string body)
+    public SmsTemplate(string? senderHandle, string body)
     {
-        SenderNumber = senderNumber ?? string.Empty;
+        SenderHandle = senderHandle ?? string.Empty;
         Body = body;
         Type = NotificationTemplateType.Sms;
     }

--- a/src/Altinn.Notifications.Core/Models/NotificationTemplate/SmsTemplate.cs
+++ b/src/Altinn.Notifications.Core/Models/NotificationTemplate/SmsTemplate.cs
@@ -1,0 +1,39 @@
+using Altinn.Notifications.Core.Enums;
+
+namespace Altinn.Notifications.Core.Models.NotificationTemplate;
+
+/// <summary>
+/// Template for a SMS notification
+/// </summary>
+public class SmsTemplate : INotificationTemplate
+{
+    /// <inheritdoc/>
+    public NotificationTemplateType Type { get; internal set; }
+
+    /// <summary>
+    /// Gets the number from which the SMS is created by the template    
+    /// </summary>
+    public string SenderNumber { get; internal set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the body of emails created by the template    
+    /// </summary>
+    public string Body { get; internal set; } = string.Empty;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SmsTemplate"/> class.
+    /// </summary>
+    public SmsTemplate(string? senderNumber, string body)
+    {
+        SenderNumber = senderNumber ?? string.Empty;
+        Body = body;
+        Type = NotificationTemplateType.Sms;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SmsTemplate"/> class.
+    /// </summary>
+    internal SmsTemplate()
+    {
+    }
+}

--- a/src/Altinn.Notifications.Core/Services/Interfaces/IOrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/Interfaces/IOrderRequestService.cs
@@ -13,5 +13,5 @@ public interface IOrderRequestService
     /// </summary>
     /// <param name="orderRequest">The email notification order request</param>
     /// <returns>The registered notification order</returns>
-    public Task<(NotificationOrder? Order, ServiceError? Error)> RegisterEmailNotificationOrder(NotificationOrderRequest orderRequest);
+    public Task<(NotificationOrder? Order, ServiceError? Error)> RegisterNotificationOrder(NotificationOrderRequest orderRequest);
 }

--- a/src/Altinn.Notifications.Core/Services/Interfaces/IOrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/Interfaces/IOrderRequestService.cs
@@ -4,14 +4,14 @@ using Altinn.Notifications.Core.Models.Orders;
 namespace Altinn.Notifications.Core.Services.Interfaces;
 
 /// <summary>
-/// Interface for the email notification order service
+/// Interface for the notification order service
 /// </summary>
 public interface IOrderRequestService
 {
     /// <summary>
     /// Registers a new order
     /// </summary>
-    /// <param name="orderRequest">The email notification order request</param>
+    /// <param name="orderRequest">The notification order request</param>
     /// <returns>The registered notification order</returns>
     public Task<(NotificationOrder? Order, ServiceError? Error)> RegisterNotificationOrder(NotificationOrderRequest orderRequest);
 }

--- a/src/Altinn.Notifications.Core/Services/Interfaces/IOrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/Interfaces/IOrderRequestService.cs
@@ -6,7 +6,7 @@ namespace Altinn.Notifications.Core.Services.Interfaces;
 /// <summary>
 /// Interface for the email notification order service
 /// </summary>
-public interface IEmailNotificationOrderService
+public interface IOrderRequestService
 {
     /// <summary>
     /// Registers a new order

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -31,7 +31,7 @@ public class OrderRequestService : IOrderRequestService
     }
 
     /// <inheritdoc/>
-    public async Task<(NotificationOrder? Order, ServiceError? Error)> RegisterEmailNotificationOrder(NotificationOrderRequest orderRequest)
+    public async Task<(NotificationOrder? Order, ServiceError? Error)> RegisterNotificationOrder(NotificationOrderRequest orderRequest)
     {
         Guid orderId = _guid.NewGuid();
         DateTime created = _dateTime.UtcNow();

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -62,9 +62,9 @@ public class OrderRequestService : IOrderRequestService
             template.FromAddress = _defaultEmailFromAddress;
         }
 
-        foreach (var template in templates.OfType<SmsTemplate>().Where(template => string.IsNullOrEmpty(template.SenderNumber)))
+        foreach (var template in templates.OfType<SmsTemplate>().Where(template => string.IsNullOrEmpty(template.SenderHandle)))
         {
-            template.SenderNumber = _defaultSmsSender;
+            template.SenderHandle = _defaultSmsSender;
         }
 
         return templates;

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -38,7 +38,7 @@ public class OrderRequestService : IOrderRequestService
         Guid orderId = _guid.NewGuid();
         DateTime created = _dateTime.UtcNow();
 
-        var templates = SetFromAddressOrSenderNumberIfNotDefined(orderRequest.Templates);
+        var templates = SetSenderIfNotDefined(orderRequest.Templates);
 
         var order = new NotificationOrder(
             orderId,
@@ -55,7 +55,7 @@ public class OrderRequestService : IOrderRequestService
         return (savedOrder, null);
     }
 
-    private List<INotificationTemplate> SetFromAddressOrSenderNumberIfNotDefined(List<INotificationTemplate> templates)
+    private List<INotificationTemplate> SetSenderIfNotDefined(List<INotificationTemplate> templates)
     {
         foreach (var template in templates.OfType<EmailTemplate>().Where(template => string.IsNullOrEmpty(template.FromAddress)))
         {

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -10,9 +10,9 @@ using Microsoft.Extensions.Options;
 namespace Altinn.Notifications.Core.Services;
 
 /// <summary>
-/// Implementation of the <see cref="IEmailNotificationOrderService"/>. 
+/// Implementation of the <see cref="IOrderRequestService"/>. 
 /// </summary>
-public class EmailNotificationOrderService : IEmailNotificationOrderService
+public class OrderRequestService : IOrderRequestService
 {
     private readonly IOrderRepository _repository;
     private readonly IGuidService _guid;
@@ -20,9 +20,9 @@ public class EmailNotificationOrderService : IEmailNotificationOrderService
     private readonly string _defaultFromAddress;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="EmailNotificationOrderService"/> class.
+    /// Initializes a new instance of the <see cref="OrderRequestService"/> class.
     /// </summary>
-    public EmailNotificationOrderService(IOrderRepository repository, IGuidService guid, IDateTimeService dateTime, IOptions<NotificationOrderConfig> config)
+    public OrderRequestService(IOrderRepository repository, IGuidService guid, IDateTimeService dateTime, IOptions<NotificationOrderConfig> config)
     {
         _repository = repository;
         _guid = guid;

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -62,9 +62,9 @@ public class OrderRequestService : IOrderRequestService
             template.FromAddress = _defaultEmailFromAddress;
         }
 
-        foreach (var template in templates.OfType<SmsTemplate>().Where(template => string.IsNullOrEmpty(template.SenderHandle)))
+        foreach (var template in templates.OfType<SmsTemplate>().Where(template => string.IsNullOrEmpty(template.SenderNumber)))
         {
-            template.SenderHandle = _defaultSmsSender;
+            template.SenderNumber = _defaultSmsSender;
         }
 
         return templates;

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -29,7 +29,7 @@ public class OrderRequestService : IOrderRequestService
         _guid = guid;
         _dateTime = dateTime;
         _defaultEmailFromAddress = config.Value.DefaultEmailFromAddress;
-        _defaultSmsSender = config.Value.DefaultSmsSender;
+        _defaultSmsSender = config.Value.DefaultSmsSenderNumber;
     }
 
     /// <inheritdoc/>

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -18,7 +18,7 @@ public class OrderRequestService : IOrderRequestService
     private readonly IGuidService _guid;
     private readonly IDateTimeService _dateTime;
     private readonly string _defaultEmailFromAddress;
-    private readonly string _defaultSenderNumber;
+    private readonly string _defaultSmsSender;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OrderRequestService"/> class.
@@ -29,7 +29,7 @@ public class OrderRequestService : IOrderRequestService
         _guid = guid;
         _dateTime = dateTime;
         _defaultEmailFromAddress = config.Value.DefaultEmailFromAddress;
-        _defaultSenderNumber = config.Value.DefaultSenderNumber;
+        _defaultSmsSender = config.Value.DefaultSmsSender;
     }
 
     /// <inheritdoc/>
@@ -64,7 +64,7 @@ public class OrderRequestService : IOrderRequestService
 
         foreach (var template in templates.OfType<SmsTemplate>().Where(template => string.IsNullOrEmpty(template.SenderNumber)))
         {
-            template.SenderNumber = _defaultSenderNumber;
+            template.SenderNumber = _defaultSmsSender;
         }
 
         return templates;

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -17,7 +17,7 @@ public class OrderRequestService : IOrderRequestService
     private readonly IOrderRepository _repository;
     private readonly IGuidService _guid;
     private readonly IDateTimeService _dateTime;
-    private readonly string _defaultFromAddress;
+    private readonly string _defaultEmailFromAddress;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OrderRequestService"/> class.
@@ -27,7 +27,7 @@ public class OrderRequestService : IOrderRequestService
         _repository = repository;
         _guid = guid;
         _dateTime = dateTime;
-        _defaultFromAddress = config.Value.DefaultEmailFromAddress;
+        _defaultEmailFromAddress = config.Value.DefaultEmailFromAddress;
     }
 
     /// <inheritdoc/>
@@ -57,7 +57,7 @@ public class OrderRequestService : IOrderRequestService
     {
         foreach (var template in templates.OfType<EmailTemplate>().Where(template => string.IsNullOrEmpty(template.FromAddress)))
         {
-            template.FromAddress = _defaultFromAddress;
+            template.FromAddress = _defaultEmailFromAddress;
         }
 
         return templates;

--- a/src/Altinn.Notifications/Controllers/EmailNotificationOrdersController.cs
+++ b/src/Altinn.Notifications/Controllers/EmailNotificationOrdersController.cs
@@ -29,15 +29,15 @@ namespace Altinn.Notifications.Controllers;
 public class EmailNotificationOrdersController : ControllerBase
 {
     private readonly IValidator<EmailNotificationOrderRequestExt> _validator;
-    private readonly IOrderRequestService _orderService;
+    private readonly IOrderRequestService _orderRequestService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EmailNotificationOrdersController"/> class.
     /// </summary>
-    public EmailNotificationOrdersController(IValidator<EmailNotificationOrderRequestExt> validator, IOrderRequestService orderService)
+    public EmailNotificationOrdersController(IValidator<EmailNotificationOrderRequestExt> validator, IOrderRequestService orderRequestService)
     {
         _validator = validator;
-        _orderService = orderService;
+        _orderRequestService = orderRequestService;
     }
 
     /// <summary>
@@ -71,7 +71,7 @@ public class EmailNotificationOrdersController : ControllerBase
         }
 
         var orderRequest = emailNotificationOrderRequest.MapToOrderRequest(creator);
-        (NotificationOrder? registeredOrder, ServiceError? error) = await _orderService.RegisterNotificationOrder(orderRequest);
+        (NotificationOrder? registeredOrder, ServiceError? error) = await _orderRequestService.RegisterNotificationOrder(orderRequest);
 
         if (error != null)
         {

--- a/src/Altinn.Notifications/Controllers/EmailNotificationOrdersController.cs
+++ b/src/Altinn.Notifications/Controllers/EmailNotificationOrdersController.cs
@@ -29,12 +29,12 @@ namespace Altinn.Notifications.Controllers;
 public class EmailNotificationOrdersController : ControllerBase
 {
     private readonly IValidator<EmailNotificationOrderRequestExt> _validator;
-    private readonly IEmailNotificationOrderService _orderService;
+    private readonly IOrderRequestService _orderService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EmailNotificationOrdersController"/> class.
     /// </summary>
-    public EmailNotificationOrdersController(IValidator<EmailNotificationOrderRequestExt> validator, IEmailNotificationOrderService orderService)
+    public EmailNotificationOrdersController(IValidator<EmailNotificationOrderRequestExt> validator, IOrderRequestService orderService)
     {
         _validator = validator;
         _orderService = orderService;

--- a/src/Altinn.Notifications/Controllers/EmailNotificationOrdersController.cs
+++ b/src/Altinn.Notifications/Controllers/EmailNotificationOrdersController.cs
@@ -71,7 +71,7 @@ public class EmailNotificationOrdersController : ControllerBase
         }
 
         var orderRequest = emailNotificationOrderRequest.MapToOrderRequest(creator);
-        (NotificationOrder? registeredOrder, ServiceError? error) = await _orderService.RegisterEmailNotificationOrder(orderRequest);
+        (NotificationOrder? registeredOrder, ServiceError? error) = await _orderService.RegisterNotificationOrder(orderRequest);
 
         if (error != null)
         {

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
@@ -206,13 +206,6 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
 
                   Assert.NotNull(emailTemplate);
                   Assert.Equal(string.Empty, emailTemplate.FromAddress);
-
-                  var smsTemplate = orderRequest.Templates
-                      .OfType<SmsTemplate>()
-                      .FirstOrDefault();
-
-                  Assert.NotNull(smsTemplate);
-                  Assert.Equal(string.Empty, smsTemplate.SenderHandle);
               })
             .ReturnsAsync((_order, null));
 

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
@@ -173,7 +173,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
     {
         // Arrange
         Mock<IOrderRequestService> serviceMock = new();
-        serviceMock.Setup(s => s.RegisterEmailNotificationOrder(It.IsAny<NotificationOrderRequest>()))
+        serviceMock.Setup(s => s.RegisterNotificationOrder(It.IsAny<NotificationOrderRequest>()))
             .ReturnsAsync((null, new ServiceError(500)));
 
         HttpClient client = GetTestClient(orderService: serviceMock.Object);
@@ -197,7 +197,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
     {
         // Arrange
         Mock<IOrderRequestService> serviceMock = new();
-        serviceMock.Setup(s => s.RegisterEmailNotificationOrder(It.IsAny<NotificationOrderRequest>()))
+        serviceMock.Setup(s => s.RegisterNotificationOrder(It.IsAny<NotificationOrderRequest>()))
               .Callback<NotificationOrderRequest>(orderRequest =>
               {
                   var emailTemplate = orderRequest.Templates
@@ -236,7 +236,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
     {
         // Arrange
         Mock<IOrderRequestService> serviceMock = new();
-        serviceMock.Setup(s => s.RegisterEmailNotificationOrder(It.IsAny<NotificationOrderRequest>()))
+        serviceMock.Setup(s => s.RegisterNotificationOrder(It.IsAny<NotificationOrderRequest>()))
               .Callback<NotificationOrderRequest>(orderRequest =>
               {
                   var emailTemplate = orderRequest.Templates
@@ -276,7 +276,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
         // Arrange
         Mock<IOrderRequestService> serviceMock = new();
 
-        serviceMock.Setup(s => s.RegisterEmailNotificationOrder(It.IsAny<NotificationOrderRequest>()))
+        serviceMock.Setup(s => s.RegisterNotificationOrder(It.IsAny<NotificationOrderRequest>()))
             .Callback<NotificationOrderRequest>(orderRequest =>
             {
                 var emailTemplate = orderRequest.Templates

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
@@ -172,7 +172,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
     public async Task Post_ServiceReturnsError_ServerError()
     {
         // Arrange
-        Mock<IEmailNotificationOrderService> serviceMock = new();
+        Mock<IOrderRequestService> serviceMock = new();
         serviceMock.Setup(s => s.RegisterEmailNotificationOrder(It.IsAny<NotificationOrderRequest>()))
             .ReturnsAsync((null, new ServiceError(500)));
 
@@ -196,7 +196,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
     public async Task Post_ValidScope_ServiceReturnsOrder_Accepted()
     {
         // Arrange
-        Mock<IEmailNotificationOrderService> serviceMock = new();
+        Mock<IOrderRequestService> serviceMock = new();
         serviceMock.Setup(s => s.RegisterEmailNotificationOrder(It.IsAny<NotificationOrderRequest>()))
               .Callback<NotificationOrderRequest>(orderRequest =>
               {
@@ -235,7 +235,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
     public async Task Post_ValidAccessToken_ServiceReturnsOrder_Accepted()
     {
         // Arrange
-        Mock<IEmailNotificationOrderService> serviceMock = new();
+        Mock<IOrderRequestService> serviceMock = new();
         serviceMock.Setup(s => s.RegisterEmailNotificationOrder(It.IsAny<NotificationOrderRequest>()))
               .Callback<NotificationOrderRequest>(orderRequest =>
               {
@@ -274,7 +274,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
     public async Task Post_OrderWithoutFromAddress_StringEmptyUsedAsServiceInput_Accepted()
     {
         // Arrange
-        Mock<IEmailNotificationOrderService> serviceMock = new();
+        Mock<IOrderRequestService> serviceMock = new();
 
         serviceMock.Setup(s => s.RegisterEmailNotificationOrder(It.IsAny<NotificationOrderRequest>()))
             .Callback<NotificationOrderRequest>(orderRequest =>
@@ -321,7 +321,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
         serviceMock.VerifyAll();
     }
 
-    private HttpClient GetTestClient(IValidator<EmailNotificationOrderRequestExt>? validator = null, IEmailNotificationOrderService? orderService = null)
+    private HttpClient GetTestClient(IValidator<EmailNotificationOrderRequestExt>? validator = null, IOrderRequestService? orderService = null)
     {
         if (validator == null)
         {
@@ -333,7 +333,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
 
         if (orderService == null)
         {
-            var orderServiceMock = new Mock<IEmailNotificationOrderService>();
+            var orderServiceMock = new Mock<IOrderRequestService>();
             orderService = orderServiceMock.Object;
         }
 

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
@@ -206,6 +206,13 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
 
                   Assert.NotNull(emailTemplate);
                   Assert.Equal(string.Empty, emailTemplate.FromAddress);
+
+                  var smsTemplate = orderRequest.Templates
+                      .OfType<SmsTemplate>()
+                      .FirstOrDefault();
+
+                  Assert.NotNull(smsTemplate);
+                  Assert.Equal(string.Empty, smsTemplate.SenderHandle);
               })
             .ReturnsAsync((_order, null));
 

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -21,7 +21,7 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices;
 public class OrderRequestServiceTests
 {
     [Fact]
-    public async Task RegisterNotificationOrder_Email_ExpectedInputToRepository()
+    public async Task RegisterNotificationOrder_ForEmail_ExpectedInputToRepository()
     {
         // Arrange
         DateTime sendTime = DateTime.UtcNow;
@@ -67,7 +67,7 @@ public class OrderRequestServiceTests
     }
 
     [Fact]
-    public async Task RegisterNotificationOrder_NoFromAddressDefaultInserted()
+    public async Task RegisterNotificationOrder_ForEmail_NoFromAddressDefaultInserted()
     {
         // Arrange
         DateTime sendTime = DateTime.UtcNow;

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices;
 
-public class EmailNotificationOrderServiceTests
+public class OrderRequestServiceTests
 {
     [Fact]
     public async Task RegisterEmailNotificationOrder_ExpectedInputToRepository()
@@ -112,7 +112,7 @@ public class EmailNotificationOrderServiceTests
         repoMock.VerifyAll();
     }
 
-    public static EmailNotificationOrderService GetTestService(IOrderRepository? repository = null, Guid? guid = null, DateTime? dateTime = null)
+    public static OrderRequestService GetTestService(IOrderRepository? repository = null, Guid? guid = null, DateTime? dateTime = null)
     {
         if (repository == null)
         {
@@ -132,6 +132,6 @@ public class EmailNotificationOrderServiceTests
         {
             DefaultEmailFromAddress = "noreply@altinn.no"
         });
-        return new EmailNotificationOrderService(repository, guidMock.Object, dateTimeMock.Object, config);
+        return new OrderRequestService(repository, guidMock.Object, dateTimeMock.Object, config);
     }
 }

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -21,7 +21,7 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices;
 public class OrderRequestServiceTests
 {
     [Fact]
-    public async Task RegisterEmailNotificationOrder_ExpectedInputToRepository()
+    public async Task RegisterNotificationOrder_ExpectedInputToRepository()
     {
         // Arrange
         DateTime sendTime = DateTime.UtcNow;
@@ -59,7 +59,7 @@ public class OrderRequestServiceTests
         var service = GetTestService(repoMock.Object, id, createdTime);
 
         // Act
-        (NotificationOrder? actual, ServiceError? _) = await service.RegisterEmailNotificationOrder(input);
+        (NotificationOrder? actual, ServiceError? _) = await service.RegisterNotificationOrder(input);
 
         // Assert
         Assert.Equivalent(expected, actual, true);
@@ -67,7 +67,7 @@ public class OrderRequestServiceTests
     }
 
     [Fact]
-    public async Task RegisterEmailNotificationOrder_NoFromAddressDefaultInserted()
+    public async Task RegisterNotificationOrder_NoFromAddressDefaultInserted()
     {
         // Arrange
         DateTime sendTime = DateTime.UtcNow;
@@ -105,7 +105,7 @@ public class OrderRequestServiceTests
         var service = GetTestService(repoMock.Object, id, createdTime);
 
         // Act
-        (NotificationOrder? actual, ServiceError? _) = await service.RegisterEmailNotificationOrder(input);
+        (NotificationOrder? actual, ServiceError? _) = await service.RegisterNotificationOrder(input);
 
         // Assert
         Assert.Equivalent(expected, actual, true);

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -129,7 +129,7 @@ public class OrderRequestServiceTests
             RequestedSendTime = sendTime,
             Recipients = { },
             SendersReference = "senders-reference",
-            Templates = { new SmsTemplate { Body = "sms-body", SenderHandle = "Skatteetaten" } }
+            Templates = { new SmsTemplate { Body = "sms-body", SenderNumber = "Skatteetaten" } }
         };
 
         NotificationOrderRequest input = new()
@@ -140,7 +140,7 @@ public class OrderRequestServiceTests
             Recipients = { },
             SendersReference = "senders-reference",
             RequestedSendTime = sendTime,
-            Templates = { new SmsTemplate { Body = "sms-body", SenderHandle = "Skatteetaten" } }
+            Templates = { new SmsTemplate { Body = "sms-body", SenderNumber = "Skatteetaten" } }
         };
 
         Mock<IOrderRepository> repoMock = new();
@@ -159,7 +159,7 @@ public class OrderRequestServiceTests
     }
 
     [Fact]
-    public async Task RegisterNotificationOrder_ForSms_NoSenderHandleDefaultInserted()
+    public async Task RegisterNotificationOrder_ForSms_NoSenderNumberDefaultInserted()
     {
         // Arrange
         DateTime sendTime = DateTime.UtcNow;
@@ -175,7 +175,7 @@ public class OrderRequestServiceTests
             RequestedSendTime = sendTime,
             Recipients = { },
             SendersReference = "senders-reference",
-            Templates = { new SmsTemplate { Body = "sms-body", SenderHandle = "TestDefaultSmsSenderHandle" } }
+            Templates = { new SmsTemplate { Body = "sms-body", SenderNumber = "TestDefaultSmsSenderNumber" } }
         };
 
         NotificationOrderRequest input = new()
@@ -223,7 +223,7 @@ public class OrderRequestServiceTests
         var config = Options.Create<NotificationOrderConfig>(new()
         {
             DefaultEmailFromAddress = "noreply@altinn.no",
-            DefaultSmsSender = "TestDefaultSmsSenderHandle"
+            DefaultSmsSender = "TestDefaultSmsSenderNumber"
         });
         return new OrderRequestService(repository, guidMock.Object, dateTimeMock.Object, config);
     }

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -158,6 +158,52 @@ public class OrderRequestServiceTests
         repoMock.VerifyAll();
     }
 
+    [Fact]
+    public async Task RegisterNotificationOrder_ForSms_NoSenderHandleDefaultInserted()
+    {
+        // Arrange
+        DateTime sendTime = DateTime.UtcNow;
+        DateTime createdTime = DateTime.UtcNow.AddMinutes(-2);
+        Guid id = Guid.NewGuid();
+
+        NotificationOrder expected = new()
+        {
+            Id = id,
+            Created = createdTime,
+            Creator = new("ttd"),
+            NotificationChannel = NotificationChannel.Sms,
+            RequestedSendTime = sendTime,
+            Recipients = { },
+            SendersReference = "senders-reference",
+            Templates = { new SmsTemplate { Body = "sms-body", SenderHandle = "TestDefaultSmsSenderHandle" } }
+        };
+
+        NotificationOrderRequest input = new()
+        {
+            Creator = new Creator("ttd"),
+
+            NotificationChannel = NotificationChannel.Sms,
+            Recipients = { },
+            SendersReference = "senders-reference",
+            RequestedSendTime = sendTime,
+            Templates = { new SmsTemplate { Body = "sms-body" } }
+        };
+
+        Mock<IOrderRepository> repoMock = new();
+        repoMock
+            .Setup(r => r.Create(It.IsAny<NotificationOrder>()))
+            .ReturnsAsync((NotificationOrder order) => order);
+
+        var service = GetTestService(repoMock.Object, id, createdTime);
+
+        // Act
+        (NotificationOrder? actual, ServiceError? _) = await service.RegisterNotificationOrder(input);
+
+        // Assert
+        Assert.Equivalent(expected, actual, true);
+        repoMock.VerifyAll();
+    }
+
     public static OrderRequestService GetTestService(IOrderRepository? repository = null, Guid? guid = null, DateTime? dateTime = null)
     {
         if (repository == null)
@@ -177,7 +223,7 @@ public class OrderRequestServiceTests
         var config = Options.Create<NotificationOrderConfig>(new()
         {
             DefaultEmailFromAddress = "noreply@altinn.no",
-            DefaultSmsSender = "TestSmsSenderHandle"
+            DefaultSmsSender = "TestDefaultSmsSenderHandle"
         });
         return new OrderRequestService(repository, guidMock.Object, dateTimeMock.Object, config);
     }

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -21,7 +21,7 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices;
 public class OrderRequestServiceTests
 {
     [Fact]
-    public async Task RegisterNotificationOrder_ExpectedInputToRepository()
+    public async Task RegisterNotificationOrder_Email_ExpectedInputToRepository()
     {
         // Arrange
         DateTime sendTime = DateTime.UtcNow;
@@ -130,7 +130,8 @@ public class OrderRequestServiceTests
 
         var config = Options.Create<NotificationOrderConfig>(new()
         {
-            DefaultEmailFromAddress = "noreply@altinn.no"
+            DefaultEmailFromAddress = "noreply@altinn.no",
+            DefaultSmsSender = "TestSmsSenderHandle"
         });
         return new OrderRequestService(repository, guidMock.Object, dateTimeMock.Object, config);
     }

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -175,7 +175,7 @@ public class OrderRequestServiceTests
             RequestedSendTime = sendTime,
             Recipients = { },
             SendersReference = "senders-reference",
-            Templates = { new SmsTemplate { Body = "sms-body", SenderNumber = "TestDefaultSmsSenderNumber" } }
+            Templates = { new SmsTemplate { Body = "sms-body", SenderNumber = "TestDefaultSmsSenderNumberNumber" } }
         };
 
         NotificationOrderRequest input = new()
@@ -223,7 +223,7 @@ public class OrderRequestServiceTests
         var config = Options.Create<NotificationOrderConfig>(new()
         {
             DefaultEmailFromAddress = "noreply@altinn.no",
-            DefaultSmsSender = "TestDefaultSmsSenderNumber"
+            DefaultSmsSenderNumber = "TestDefaultSmsSenderNumberNumber"
         });
         return new OrderRequestService(repository, guidMock.Object, dateTimeMock.Object, config);
     }


### PR DESCRIPTION
This PR is made to implement the core logic for placing an sms notification order described on the issue #336 

## Description
- Added SMS channel to `NotificationChannel` enum.
- Added SMS notification template type to the `NotificationTemplateType` enum.
- Added SMS template(`SmsTemplate`) to the `NotificationTemplate` directory.
- Added JSON subtype(`JsonDerivedType`) for SMS in the notification interface.
- Renamed `EmailNotificationOrderService` and `IEmailNotificationOrderService` to `OrderRequestService` and `IOrderRequestService`.
- Renamed `RegisterEmailNotificationOrder` in `OrderRequestService` to `RegisterNotificationOrder`.
- Added default sender number in the config
- Extended method for setting default value when empty
- Necessary unit tests added
- No manual QA would be done as mentioned in the regarding issue that it is not possible as no external endpoints are available

## Related Issue(s)
- #336

## Verification
- [x] **Your** code builds clean without any errors or warnings
  - Except the SonarCloud Code Analysis 
- [ ] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
