### PR TITLE
Create /tmp/logtelemetry during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,6 @@ COPY src/Altinn.Notifications/Views ./Views
 
 RUN addgroup -g 3000 dotnet && adduser -u 1000 -G dotnet -D -s /bin/false dotnet
 USER dotnet
+RUN mkdir /tmp/logtelemetry
+
 ENTRYPOINT [ "dotnet", "Altinn.Notifications.dll" ]


### PR DESCRIPTION
## Description
Telemetry features need a folder for temporary storage of data when there are network issues. This is missing for notifications.

## Related Issue(s)
- Discovered when analyzing an issue in production.