### PR TITLE
Using Result instead of tuple where applicable

### DIFF
--- a/src/Altinn.Notifications.Core/Services/GetOrderService.cs
+++ b/src/Altinn.Notifications.Core/Services/GetOrderService.cs
@@ -1,8 +1,8 @@
 ﻿using Altinn.Notifications.Core.Enums;
-using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.Orders;
 using Altinn.Notifications.Core.Persistence;
 using Altinn.Notifications.Core.Services.Interfaces;
+using Altinn.Notifications.Core.Shared;
 
 namespace Altinn.Notifications.Core.Services;
 
@@ -28,38 +28,38 @@ public class GetOrderService : IGetOrderService
     }
 
     /// <inheritdoc/>
-    public async Task<(NotificationOrder? Order, ServiceError? Error)> GetOrderById(Guid id, string creator)
+    public async Task<Result<NotificationOrder, ServiceError>> GetOrderById(Guid id, string creator)
     {
         NotificationOrder? order = await _repo.GetOrderById(id, creator);
 
         if (order == null)
         {
-            return (null, new ServiceError(404));
+            return new ServiceError(404);
         }
 
-        return (order, null);
+        return order;
     }
 
     /// <inheritdoc/>
-    public async Task<(List<NotificationOrder>? Orders, ServiceError? Error)> GetOrdersBySendersReference(string senderRef, string creator)
+    public async Task<Result<List<NotificationOrder>, ServiceError>> GetOrdersBySendersReference(string senderRef, string creator)
     {
         List<NotificationOrder> orders = await _repo.GetOrdersBySendersReference(senderRef, creator);
 
-        return (orders, null);
+        return orders;
     }
 
     /// <inheritdoc/>
-    public async Task<(NotificationOrderWithStatus? Order, ServiceError? Error)> GetOrderWithStatuById(Guid id, string creator)
+    public async Task<Result<NotificationOrderWithStatus, ServiceError>> GetOrderWithStatuById(Guid id, string creator)
     {
         NotificationOrderWithStatus? order = await _repo.GetOrderWithStatusById(id, creator);
 
         if (order == null)
         {
-            return (null, new ServiceError(404));
+            return new ServiceError(404);
         }
 
         order.ProcessingStatus.StatusDescription = GetStatusDescription(order.ProcessingStatus.Status);
-        return (order, null);
+        return order;
     }
 
     /// <summary>

--- a/src/Altinn.Notifications.Core/Services/Interfaces/IGetOrderService.cs
+++ b/src/Altinn.Notifications.Core/Services/Interfaces/IGetOrderService.cs
@@ -1,5 +1,5 @@
-﻿using Altinn.Notifications.Core.Models;
-using Altinn.Notifications.Core.Models.Orders;
+﻿using Altinn.Notifications.Core.Models.Orders;
+using Altinn.Notifications.Core.Shared;
 
 namespace Altinn.Notifications.Core.Services.Interfaces;
 
@@ -13,19 +13,19 @@ public interface IGetOrderService
     /// </summary>
     /// <param name="id">The order id</param>
     /// <param name="creator">The creator of the orders</param>
-    public Task<(NotificationOrder? Order, ServiceError? Error)> GetOrderById(Guid id, string creator);
+    public Task<Result<NotificationOrder, ServiceError>> GetOrderById(Guid id, string creator);
 
     /// <summary>
     /// Retrieves a notification order by senders reference
     /// </summary>
     /// <param name="senderRef">The senders reference</param>
     /// <param name="creator">The creator of the orders</param>
-    public Task<(List<NotificationOrder>? Orders, ServiceError? Error)> GetOrdersBySendersReference(string senderRef, string creator);
+    public Task<Result<List<NotificationOrder>, ServiceError>> GetOrdersBySendersReference(string senderRef, string creator);
 
     /// <summary>
     /// Retrieves a notification order with process and notification status by id
     /// </summary>
     /// <param name="id">The order id</param>
     /// <param name="creator">The creator of the orders</param>
-    public Task<(NotificationOrderWithStatus? Order, ServiceError? Error)> GetOrderWithStatuById(Guid id, string creator);
+    public Task<Result<NotificationOrderWithStatus, ServiceError>> GetOrderWithStatuById(Guid id, string creator);
 }

