### PR TITLE
option to update sms send status with only gateway ref

### DIFF
--- a/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
@@ -12,7 +12,7 @@ public class SmsSendOperationResult
     /// <summary>
     /// The notification id
     /// </summary>
-    public Guid NotificationId { get; set; }
+    public Guid? NotificationId { get; set; }
 
     /// <summary>
     /// The reference to the delivery in sms gateway
@@ -59,7 +59,7 @@ public class SmsSendOperationResult
             parsedOutput = Deserialize(input!);
 
             value = parsedOutput!;
-            return value.NotificationId != Guid.Empty;
+            return value.NotificationId != Guid.Empty || value.GatewayReference != string.Empty;
         }
         catch
         {

--- a/src/Altinn.Notifications.Core/Persistence/ISmsNotificationRepository.cs
+++ b/src/Altinn.Notifications.Core/Persistence/ISmsNotificationRepository.cs
@@ -30,5 +30,5 @@ public interface ISmsNotificationRepository
     /// <summary>
     /// Sets result status of an sms notification and update operation id
     /// </summary>
-    public Task UpdateSendStatus(Guid notificationId, SmsNotificationResultType result, string? gatewayReference = null);
+    public Task UpdateSendStatus(Guid? notificationId, SmsNotificationResultType result, string? gatewayReference = null);
 }

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
@@ -108,7 +108,7 @@ public class SmsNotificationRepositoryTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task UpdateSendStatus_WithGatewayRef()
+    public async Task UpdateSendStatus_WithNotificationId_WithGatewayRef()
     {
         // Arrange
         (NotificationOrder order, SmsNotification smsNotification) = await PostgreUtil.PopulateDBWithOrderAndSmsNotification();
@@ -136,7 +136,41 @@ public class SmsNotificationRepositoryTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task UpdateSendStatus_WithoutGatewayRef()
+    public async Task UpdateSendStatus_WithoutNotificationId_WithGatewayRef()
+    {
+        // Arrange
+        (NotificationOrder order, SmsNotification smsNotification) = await PostgreUtil.PopulateDBWithOrderAndSmsNotification();
+        _orderIdsToDelete.Add(order.Id);
+
+        SmsNotificationRepository repo = (SmsNotificationRepository)ServiceUtil
+          .GetServices(new List<Type>() { typeof(ISmsNotificationRepository) })
+          .First(i => i.GetType() == typeof(SmsNotificationRepository));
+
+        string gatewayReference = Guid.NewGuid().ToString();
+
+        string setGateqwaySql = $@"Update notifications.smsnotifications 
+                SET gatewayreference = '{gatewayReference}'
+                WHERE alternateid = '{smsNotification.Id}'";
+
+        await PostgreUtil.RunSql(setGateqwaySql);
+
+        // Act
+        await repo.UpdateSendStatus(null, SmsNotificationResultType.Accepted, gatewayReference);
+
+        // Assert
+        string sql = $@"SELECT count(1) 
+              FROM notifications.smsnotifications sms
+              WHERE sms.alternateid = '{smsNotification.Id}'
+              AND sms.result = '{SmsNotificationResultType.Accepted}'
+              AND sms.gatewayreference = '{gatewayReference}'";
+
+        int actualCount = await PostgreUtil.RunSqlReturnOutput<int>(sql);
+
+        Assert.Equal(1, actualCount);
+    }
+
+    [Fact]
+    public async Task UpdateSendStatus_WithNotificationId_WithoutGatewayRef()
     {
         // Arrange
         (NotificationOrder order, SmsNotification smsNotification) = await PostgreUtil.PopulateDBWithOrderAndSmsNotification();

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
@@ -1,0 +1,35 @@
+﻿using Altinn.Notifications.Core.Models.Notification;
+
+using Xunit;
+
+namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
+{
+    public class SmsSendOperationResultTests
+    {
+        [Fact]
+        public void TryParse_ValidInput_ReturnsTrue()
+        {
+            // Arrange
+            string input = "{\"notificationId\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\",\"gatewayReference\":\"123456789\",\"sendResult\":1}";
+
+            // Act
+            bool result = SmsSendOperationResult.TryParse(input, out SmsSendOperationResult value);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void TryParse_ValidInput_NoNotificationId_ReturnsTrue()
+        {
+            // Arrange
+            string input = "{\"gatewayReference\":\"123456789\",\"sendResult\":1}";
+
+            // Act
+            bool result = SmsSendOperationResult.TryParse(input, out SmsSendOperationResult value);
+
+            // Assert
+            Assert.True(result);
+        }
+    }
+}

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
@@ -13,7 +13,7 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
             string input = "{\"notificationId\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\",\"gatewayReference\":\"123456789\",\"sendResult\":1}";
 
             // Act
-            bool result = SmsSendOperationResult.TryParse(input, out SmsSendOperationResult value);
+            bool result = SmsSendOperationResult.TryParse(input, out _);
 
             // Assert
             Assert.True(result);
@@ -26,7 +26,7 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
             string input = "{\"gatewayReference\":\"123456789\",\"sendResult\":1}";
 
             // Act
-            bool result = SmsSendOperationResult.TryParse(input, out SmsSendOperationResult value);
+            bool result = SmsSendOperationResult.TryParse(input, out _);
 
             // Assert
             Assert.True(result);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When delivery reports are returned for sms, the notificationId is not available, hence it should be possible to update the database with only the gateway reference

## Related Issue(s)
- #361

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
