### PR TITLE
ignoring recipientId in all db read and writes

### DIFF
--- a/src/Altinn.Notifications.Persistence/Migration/v0.25/01-alter-procedures.sql
+++ b/src/Altinn.Notifications.Persistence/Migration/v0.25/01-alter-procedures.sql
@@ -1,0 +1,38 @@
+CREATE OR REPLACE PROCEDURE notifications.insertemailnotification(_orderid uuid, 
+																  _alternateid uuid, 
+																  _toaddress TEXT, 
+																  _result text, 
+																  _resulttime timestamptz, 
+																  _expirytime timestamptz
+																 )
+LANGUAGE 'plpgsql'
+AS $BODY$
+DECLARE
+__orderid BIGINT := (SELECT _id from notifications.orders
+			where alternateid = _orderid);
+BEGIN
+
+INSERT INTO notifications.emailnotifications(_orderid, alternateid,  toaddress, result, resulttime, expirytime)
+	VALUES (__orderid, _alternateid, _toaddress, _result::emailnotificationresulttype, _resulttime, _expirytime);
+END;
+$BODY$
+
+
+CREATE OR REPLACE PROCEDURE notifications.insertsmsnotification(_orderid uuid, 
+																  _alternateid uuid, 
+																  _mobilenumber TEXT, 
+																  _result text, 
+																  _resulttime timestamptz, 
+																  _expirytime timestamptz
+																 )
+LANGUAGE 'plpgsql'
+AS $BODY$
+DECLARE
+__orderid BIGINT := (SELECT _id from notifications.orders
+			where alternateid = _orderid);
+BEGIN
+
+INSERT INTO notifications.smsnotifications(_orderid, alternateid, mobilenumber, result, resulttime, expirytime)
+	VALUES (__orderid, _alternateid, _mobilenumber, _result::smsnotificationresulttype, _resulttime, _expirytime);
+END;
+$BODY$

--- a/src/Altinn.Notifications.Persistence/Migration/v0.25/01-alter-procedures.sql
+++ b/src/Altinn.Notifications.Persistence/Migration/v0.25/01-alter-procedures.sql
@@ -15,7 +15,7 @@ BEGIN
 INSERT INTO notifications.emailnotifications(_orderid, alternateid,  toaddress, result, resulttime, expirytime)
 	VALUES (__orderid, _alternateid, _toaddress, _result::emailnotificationresulttype, _resulttime, _expirytime);
 END;
-$BODY$
+$BODY$;
 
 
 CREATE OR REPLACE PROCEDURE notifications.insertsmsnotification(_orderid uuid, 

--- a/src/Altinn.Notifications.Persistence/Migration/v0.25/02-alter-functions.sql
+++ b/src/Altinn.Notifications.Persistence/Migration/v0.25/02-alter-functions.sql
@@ -1,0 +1,99 @@
+CREATE OR REPLACE FUNCTION notifications.getsmsrecipients(_orderid uuid)
+RETURNS TABLE(
+    recipientid text, 
+    mobilenumber text
+) 
+LANGUAGE 'plpgsql'
+AS $BODY$
+DECLARE
+__orderid BIGINT := (SELECT _id from notifications.orders
+			where alternateid = _orderid);
+BEGIN
+RETURN query 
+	SELECT NULL::text, s.mobilenumber
+	FROM notifications.smsnotifications s
+	WHERE s._orderid = __orderid;
+END;
+$BODY$;
+
+CREATE OR REPLACE FUNCTION notifications.getemailrecipients(_alternateid uuid)
+RETURNS TABLE(
+    recipientid text, 
+    toaddress text
+) 
+LANGUAGE 'plpgsql'
+AS $BODY$
+DECLARE
+__orderid BIGINT := (SELECT _id from notifications.orders
+			where alternateid = _alternateid);
+BEGIN
+RETURN query 
+	SELECT NULL::text, e.toaddress
+	FROM notifications.emailnotifications e
+	WHERE e._orderid = __orderid;
+END;
+$BODY$;
+
+CREATE OR REPLACE FUNCTION notifications.getemailsummary(
+	_alternateorderid uuid,
+	_creatorname text)
+    RETURNS TABLE(
+        sendersreference text, 
+        alternateid uuid, 
+        recipientid text, 
+        toaddress text, 
+        result emailnotificationresulttype, 
+        resulttime timestamptz) 
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+    ROWS 1000
+
+AS $BODY$
+
+	BEGIN
+		RETURN QUERY
+		   SELECT o.sendersreference, n.alternateid, NULL::text, n.toaddress, n.result, n.resulttime
+			FROM notifications.emailnotifications n
+            LEFT JOIN notifications.orders o ON n._orderid = o._id
+			WHERE o.alternateid = _alternateorderid
+			and o.creatorname = _creatorname;
+        IF NOT FOUND THEN
+            RETURN QUERY
+            SELECT o.sendersreference, NULL::uuid, NULL::text, NULL::text, NULL::emailnotificationresulttype, NULL::timestamptz
+            FROM notifications.orders o
+            WHERE o.alternateid = _alternateorderid
+            and o.creatorname = _creatorname;
+        END IF;
+	END;
+$BODY$;
+
+CREATE OR REPLACE FUNCTION notifications.getsmssummary(
+	_alternateorderid uuid,
+	_creatorname text)
+    RETURNS TABLE(
+        sendersreference text, 
+        alternateid uuid, 
+        recipientid text, 
+        mobilenumber text, 
+        result smsnotificationresulttype, 
+        resulttime timestamptz) 
+    LANGUAGE 'plpgsql'
+AS $BODY$
+
+	BEGIN
+		RETURN QUERY
+		   SELECT o.sendersreference, n.alternateid, NULL::text, n.mobilenumber, n.result, n.resulttime
+			FROM notifications.smsnotifications n
+            LEFT JOIN notifications.orders o ON n._orderid = o._id
+			WHERE o.alternateid = _alternateorderid
+			and o.creatorname = _creatorname;
+        IF NOT FOUND THEN
+            RETURN QUERY
+            SELECT o.sendersreference, NULL::uuid, NULL::text, NULL::text, NULL::smsnotificationresulttype, NULL::timestamptz
+            FROM notifications.orders o
+            WHERE o.alternateid = _alternateorderid
+            and o.creatorname = _creatorname;
+        END IF;
+	END;
+$BODY$;

--- a/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
@@ -18,7 +18,7 @@ public class EmailNotificationRepository : IEmailNotificationRepository
     private readonly NpgsqlDataSource _dataSource;
     private readonly TelemetryClient? _telemetryClient;
 
-    private const string _insertEmailNotificationSql = "call notifications.insertemailnotification($1, $2, $3, $4, $5, $6, $7)"; // (__orderid, _alternateid, _recipientid, _toaddress, _result, _resulttime, _expirytime)
+    private const string _insertEmailNotificationSql = "call notifications.insertemailnotification($1, $2, $3, $4, $5, $6)"; // (__orderid, _alternateid, _toaddress, _result, _resulttime, _expirytime)
     private const string _getEmailNotificationsSql = "select * from notifications.getemails_statusnew_updatestatus()";
     private const string _updateEmailStatus = "call notifications.updateemailstatus($1, $2, $3)"; // (_alternateid, _result, _operationid)
     private const string _getEmailRecipients = "select * from notifications.getemailrecipients($1)"; // (_orderid)
@@ -42,7 +42,6 @@ public class EmailNotificationRepository : IEmailNotificationRepository
 
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notification.OrderId);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notification.Id);
-        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.RecipientId ?? (object)DBNull.Value);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.ToAddress);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.SendResult.Result.ToString());
         pgcom.Parameters.AddWithValue(NpgsqlDbType.TimestampTz, notification.SendResult.ResultTime);