--- a/src/Altinn.Notifications.Core/Services/Interfaces/INotificationSummaryService.cs
+++ b/src/Altinn.Notifications.Core/Services/Interfaces/INotificationSummaryService.cs
@@ -1,5 +1,5 @@
-﻿using Altinn.Notifications.Core.Models;
-using Altinn.Notifications.Core.Models.Notification;
+﻿using Altinn.Notifications.Core.Models.Notification;
+using Altinn.Notifications.Core.Shared;
 
 namespace Altinn.Notifications.Core.Services.Interfaces
 {
@@ -13,6 +13,6 @@ namespace Altinn.Notifications.Core.Services.Interfaces
         /// </summary>
         /// <param name="orderId">The order id to find notifications for</param>
         /// <param name="creator">The creator of the order</param>
-        public Task<(EmailNotificationSummary? Summary, ServiceError? Error)> GetEmailSummary(Guid orderId, string creator);
+        public Task<Result<EmailNotificationSummary, ServiceError>> GetEmailSummary(Guid orderId, string creator);
     }
 }

--- a/src/Altinn.Notifications.Core/Services/Interfaces/IOrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/Interfaces/IOrderRequestService.cs
@@ -1,5 +1,5 @@
-﻿using Altinn.Notifications.Core.Models;
-using Altinn.Notifications.Core.Models.Orders;
+﻿using Altinn.Notifications.Core.Models.Orders;
+using Altinn.Notifications.Core.Shared;
 
 namespace Altinn.Notifications.Core.Services.Interfaces;
 
@@ -13,5 +13,5 @@ public interface IOrderRequestService
     /// </summary>
     /// <param name="orderRequest">The notification order request</param>
     /// <returns>The registered notification order</returns>
-    public Task<(NotificationOrder? Order, ServiceError? Error)> RegisterNotificationOrder(NotificationOrderRequest orderRequest);
+    public Task<Result<NotificationOrder, ServiceError>> RegisterNotificationOrder(NotificationOrderRequest orderRequest);
 }

--- a/src/Altinn.Notifications.Core/Services/Interfaces/IOrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/Interfaces/IOrderRequestService.cs
@@ -13,5 +13,5 @@ public interface IOrderRequestService
     /// </summary>
     /// <param name="orderRequest">The notification order request</param>
     /// <returns>The registered notification order</returns>
-    public Task<Result<NotificationOrder, ServiceError>> RegisterNotificationOrder(NotificationOrderRequest orderRequest);
+    public Task<NotificationOrder> RegisterNotificationOrder(NotificationOrderRequest orderRequest);
 }

--- a/src/Altinn.Notifications.Core/Services/NotificationSummaryService.cs
+++ b/src/Altinn.Notifications.Core/Services/NotificationSummaryService.cs
@@ -1,8 +1,8 @@
 ﻿using Altinn.Notifications.Core.Enums;
-using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.Notification;
 using Altinn.Notifications.Core.Persistence;
 using Altinn.Notifications.Core.Services.Interfaces;
+using Altinn.Notifications.Core.Shared;
 
 namespace Altinn.Notifications.Core.Services
 {
@@ -40,13 +40,13 @@ namespace Altinn.Notifications.Core.Services
         }
 
         /// <inheritdoc/>
-        public async Task<(EmailNotificationSummary? Summary, ServiceError? Error)> GetEmailSummary(Guid orderId, string creator)
+        public async Task<Result<EmailNotificationSummary, ServiceError>> GetEmailSummary(Guid orderId, string creator)
         {
             EmailNotificationSummary? summary = await _summaryRepository.GetEmailSummary(orderId, creator);
 
             if (summary == null)
             {
-                return (null, new ServiceError(404));
+                return  new ServiceError(404);
             }
 
             if (summary.Notifications.Count != 0)
@@ -54,7 +54,7 @@ namespace Altinn.Notifications.Core.Services
                 ProcessNotificationResults(summary);
             }
 
-            return (summary, null);
+            return summary;
         }
 
         /// <summary>

--- a/src/Altinn.Notifications.Core/Services/NotificationSummaryService.cs
+++ b/src/Altinn.Notifications.Core/Services/NotificationSummaryService.cs
@@ -46,7 +46,7 @@ namespace Altinn.Notifications.Core.Services
 
             if (summary == null)
             {
-                return  new ServiceError(404);
+                return new ServiceError(404);
             }
 
             if (summary.Notifications.Count != 0)

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -1,9 +1,9 @@
 ﻿using Altinn.Notifications.Core.Configuration;
-using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.NotificationTemplate;
 using Altinn.Notifications.Core.Models.Orders;
 using Altinn.Notifications.Core.Persistence;
 using Altinn.Notifications.Core.Services.Interfaces;
+using Altinn.Notifications.Core.Shared;
 
 using Microsoft.Extensions.Options;
 
