### PR TITLE
removed self link for oerd/{id}/notifications endpoint

### DIFF
--- a/src/Altinn.Notifications/Extensions/ResourceLinkExtensions.cs
+++ b/src/Altinn.Notifications/Extensions/ResourceLinkExtensions.cs
@@ -38,7 +38,6 @@ public static class ResourceLinkExtensions
         {
             Self = self,
             Status = self + "/status",
-            Notifications = self + "/notifications"
         };
     }
 

--- a/src/Altinn.Notifications/Models/NotificationChannelExt.cs
+++ b/src/Altinn.Notifications/Models/NotificationChannelExt.cs
@@ -8,5 +8,10 @@ public enum NotificationChannelExt
     /// <summary>
     /// The selected channel for the notification is email.
     /// </summary>
-    Email
+    Email,
+
+    /// <summary>
+    /// The selected channel for the notification is sms.
+    /// </summary>
+    Sms
 }

--- a/src/Altinn.Notifications/Models/OrderResourceLinksExt.cs
+++ b/src/Altinn.Notifications/Models/OrderResourceLinksExt.cs
@@ -21,10 +21,4 @@ public class OrderResourceLinksExt
     /// </summary>
     [JsonPropertyName("status")]
     public string Status { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets or sets the notifications link 
-    /// </summary>
-    [JsonPropertyName("notifications")]
-    public string Notifications { get; set; } = string.Empty;
 }

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/OrdersController/GetByIdTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/OrdersController/GetByIdTests.cs
@@ -73,7 +73,6 @@ public class GetByIdTests : IClassFixture<IntegrationTestWebApplicationFactory<C
             Created = persistedOrder.Created,
             Links = new()
             {
-                Notifications = $"{refLinkBase}/{id}/notifications",
                 Self = $"{refLinkBase}/{id}",
                 Status = $"{refLinkBase}/{id}/status"
             },

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -67,7 +67,6 @@ public class OrderMapperTests
             Links = new OrderResourceLinksExt()
             {
                 Self = $"https://platform.at22.altinn.cloud/notifications/api/v1/orders/{order.Id}",
-                Notifications = $"https://platform.at22.altinn.cloud/notifications/api/v1/orders/{order.Id}/notifications",
                 Status = $"https://platform.at22.altinn.cloud/notifications/api/v1/orders/{order.Id}/status"
             }
         };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- The /notifications  endpoint for orders has never been implemented and should not be exposed in the self links of an order
- Added missing enum type to src/Altinn.Notifications/Models/NotificationChannelExt.cs

## Related Issue(s)
- #N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