--- a/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
@@ -21,7 +21,7 @@ public class SmsNotificationRepository : ISmsNotificationRepository
     private readonly NpgsqlDataSource _dataSource;
     private readonly TelemetryClient? _telemetryClient;
 
-    private const string _insertSmsNotificationSql = "call notifications.insertsmsnotification($1, $2, $3, $4, $5, $6, $7)"; // (__orderid, _alternateid, _recipientid, _mobilenumber, _result, _resulttime, _expirytime)
+    private const string _insertSmsNotificationSql = "call notifications.insertsmsnotification($1, $2, $3, $4, $5, $6)"; // (__orderid, _alternateid, _mobilenumber, _result, _resulttime, _expirytime)
     private const string _getSmsNotificationsSql = "select * from notifications.getsms_statusnew_updatestatus()";
     private const string _getSmsRecipients = "select * from notifications.getsmsrecipients($1)"; // (_orderid)
 
@@ -51,7 +51,6 @@ public class SmsNotificationRepository : ISmsNotificationRepository
 
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notification.OrderId);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notification.Id);
-        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.RecipientId ?? (object)DBNull.Value);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.RecipientNumber);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.SendResult.Result.ToString());
         pgcom.Parameters.AddWithValue(NpgsqlDbType.TimestampTz, notification.SendResult.ResultTime);

--- a/test/Altinn.Notifications.IntegrationTests/Utils/TestdataUtil.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Utils/TestdataUtil.cs
@@ -22,7 +22,6 @@ public static class TestdataUtil
             OrderId = order.Id,
             RequestedSendTime = order.RequestedSendTime,
             RecipientNumber = addressPoint!.MobileNumber,
-            RecipientId = recipient.RecipientId,
             SendResult = new(SmsNotificationResultType.New, DateTime.UtcNow)
         };
 
@@ -42,7 +41,6 @@ public static class TestdataUtil
             OrderId = order.Id,
             RequestedSendTime = order.RequestedSendTime,
             ToAddress = addressPoint!.EmailAddress,
-            RecipientId = recipient.RecipientId,
             SendResult = new(EmailNotificationResultType.New, DateTime.UtcNow)
         };
 
@@ -76,7 +74,6 @@ public static class TestdataUtil
             {
                 new Recipient()
                 {
-                    RecipientId = "recipient1",
                     AddressInfo = new()
                     {
                         new EmailAddressPoint()
@@ -115,7 +112,6 @@ public static class TestdataUtil
             {
                 new Recipient()
                 {
-                    RecipientId = "recipient1",
                     AddressInfo = new()
                     {
                         new SmsAddressPoint()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In preparation of removing the recipientId property we need to stop using the column in the table e.g. on creation on new notifications. 

## Related Issue(s)
- #436 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