@@ -33,7 +33,7 @@ public class OrderRequestService : IOrderRequestService
     }
 
     /// <inheritdoc/>
-    public async Task<(NotificationOrder? Order, ServiceError? Error)> RegisterNotificationOrder(NotificationOrderRequest orderRequest)
+    public async Task<Result<NotificationOrder, ServiceError>> RegisterNotificationOrder(NotificationOrderRequest orderRequest)
     {
         Guid orderId = _guid.NewGuid();
         DateTime created = _dateTime.UtcNow();
@@ -52,7 +52,7 @@ public class OrderRequestService : IOrderRequestService
 
         NotificationOrder savedOrder = await _repository.Create(order);
 
-        return (savedOrder, null);
+        return savedOrder;
     }
 
     private List<INotificationTemplate> SetSenderIfNotDefined(List<INotificationTemplate> templates)

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -33,7 +33,7 @@ public class OrderRequestService : IOrderRequestService
     }
 
     /// <inheritdoc/>
-    public async Task<Result<NotificationOrder, ServiceError>> RegisterNotificationOrder(NotificationOrderRequest orderRequest)
+    public async Task<NotificationOrder> RegisterNotificationOrder(NotificationOrderRequest orderRequest)
     {
         Guid orderId = _guid.NewGuid();
         DateTime created = _dateTime.UtcNow();

--- a/src/Altinn.Notifications.Core/Shared/Result.cs
+++ b/src/Altinn.Notifications.Core/Shared/Result.cs
@@ -1,0 +1,61 @@
+﻿namespace Altinn.Notifications.Core.Shared;
+
+/// <summary>
+/// A simple implementation of the Result class to handle success XOR failure as separate return 
+/// values in a type safe way. 
+/// </summary>
+/// <typeparam name="TValue">The type to be assigned to indicate success.</typeparam>
+/// <typeparam name="TError">The type to be assigned to indicate failure.</typeparam>
+public readonly struct Result<TValue, TError>
+{
+    private readonly TValue? _value;
+    private readonly TError? _error;
+
+    private Result(TValue value)
+    {
+        IsError = false;
+        _value = value;
+        _error = default;
+    }
+
+    private Result(TError error)
+    {
+        IsError = true;
+        _value = default;
+        _error = error;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the Result contains an error value.
+    /// </summary>
+    public bool IsError { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the Result contains a success value.
+    /// </summary>
+    public bool IsSuccess => !IsError;
+
+    /// <summary>
+    /// Implicit operator used when creating an instance of Result when assigning a success value.
+    /// </summary>
+    /// <param name="value">An object of the type indicating success.</param>
+    public static implicit operator Result<TValue, TError>(TValue value) => new(value);
+
+    /// <summary>
+    /// Implicit operator used when creating an instance of Result when assigning an error value.
+    /// </summary>
+    /// <param name="error">An object of the type indicating failure.</param>
+    public static implicit operator Result<TValue, TError>(TError error) => new(error);
+
+    /// <summary>
+    /// This method will call either the success OR the failure function based on it's error state.
+    /// </summary>
+    /// <typeparam name="TResult">The type to be returned by the given functions.</typeparam>
+    /// <param name="success">The function to call if Result holds a success value.</param>
+    /// <param name="failure">The function to call if Result holds an error value.</param>
+    /// <returns>An instance of the defined type.</returns>
+    public TResult Match<TResult>(
+        Func<TValue, TResult> success,
+        Func<TError, TResult> failure) =>
+        !IsError ? success(_value!) : failure(_error!);
+}

--- a/src/Altinn.Notifications.Core/Shared/ServiceError.cs
+++ b/src/Altinn.Notifications.Core/Shared/ServiceError.cs
@@ -1,4 +1,4 @@
-﻿namespace Altinn.Notifications.Core.Models;
+﻿namespace Altinn.Notifications.Core.Shared;
 
 /// <summary>
 /// A class representing a service error object used to transfere error information from service to controller.

--- a/src/Altinn.Notifications/Controllers/EmailNotificationsController.cs
+++ b/src/Altinn.Notifications/Controllers/EmailNotificationsController.cs
@@ -1,6 +1,7 @@
 ﻿using Altinn.Notifications.Configuration;
 using Altinn.Notifications.Core.Models.Notification;
 using Altinn.Notifications.Core.Services.Interfaces;
+using Altinn.Notifications.Core.Shared;
 using Altinn.Notifications.Extensions;
 using Altinn.Notifications.Mappers;
 
@@ -50,14 +51,11 @@ namespace Altinn.Notifications.Controllers
                 return Forbid();
             }
 
-            var (emailSummary, error) = await _summaryService.GetEmailSummary(id, expectedCreator);
+            Result<EmailNotificationSummary, ServiceError> result = await _summaryService.GetEmailSummary(id, expectedCreator);
 
-            if (error != null)
-            {
-                return StatusCode(error.ErrorCode, error.ErrorMessage);
-            }
-
-            return Ok(emailSummary?.MapToEmailNotificationSummaryExt());
+            return result.Match(
+                summary => Ok(summary.MapToEmailNotificationSummaryExt()),
+                error => StatusCode(error.ErrorCode, error.ErrorMessage));
         }
     }
 }

--- a/src/Altinn.Notifications/Controllers/OrdersController.cs
+++ b/src/Altinn.Notifications/Controllers/OrdersController.cs
@@ -1,5 +1,7 @@
 ﻿using Altinn.Notifications.Configuration;
+using Altinn.Notifications.Core.Models.Orders;
 using Altinn.Notifications.Core.Services.Interfaces;
+using Altinn.Notifications.Core.Shared;
 using Altinn.Notifications.Extensions;
 using Altinn.Notifications.Mappers;
 using Altinn.Notifications.Models;
@@ -51,14 +53,14 @@ public class OrdersController : ControllerBase
             return Forbid();
         }
 
-        var (order, error) = await _getOrderService.GetOrderById(id, expectedCreator);
+        Result<NotificationOrder, ServiceError> result = await _getOrderService.GetOrderById(id, expectedCreator);
 
-        if (error != null)
-        {
-            return StatusCode(error.ErrorCode, error.ErrorMessage);
-        }
-
-        return order!.MapToNotificationOrderExt();
+        return result.Match<ActionResult<NotificationOrderExt>>(
+             order =>
+             {
+                 return order.MapToNotificationOrderExt();
+             },
+             error => StatusCode(error.ErrorCode, error.ErrorMessage));
     }
 
     /// <summary>
@@ -77,14 +79,14 @@ public class OrdersController : ControllerBase
             return Forbid();
         }
 
-        var (orders, error) = await _getOrderService.GetOrdersBySendersReference(sendersReference, expectedCreator);
+        Result<List<NotificationOrder>, ServiceError> result = await _getOrderService.GetOrdersBySendersReference(sendersReference, expectedCreator);
 
-        if (error != null)
-        {
-            return StatusCode(error.ErrorCode, error.ErrorMessage);
-        }
-
-        return orders!.MapToNotificationOrderListExt();
+        return result.Match<ActionResult<NotificationOrderListExt>>(
+             orders =>
+             {
+                 return orders.MapToNotificationOrderListExt();
+             },
+             error => StatusCode(error.ErrorCode, error.ErrorMessage));
     }
 
     /// <summary>
@@ -105,13 +107,13 @@ public class OrdersController : ControllerBase
             return Forbid();
         }
 
-        var (order, error) = await _getOrderService.GetOrderWithStatuById(id, expectedCreator);
+        Result<NotificationOrderWithStatus, ServiceError> result = await _getOrderService.GetOrderWithStatuById(id, expectedCreator);
 
-        if (error != null)
-        {
-            return StatusCode(error.ErrorCode, error.ErrorMessage);
-        }
-
-        return order!.MapToNotificationOrderWithStatusExt();
+        return result.Match<ActionResult<NotificationOrderWithStatusExt>>(
+         order =>
+         {
+             return order.MapToNotificationOrderWithStatusExt();
+         },
+         error => StatusCode(error.ErrorCode, error.ErrorMessage));
     }
 }

--- a/src/Altinn.Notifications/Controllers/SmsNotificationOrdersController.cs
+++ b/src/Altinn.Notifications/Controllers/SmsNotificationOrdersController.cs
@@ -1,8 +1,7 @@
-﻿using System.Collections;
-using Altinn.Notifications.Configuration;
-using Altinn.Notifications.Core.Models;
+﻿using Altinn.Notifications.Configuration;
 using Altinn.Notifications.Core.Models.Orders;
 using Altinn.Notifications.Core.Services.Interfaces;
+using Altinn.Notifications.Core.Shared;
 using Altinn.Notifications.Extensions;
 using Altinn.Notifications.Mappers;
 using Altinn.Notifications.Models;
@@ -72,14 +71,14 @@ public class SmsNotificationOrdersController : ControllerBase
         }
 
         NotificationOrderRequest orderRequest = smsNotificationOrderRequest.MapToOrderRequest(creator);
-        (NotificationOrder? registeredOrder, ServiceError? error) = await _orderRequestService.RegisterNotificationOrder(orderRequest);
+        Result<NotificationOrder, ServiceError> result = await _orderRequestService.RegisterNotificationOrder(orderRequest);
 
-        if (error != null)
-        {
-            return StatusCode(error.ErrorCode, error.ErrorMessage);
-        }
-
-        string selfLink = registeredOrder!.GetSelfLink();
-        return Accepted(selfLink, new OrderIdExt(registeredOrder!.Id));
+        return result.Match(
+             registeredOrder =>
+             {
+                 string selfLink = registeredOrder!.GetSelfLink();
+                 return Accepted(selfLink, new OrderIdExt(registeredOrder!.Id));
+             },
+             error => StatusCode(error.ErrorCode, error.ErrorMessage));
     }
 }

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsController/EmailNotificationsControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsController/EmailNotificationsControllerTests.cs
@@ -8,6 +8,7 @@ using Altinn.Notifications.Configuration;
 using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.Notification;
 using Altinn.Notifications.Core.Services.Interfaces;
+using Altinn.Notifications.Core.Shared;
 using Altinn.Notifications.Tests.Notifications.Mocks.Authentication;
 using Altinn.Notifications.Tests.Notifications.Utils;
 
@@ -101,7 +102,7 @@ public class EmailNotificationsControllerTests : IClassFixture<IntegrationTestWe
         // Arrange
         Mock<INotificationSummaryService> serviceMock = new();
         serviceMock.Setup(s => s.GetEmailSummary(It.IsAny<Guid>(), It.IsAny<string>()))
-            .ReturnsAsync((null, new ServiceError(500)));
+            .ReturnsAsync(new ServiceError(500));
 
         HttpClient client = GetTestClient(summaryService: serviceMock.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
@@ -131,7 +132,7 @@ public class EmailNotificationsControllerTests : IClassFixture<IntegrationTestWe
 
         Mock<INotificationSummaryService> serviceMock = new();
         serviceMock.Setup(s => s.GetEmailSummary(It.IsAny<Guid>(), It.Is<string>(s => s.Equals("ttd"))))
-            .ReturnsAsync((output, null));
+            .ReturnsAsync(output);
 
         HttpClient client = GetTestClient(summaryService: serviceMock.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
@@ -167,7 +168,7 @@ public class EmailNotificationsControllerTests : IClassFixture<IntegrationTestWe
 
         Mock<INotificationSummaryService> serviceMock = new();
         serviceMock.Setup(s => s.GetEmailSummary(It.IsAny<Guid>(), It.Is<string>(s => s.Equals("ttd"))))
-            .ReturnsAsync((output, null));
+            .ReturnsAsync(output);
 
         HttpClient client = GetTestClient(summaryService: serviceMock.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
@@ -168,31 +168,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
         // Assert
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
-
-    [Fact]
-    public async Task Post_ServiceReturnsError_ServerError()
-    {
-        // Arrange
-        Mock<IOrderRequestService> serviceMock = new();
-        serviceMock.Setup(s => s.RegisterNotificationOrder(It.IsAny<NotificationOrderRequest>()))
-            .ReturnsAsync(new ServiceError(500));
-
-        HttpClient client = GetTestClient(orderService: serviceMock.Object);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
-
-        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, _basePath)
-        {
-            Content = new StringContent(_orderRequestExt.Serialize(), Encoding.UTF8, "application/json")
-        };
-
-        // Act
-        HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-
-        // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-        serviceMock.VerifyAll();
-    }
-
+   
     [Fact]
     public async Task Post_ValidScope_ServiceReturnsOrder_Accepted()
     {

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/EmailNotificationsOrderController/EmailNotificationOrdersControllerTests.cs
@@ -10,6 +10,7 @@ using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.NotificationTemplate;
 using Altinn.Notifications.Core.Models.Orders;
 using Altinn.Notifications.Core.Services.Interfaces;
+using Altinn.Notifications.Core.Shared;
 using Altinn.Notifications.Models;
 using Altinn.Notifications.Tests.Notifications.Mocks.Authentication;
 using Altinn.Notifications.Tests.Notifications.Utils;
@@ -174,7 +175,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
         // Arrange
         Mock<IOrderRequestService> serviceMock = new();
         serviceMock.Setup(s => s.RegisterNotificationOrder(It.IsAny<NotificationOrderRequest>()))
-            .ReturnsAsync((null, new ServiceError(500)));
+            .ReturnsAsync(new ServiceError(500));
 
         HttpClient client = GetTestClient(orderService: serviceMock.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
@@ -207,7 +208,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
                   Assert.NotNull(emailTemplate);
                   Assert.Equal(string.Empty, emailTemplate.FromAddress);
               })
-            .ReturnsAsync((_order, null));
+            .ReturnsAsync(_order);
 
         HttpClient client = GetTestClient(orderService: serviceMock.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
@@ -246,7 +247,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
                   Assert.NotNull(emailTemplate);
                   Assert.Empty(emailTemplate.FromAddress);
               })
-            .ReturnsAsync((_order, null));
+            .ReturnsAsync(_order);
 
         HttpClient client = GetTestClient(orderService: serviceMock.Object);
 
@@ -286,7 +287,7 @@ public class EmailNotificationOrdersControllerTests : IClassFixture<IntegrationT
                 Assert.NotNull(emailTemplate);
                 Assert.Empty(emailTemplate.FromAddress);
             })
-            .ReturnsAsync((_order, null));
+            .ReturnsAsync(_order);
 
         HttpClient client = GetTestClient(orderService: serviceMock.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/OrdersController/OrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/OrdersController/OrdersControllerTests.cs
@@ -7,6 +7,7 @@ using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.NotificationTemplate;
 using Altinn.Notifications.Core.Models.Orders;
 using Altinn.Notifications.Core.Services.Interfaces;
+using Altinn.Notifications.Core.Shared;
 using Altinn.Notifications.Tests.Notifications.Mocks.Authentication;
 using Altinn.Notifications.Tests.Notifications.Utils;
 
@@ -112,7 +113,7 @@ public class OrdersControllerTests : IClassFixture<IntegrationTestWebApplication
         var orderService = new Mock<IGetOrderService>();
         orderService
              .Setup(o => o.GetOrdersBySendersReference(It.Is<string>(s => s.Equals("internal-ref")), It.Is<string>(s => s.Equals("ttd"))))
-             .ReturnsAsync((new List<NotificationOrder>() { _order }, null));
+             .ReturnsAsync(new List<NotificationOrder>() { _order });
 
         HttpClient client = GetTestClient(orderService.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
@@ -135,7 +136,7 @@ public class OrdersControllerTests : IClassFixture<IntegrationTestWebApplication
         var orderService = new Mock<IGetOrderService>();
         orderService
              .Setup(o => o.GetOrdersBySendersReference(It.Is<string>(s => s.Equals("internal-ref")), It.Is<string>(s => s.Equals("ttd"))))
-             .ReturnsAsync((new List<NotificationOrder>() { _order }, null));
+             .ReturnsAsync(new List<NotificationOrder>() { _order });
 
         HttpClient client = GetTestClient(orderService.Object);
 
@@ -209,7 +210,7 @@ public class OrdersControllerTests : IClassFixture<IntegrationTestWebApplication
         var orderService = new Mock<IGetOrderService>();
         orderService
              .Setup(o => o.GetOrderById(It.Is<Guid>(g => g.Equals(orderId)), It.Is<string>(s => s.Equals("ttd"))))
-             .ReturnsAsync((_order, null));
+             .ReturnsAsync(_order);
 
         HttpClient client = GetTestClient(orderService.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
@@ -234,7 +235,7 @@ public class OrdersControllerTests : IClassFixture<IntegrationTestWebApplication
         var orderService = new Mock<IGetOrderService>();
         orderService
              .Setup(o => o.GetOrderById(It.Is<Guid>(g => g.Equals(orderId)), It.Is<string>(s => s.Equals("ttd"))))
-             .ReturnsAsync((_order, null));
+             .ReturnsAsync(_order);
 
         HttpClient client = GetTestClient(orderService.Object);
 
@@ -259,7 +260,7 @@ public class OrdersControllerTests : IClassFixture<IntegrationTestWebApplication
         var orderService = new Mock<IGetOrderService>();
         orderService
              .Setup(o => o.GetOrderById(It.Is<Guid>(g => g.Equals(orderId)), It.Is<string>(s => s.Equals("ttd"))))
-             .ReturnsAsync((null, new ServiceError(404)));
+             .ReturnsAsync(new ServiceError(404));
 
         HttpClient client = GetTestClient(orderService.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
@@ -333,7 +334,7 @@ public class OrdersControllerTests : IClassFixture<IntegrationTestWebApplication
         var orderService = new Mock<IGetOrderService>();
         orderService
              .Setup(o => o.GetOrderWithStatuById(It.Is<Guid>(g => g.Equals(orderId)), It.Is<string>(s => s.Equals("ttd"))))
-             .ReturnsAsync((_orderWithStatus, null));
+             .ReturnsAsync(_orderWithStatus);
 
         HttpClient client = GetTestClient(orderService.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
@@ -358,7 +359,7 @@ public class OrdersControllerTests : IClassFixture<IntegrationTestWebApplication
         var orderService = new Mock<IGetOrderService>();
         orderService
              .Setup(o => o.GetOrderWithStatuById(It.Is<Guid>(g => g.Equals(orderId)), It.Is<string>(s => s.Equals("ttd"))))
-             .ReturnsAsync((_orderWithStatus, null));
+             .ReturnsAsync(_orderWithStatus);
 
         HttpClient client = GetTestClient(orderService.Object);
 
@@ -384,7 +385,7 @@ public class OrdersControllerTests : IClassFixture<IntegrationTestWebApplication
         var orderService = new Mock<IGetOrderService>();
         orderService
              .Setup(o => o.GetOrderWithStatuById(It.Is<Guid>(g => g.Equals(orderId)), It.Is<string>(s => s.Equals("ttd"))))
-             .ReturnsAsync((null, new ServiceError(404)));
+             .ReturnsAsync(new ServiceError(404));
 
         HttpClient client = GetTestClient(orderService.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
@@ -407,11 +408,11 @@ public class OrdersControllerTests : IClassFixture<IntegrationTestWebApplication
             var orderServiceMock = new Mock<IGetOrderService>();
             orderServiceMock
                 .Setup(o => o.GetOrderById(It.IsAny<Guid>(), It.IsAny<string>()))
-                .ReturnsAsync((_order, null));
+                .ReturnsAsync(_order);
 
             orderServiceMock
                  .Setup(o => o.GetOrdersBySendersReference(It.IsAny<string>(), It.IsAny<string>()))
-                 .ReturnsAsync((new List<NotificationOrder>() { _order }, null));
+                 .ReturnsAsync(new List<NotificationOrder>() { _order });
 
             orderService = orderServiceMock.Object;
         }

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/SmsNotificationsOrdersController/SmsNotificationOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/SmsNotificationsOrdersController/SmsNotificationOrdersControllerTests.cs
@@ -10,6 +10,7 @@ using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.NotificationTemplate;
 using Altinn.Notifications.Core.Models.Orders;
 using Altinn.Notifications.Core.Services.Interfaces;
+using Altinn.Notifications.Core.Shared;
 using Altinn.Notifications.Models;
 using Altinn.Notifications.Tests.Notifications.Mocks.Authentication;
 using Altinn.Notifications.Tests.Notifications.Utils;
@@ -172,7 +173,7 @@ public class SmsNotificationOrdersControllerTests : IClassFixture<IntegrationTes
         // Arrange
         Mock<IOrderRequestService> serviceMock = new();
         serviceMock.Setup(s => s.RegisterNotificationOrder(It.IsAny<NotificationOrderRequest>()))
-            .ReturnsAsync((null, new ServiceError(500)));
+            .ReturnsAsync(new ServiceError(500));
 
         HttpClient client = GetTestClient(orderService: serviceMock.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
@@ -205,7 +206,7 @@ public class SmsNotificationOrdersControllerTests : IClassFixture<IntegrationTes
                   Assert.NotNull(smsTemplate);
                   Assert.Equal(string.Empty, smsTemplate.SenderNumber);
               })
-            .ReturnsAsync((_order, null));
+            .ReturnsAsync(_order);
 
         HttpClient client = GetTestClient(orderService: serviceMock.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
@@ -244,7 +245,7 @@ public class SmsNotificationOrdersControllerTests : IClassFixture<IntegrationTes
                   Assert.NotNull(smsTemplate);
                   Assert.Empty(smsTemplate.SenderNumber);
               })
-            .ReturnsAsync((_order, null));
+            .ReturnsAsync(_order);
 
         HttpClient client = GetTestClient(orderService: serviceMock.Object);
 
@@ -284,7 +285,7 @@ public class SmsNotificationOrdersControllerTests : IClassFixture<IntegrationTes
                 Assert.NotNull(smsTemplate);
                 Assert.Empty(smsTemplate.SenderNumber);
             })
-            .ReturnsAsync((_order, null));
+            .ReturnsAsync(_order);
 
         HttpClient client = GetTestClient(orderService: serviceMock.Object);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/SmsNotificationsOrdersController/SmsNotificationOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/SmsNotificationsOrdersController/SmsNotificationOrdersControllerTests.cs
@@ -168,30 +168,6 @@ public class SmsNotificationOrdersControllerTests : IClassFixture<IntegrationTes
     }
 
     [Fact]
-    public async Task Post_ServiceReturnsError_ServerError()
-    {
-        // Arrange
-        Mock<IOrderRequestService> serviceMock = new();
-        serviceMock.Setup(s => s.RegisterNotificationOrder(It.IsAny<NotificationOrderRequest>()))
-            .ReturnsAsync(new ServiceError(500));
-
-        HttpClient client = GetTestClient(orderService: serviceMock.Object);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
-
-        HttpRequestMessage httpRequestMessage = new(HttpMethod.Post, _basePath)
-        {
-            Content = new StringContent(_orderRequestExt.Serialize(), Encoding.UTF8, "application/json")
-        };
-
-        // Act
-        HttpResponseMessage response = await client.SendAsync(httpRequestMessage);
-
-        // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-        serviceMock.VerifyAll();
-    }
-
-    [Fact]
     public async Task Post_ValidScope_ServiceReturnsOrder_Accepted()
     {
         // Arrange

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -9,6 +9,7 @@ using Altinn.Notifications.Core.Models.Orders;
 using Altinn.Notifications.Core.Persistence;
 using Altinn.Notifications.Core.Services;
 using Altinn.Notifications.Core.Services.Interfaces;
+using Altinn.Notifications.Core.Shared;
 
 using Microsoft.Extensions.Options;
 
@@ -59,11 +60,18 @@ public class OrderRequestServiceTests
         var service = GetTestService(repoMock.Object, id, createdTime);
 
         // Act
-        (NotificationOrder? actual, ServiceError? _) = await service.RegisterNotificationOrder(input);
+        Result<NotificationOrder, ServiceError> result = await service.RegisterNotificationOrder(input);
 
         // Assert
-        Assert.Equivalent(expected, actual, true);
-        repoMock.VerifyAll();
+        Assert.True(result.IsSuccess);
+        await result.Match<Task>(
+           async actual =>
+           {
+               await Task.CompletedTask;
+               Assert.Equivalent(expected, actual, true);
+               repoMock.VerifyAll();
+           },
+           async actuallError => await Task.CompletedTask);
     }
 
     [Fact]
@@ -105,11 +113,18 @@ public class OrderRequestServiceTests
         var service = GetTestService(repoMock.Object, id, createdTime);
 
         // Act
-        (NotificationOrder? actual, ServiceError? _) = await service.RegisterNotificationOrder(input);
+        Result<NotificationOrder, ServiceError> result = await service.RegisterNotificationOrder(input);
 
         // Assert
-        Assert.Equivalent(expected, actual, true);
-        repoMock.VerifyAll();
+        Assert.True(result.IsSuccess);
+        await result.Match<Task>(
+           async actual =>
+           {
+               await Task.CompletedTask;
+               Assert.Equivalent(expected, actual, true);
+               repoMock.VerifyAll();
+           },
+           async actuallError => await Task.CompletedTask);
     }
 
     [Fact]
@@ -151,11 +166,18 @@ public class OrderRequestServiceTests
         var service = GetTestService(repoMock.Object, id, createdTime);
 
         // Act
-        (NotificationOrder? actual, ServiceError? _) = await service.RegisterNotificationOrder(input);
+        Result<NotificationOrder, ServiceError> result = await service.RegisterNotificationOrder(input);
 
         // Assert
-        Assert.Equivalent(expected, actual, true);
-        repoMock.VerifyAll();
+        Assert.True(result.IsSuccess);
+        await result.Match<Task>(
+           async actual =>
+           {
+               await Task.CompletedTask;
+               Assert.Equivalent(expected, actual, true);
+               repoMock.VerifyAll();
+           },
+           async actuallError => await Task.CompletedTask);
     }
 
     [Fact]
@@ -197,11 +219,18 @@ public class OrderRequestServiceTests
         var service = GetTestService(repoMock.Object, id, createdTime);
 
         // Act
-        (NotificationOrder? actual, ServiceError? _) = await service.RegisterNotificationOrder(input);
+        Result<NotificationOrder, ServiceError> result = await service.RegisterNotificationOrder(input);
 
         // Assert
-        Assert.Equivalent(expected, actual, true);
-        repoMock.VerifyAll();
+        Assert.True(result.IsSuccess);
+        await result.Match<Task>(
+           async actual =>
+           {
+               await Task.CompletedTask;
+               Assert.Equivalent(expected, actual, true);
+               repoMock.VerifyAll();
+           },
+           async actuallError => await Task.CompletedTask);
     }
 
     public static OrderRequestService GetTestService(IOrderRepository? repository = null, Guid? guid = null, DateTime? dateTime = null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed use of tuples to return success or error response. 


## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
