### PR TITLE
NationalIdentityNumber and OrganisationNumber added to Recipient models

### DIFF
--- a/src/Altinn.Notifications.Core/Models/Notification/EmailNotification.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/EmailNotification.cs
@@ -1,4 +1,5 @@
 ﻿using Altinn.Notifications.Core.Enums;
+using Altinn.Notifications.Core.Models.Recipients;
 
 namespace Altinn.Notifications.Core.Models.Notification;
 
@@ -20,14 +21,9 @@ public class EmailNotification : INotification<EmailNotificationResultType>
     public NotificationChannel NotificationChannel { get; } = NotificationChannel.Email;
 
     /// <summary>
-    /// Get the id of the recipient of the email notification
+    /// Gets the recipient of the notification
     /// </summary>
-    public string? RecipientId { get; internal set; }
-
-    /// <summary>
-    /// Get or sets the to address of the email notification
-    /// </summary>
-    public string ToAddress { get; internal set; } = string.Empty;
+    public EmailRecipient Recipient { get; internal set; } = new();
 
     /// <summary>
     /// Get or sets the send result of the notification

--- a/src/Altinn.Notifications.Core/Models/Notification/SmsNotification.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/SmsNotification.cs
@@ -1,4 +1,5 @@
 ﻿using Altinn.Notifications.Core.Enums;
+using Altinn.Notifications.Core.Models.Recipients;
 
 namespace Altinn.Notifications.Core.Models.Notification;
 
@@ -20,14 +21,9 @@ public class SmsNotification : INotification<SmsNotificationResultType>
     public NotificationChannel NotificationChannel { get; } = NotificationChannel.Sms;
 
     /// <summary>
-    /// Get the id of the recipient of the sms notification
+    /// Get the recipient of the notification
     /// </summary>
-    public string? RecipientId { get; internal set; }
-
-    /// <summary>
-    /// Get or sets the mobilenumber of the sms notification
-    /// </summary>
-    public string RecipientNumber { get; internal set; } = string.Empty;
+    public SmsRecipient Recipient { get; internal set; } = new();
 
     /// <inheritdoc/>
     public NotificationResult<SmsNotificationResultType> SendResult { get; internal set; } = new(SmsNotificationResultType.New, DateTime.UtcNow);

--- a/src/Altinn.Notifications.Core/Models/Recipient.cs
+++ b/src/Altinn.Notifications.Core/Models/Recipient.cs
@@ -8,9 +8,14 @@ namespace Altinn.Notifications.Core.Models;
 public class Recipient
 {
     /// <summary>
-    /// Gets the recipient id
+    /// Gets the recipient's organisation number
     /// </summary>
-    public string RecipientId { get; set; } = string.Empty;
+    public string? OrganisationNumber { get; set; } = null;
+
+    /// <summary>
+    /// Gets the recipient's national identity number
+    /// </summary>
+    public string? NationalIdentityNumber { get; set; } = null;
 
     /// <summary>
     /// Gets a list of address points for the recipient
@@ -20,17 +25,10 @@ public class Recipient
     /// <summary>
     /// Initializes a new instance of the <see cref="Recipient"/> class.
     /// </summary>
-    public Recipient(string recipientId, List<IAddressPoint> addressInfo)
+    public Recipient(List<IAddressPoint> addressInfo, string? organisationNumber = null, string? nationalIdentityNumber = null)
     {
-        RecipientId = recipientId;
-        AddressInfo = addressInfo;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Recipient"/> class.
-    /// </summary>
-    public Recipient(List<IAddressPoint> addressInfo)
-    {
+        OrganisationNumber = organisationNumber;
+        NationalIdentityNumber = nationalIdentityNumber;
         AddressInfo = addressInfo;
     }
 

--- a/src/Altinn.Notifications.Core/Models/Recipients/EmailRecipient.cs
+++ b/src/Altinn.Notifications.Core/Models/Recipients/EmailRecipient.cs
@@ -6,9 +6,14 @@ namespace Altinn.Notifications.Core.Models.Recipients;
 public class EmailRecipient
 {
     /// <summary>
-    /// Gets or sets the recipient id
+    /// Gets or sets the recipient's organisation number
     /// </summary>
-    public string? RecipientId { get; set; } = null;
+    public string? OrganisationNumber { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets the recipient's national identity number
+    /// </summary>
+    public string? NationalIdentityNumber { get; set; } = null;
 
     /// <summary>
     /// Gets or sets the toaddress

--- a/src/Altinn.Notifications.Core/Models/Recipients/SmsRecipient.cs
+++ b/src/Altinn.Notifications.Core/Models/Recipients/SmsRecipient.cs
@@ -6,9 +6,14 @@ namespace Altinn.Notifications.Core.Models.Recipients;
 public class SmsRecipient
 {
     /// <summary>
-    /// Gets or sets the recipient id
+    /// Gets or sets the recipient's organisation number
     /// </summary>
-    public string? RecipientId { get; set; } = null;
+    public string? OrganisationNumber { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets the recipient's national identity number
+    /// </summary>
+    public string? NationalIdentityNumber { get; set; } = null;
 
     /// <summary>
     /// Gets or sets the mobile number

--- a/src/Altinn.Notifications.Core/Services/EmailOrderProcessingService.cs
+++ b/src/Altinn.Notifications.Core/Services/EmailOrderProcessingService.cs
@@ -44,9 +44,9 @@ public class EmailOrderProcessingService : IEmailOrderProcessingService
         {
             EmailAddressPoint? addressPoint = recipient.AddressInfo.Find(a => a.AddressType == AddressType.Email) as EmailAddressPoint;
 
-            if (!emailRecipients.Exists(er =>            
-                (er.NationalIdentityNumber == (string.IsNullOrEmpty(recipient.NationalIdentityNumber) ? null : recipient.NationalIdentityNumber) ||
-                 er.NationalIdentityNumber == (string.IsNullOrEmpty(recipient.OrganisationNumber) ? null : recipient.OrganisationNumber))
+            if (!emailRecipients.Exists(er =>
+                er.NationalIdentityNumber == recipient.NationalIdentityNumber
+                && er.NationalIdentityNumber == recipient.OrganisationNumber
                 && er.ToAddress.Equals(addressPoint?.EmailAddress)))
             {
                 await _emailService.CreateNotification(order.Id, order.RequestedSendTime, recipient);

--- a/src/Altinn.Notifications.Core/Services/EmailOrderProcessingService.cs
+++ b/src/Altinn.Notifications.Core/Services/EmailOrderProcessingService.cs
@@ -44,8 +44,9 @@ public class EmailOrderProcessingService : IEmailOrderProcessingService
         {
             EmailAddressPoint? addressPoint = recipient.AddressInfo.Find(a => a.AddressType == AddressType.Email) as EmailAddressPoint;
 
-            if (!emailRecipients.Exists(er =>
-                er.RecipientId == (string.IsNullOrEmpty(recipient.RecipientId) ? null : recipient.RecipientId)
+            if (!emailRecipients.Exists(er =>            
+                (er.NationalIdentityNumber == (string.IsNullOrEmpty(recipient.NationalIdentityNumber) ? null : recipient.NationalIdentityNumber) ||
+                 er.NationalIdentityNumber == (string.IsNullOrEmpty(recipient.OrganisationNumber) ? null : recipient.OrganisationNumber))
                 && er.ToAddress.Equals(addressPoint?.EmailAddress)))
             {
                 await _emailService.CreateNotification(order.Id, order.RequestedSendTime, recipient);

--- a/src/Altinn.Notifications.Core/Services/EmailOrderProcessingService.cs
+++ b/src/Altinn.Notifications.Core/Services/EmailOrderProcessingService.cs
@@ -45,9 +45,9 @@ public class EmailOrderProcessingService : IEmailOrderProcessingService
             EmailAddressPoint? addressPoint = recipient.AddressInfo.Find(a => a.AddressType == AddressType.Email) as EmailAddressPoint;
 
             if (!emailRecipients.Exists(er =>
-                er.NationalIdentityNumber == recipient.NationalIdentityNumber
-                && er.NationalIdentityNumber == recipient.OrganisationNumber
-                && er.ToAddress.Equals(addressPoint?.EmailAddress)))
+             er.NationalIdentityNumber == recipient.NationalIdentityNumber
+             && er.OrganisationNumber == recipient.OrganisationNumber
+             && er.ToAddress == addressPoint?.EmailAddress))
             {
                 await _emailService.CreateNotification(order.Id, order.RequestedSendTime, recipient);
             }

--- a/src/Altinn.Notifications.Core/Services/SmsNotificationService.cs
+++ b/src/Altinn.Notifications.Core/Services/SmsNotificationService.cs
@@ -4,6 +4,7 @@ using Altinn.Notifications.Core.Integrations;
 using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.Address;
 using Altinn.Notifications.Core.Models.Notification;
+using Altinn.Notifications.Core.Models.Recipients;
 using Altinn.Notifications.Core.Persistence;
 using Altinn.Notifications.Core.Services.Interfaces;
 
@@ -44,13 +45,20 @@ public class SmsNotificationService : ISmsNotificationService
     {
         SmsAddressPoint? addressPoint = recipient.AddressInfo.Find(a => a.AddressType == AddressType.Sms) as SmsAddressPoint;
 
+        SmsRecipient smsRecipient = new()
+        {
+            OrganisationNumber = recipient.OrganisationNumber,
+            NationalIdentityNumber = recipient.NationalIdentityNumber,
+            MobileNumber = addressPoint?.MobileNumber ?? string.Empty
+        };
+
         if (!string.IsNullOrEmpty(addressPoint?.MobileNumber))
         {
-            await CreateNotificationForRecipient(orderId, requestedSendTime, recipient.RecipientId, addressPoint!.MobileNumber, SmsNotificationResultType.New);
+            await CreateNotificationForRecipient(orderId, requestedSendTime, smsRecipient, SmsNotificationResultType.New);
         }
         else
         {
-            await CreateNotificationForRecipient(orderId, requestedSendTime, recipient.RecipientId, string.Empty, SmsNotificationResultType.Failed_RecipientNotIdentified);
+            await CreateNotificationForRecipient(orderId, requestedSendTime, smsRecipient, SmsNotificationResultType.Failed_RecipientNotIdentified);
         }
     }
 
@@ -75,15 +83,14 @@ public class SmsNotificationService : ISmsNotificationService
         await _repository.UpdateSendStatus(sendOperationResult.NotificationId, sendOperationResult.SendResult, sendOperationResult.GatewayReference);
     }
 
-    private async Task CreateNotificationForRecipient(Guid orderId, DateTime requestedSendTime, string recipientId, string recipientNumber, SmsNotificationResultType type)
+    private async Task CreateNotificationForRecipient(Guid orderId, DateTime requestedSendTime, SmsRecipient recipient, SmsNotificationResultType type)
     {
         var smsNotification = new SmsNotification()
         {
             Id = _guid.NewGuid(),
             OrderId = orderId,
             RequestedSendTime = requestedSendTime,
-            RecipientNumber = recipientNumber,
-            RecipientId = string.IsNullOrEmpty(recipientId) ? null : recipientId,
+            Recipient = recipient,
             SendResult = new(type, _dateTime.UtcNow())
         };
 

--- a/src/Altinn.Notifications.Core/Services/SmsOrderProcessingService.cs
+++ b/src/Altinn.Notifications.Core/Services/SmsOrderProcessingService.cs
@@ -43,7 +43,8 @@ public class SmsOrderProcessingService : ISmsOrderProcessingService
             SmsAddressPoint? addressPoint = recipient.AddressInfo.Find(a => a.AddressType == AddressType.Sms) as SmsAddressPoint;
 
             if (!smsRecipients.Exists(sr =>
-                sr.RecipientId == (string.IsNullOrEmpty(recipient.RecipientId) ? null : recipient.RecipientId)
+                (sr.NationalIdentityNumber == (string.IsNullOrEmpty(recipient.NationalIdentityNumber) ? null : recipient.NationalIdentityNumber) ||
+                sr.NationalIdentityNumber == (string.IsNullOrEmpty(recipient.OrganisationNumber) ? null : recipient.OrganisationNumber))
                 && sr.MobileNumber.Equals(addressPoint?.MobileNumber)))
             {
                 await _smsService.CreateNotification(order.Id, order.RequestedSendTime, recipient);

--- a/src/Altinn.Notifications.Core/Services/SmsOrderProcessingService.cs
+++ b/src/Altinn.Notifications.Core/Services/SmsOrderProcessingService.cs
@@ -45,7 +45,7 @@ public class SmsOrderProcessingService : ISmsOrderProcessingService
             if (!smsRecipients.Exists(sr =>
                 sr.NationalIdentityNumber == recipient.NationalIdentityNumber
                 && sr.OrganisationNumber == recipient.OrganisationNumber
-                && sr.MobileNumber.Equals(addressPoint?.MobileNumber)))
+                && sr.MobileNumber == addressPoint?.MobileNumber))
             {
                 await _smsService.CreateNotification(order.Id, order.RequestedSendTime, recipient);
             }

--- a/src/Altinn.Notifications.Core/Services/SmsOrderProcessingService.cs
+++ b/src/Altinn.Notifications.Core/Services/SmsOrderProcessingService.cs
@@ -43,8 +43,8 @@ public class SmsOrderProcessingService : ISmsOrderProcessingService
             SmsAddressPoint? addressPoint = recipient.AddressInfo.Find(a => a.AddressType == AddressType.Sms) as SmsAddressPoint;
 
             if (!smsRecipients.Exists(sr =>
-                (sr.NationalIdentityNumber == (string.IsNullOrEmpty(recipient.NationalIdentityNumber) ? null : recipient.NationalIdentityNumber) ||
-                sr.NationalIdentityNumber == (string.IsNullOrEmpty(recipient.OrganisationNumber) ? null : recipient.OrganisationNumber))
+                sr.NationalIdentityNumber == recipient.NationalIdentityNumber
+                && sr.OrganisationNumber == recipient.OrganisationNumber
                 && sr.MobileNumber.Equals(addressPoint?.MobileNumber)))
             {
                 await _smsService.CreateNotification(order.Id, order.RequestedSendTime, recipient);

--- a/src/Altinn.Notifications.Persistence/Migration/v0.26/01-alter-tables.sql
+++ b/src/Altinn.Notifications.Persistence/Migration/v0.26/01-alter-tables.sql
@@ -1,0 +1,18 @@
+-- Modify table emailnotifications: Remove the recipientid column
+ALTER TABLE notifications.emailnotifications
+DROP COLUMN IF EXISTS recipientid;
+
+-- Modify table smsnotifications: Add new columns recipientorgno and recipientnin
+ALTER TABLE notifications.emailnotifications
+ADD COLUMN IF NOT EXISTS recipientorgno text,
+ADD COLUMN IF NOT EXISTS recipientnin text;
+
+
+-- Modify table smsnotifications: Remove the recipientid column
+ALTER TABLE notifications.smsnotifications
+DROP COLUMN IF EXISTS recipientid;
+
+-- Modify table smsnotifications: Add new columns recipientorgno and recipientnin
+ALTER TABLE notifications.smsnotifications
+ADD COLUMN IF NOT EXISTS recipientorgno text,
+ADD COLUMN IF NOT EXISTS recipientnin text;

--- a/src/Altinn.Notifications.Persistence/Migration/v0.26/02-alter-types.sql
+++ b/src/Altinn.Notifications.Persistence/Migration/v0.26/02-alter-types.sql
@@ -1,0 +1,3 @@
+ALTER TYPE public.emailnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_RecipientReserved';
+
+ALTER TYPE public.smsnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_Recipientreserved';

--- a/src/Altinn.Notifications.Persistence/Migration/v0.26/03-alter-procedures.sql
+++ b/src/Altinn.Notifications.Persistence/Migration/v0.26/03-alter-procedures.sql
@@ -1,0 +1,92 @@
+drop procedure if exists notifications.insertemailnotification(
+IN _orderid uuid,
+IN _alternateid uuid,
+IN _recipientid text,
+IN _toaddress text,
+IN _result text,
+IN _resulttime timestamp with time zone,
+IN _expirytime timestamp with time zone);
+
+drop procedure if exists notifications.insertsmsnotification(
+IN _orderid uuid, 
+IN _alternateid uuid, 
+IN _recipientid text, 
+IN _mobilenumber text, 
+IN _result text, 
+IN _resulttime timestamp with time zone, 
+IN _expirytime timestamp with time zone);
+
+
+CREATE OR REPLACE PROCEDURE notifications.insertemailnotification(
+_orderid uuid, 
+_alternateid uuid, 
+_recipientorgno TEXT,
+_recipientnin TEXT,
+_toaddress TEXT, 
+_result text, 
+_resulttime timestamptz, 
+_expirytime timestamptz)
+LANGUAGE 'plpgsql'
+AS $BODY$
+DECLARE
+__orderid BIGINT := (SELECT _id from notifications.orders
+			where alternateid = _orderid);
+BEGIN
+
+INSERT INTO notifications.emailnotifications(
+_orderid, 
+alternateid, 
+recipientorgno, 
+recipientnin, 
+toaddress, result, 
+resulttime, 
+expirytime)
+VALUES (
+__orderid, 
+_alternateid,
+_recipientorgno,
+_recipientnin,
+_toaddress,
+_result::emailnotificationresulttype,
+_resulttime,
+_expirytime);
+END;
+$BODY$;
+
+
+CREATE OR REPLACE PROCEDURE notifications.insertsmsnotification(
+_orderid uuid, 
+_alternateid uuid, 
+_recipientorgno TEXT, 
+_recipientnin TEXT,
+_mobilenumber TEXT, 
+_result text, 
+_resulttime timestamptz, 
+_expirytime timestamptz)
+LANGUAGE 'plpgsql'
+AS $BODY$
+DECLARE
+__orderid BIGINT := (SELECT _id from notifications.orders
+			where alternateid = _orderid);
+BEGIN
+
+INSERT INTO notifications.smsnotifications(
+_orderid, 
+alternateid,
+recipientorgno, 
+recipientnin, 
+mobilenumber,
+result,
+resulttime,
+expirytime)
+VALUES (
+__orderid,
+_alternateid,
+_recipientorgno, 
+_recipientnin, 
+_mobilenumber,
+_result::smsnotificationresulttype,
+_resulttime,
+_expirytime);
+END;
+$BODY$;

--- a/src/Altinn.Notifications.Persistence/Migration/v0.26/04-alter-functions.sql
+++ b/src/Altinn.Notifications.Persistence/Migration/v0.26/04-alter-functions.sql
@@ -1,0 +1,103 @@
+CREATE OR REPLACE FUNCTION notifications.getsmsrecipients_v2(_orderid uuid)
+RETURNS TABLE(
+  recipientorgno text, 
+  recipientnin text,
+  mobilenumber text
+) 
+LANGUAGE 'plpgsql'
+AS $BODY$
+DECLARE
+__orderid BIGINT := (SELECT _id from notifications.orders
+			where alternateid = _orderid);
+BEGIN
+RETURN query 
+	SELECT s.recipientorgno, s.recipientnin, s.mobilenumber
+	FROM notifications.smsnotifications s
+	WHERE s._orderid = __orderid;
+END;
+$BODY$;
+
+CREATE OR REPLACE FUNCTION notifications.getemailrecipients_v2(_alternateid uuid)
+RETURNS TABLE(
+    recipientorgno text, 
+    recipientnin text, 
+    toaddress text
+) 
+LANGUAGE 'plpgsql'
+AS $BODY$
+DECLARE
+__orderid BIGINT := (SELECT _id from notifications.orders
+			where alternateid = _alternateid);
+BEGIN
+RETURN query 
+	SELECT e.recipientorgno, e.recipientnin, e.toaddress
+	FROM notifications.emailnotifications e
+	WHERE e._orderid = __orderid;
+END;
+$BODY$;
+
+CREATE OR REPLACE FUNCTION notifications.getsmssummary_v2(
+	_alternateorderid uuid,
+	_creatorname text)
+    RETURNS TABLE(
+        sendersreference text, 
+        alternateid uuid, 
+        recipientorgno text, 
+        recipientnin text, 
+        mobilenumber text, 
+        result smsnotificationresulttype, 
+        resulttime timestamptz) 
+    LANGUAGE 'plpgsql'
+AS $BODY$
+
+	BEGIN
+		RETURN QUERY
+		   SELECT o.sendersreference, n.alternateid, n.recipientorgno, n.recipientnin, n.mobilenumber, n.result, n.resulttime
+			FROM notifications.smsnotifications n
+            LEFT JOIN notifications.orders o ON n._orderid = o._id
+			WHERE o.alternateid = _alternateorderid
+			and o.creatorname = _creatorname;
+        IF NOT FOUND THEN
+            RETURN QUERY
+            SELECT o.sendersreference, NULL::uuid, NULL::text, NULL::text, NULL::text, NULL::smsnotificationresulttype, NULL::timestamptz
+            FROM notifications.orders o
+            WHERE o.alternateid = _alternateorderid
+            and o.creatorname = _creatorname;
+        END IF;
+	END;
+$BODY$;
+
+CREATE OR REPLACE FUNCTION notifications.getemailsummary_V2(
+	_alternateorderid uuid,
+	_creatorname text)
+    RETURNS TABLE(
+        sendersreference text, 
+        alternateid uuid, 
+        recipientorgno text, 
+        recipientnin text, 
+        toaddress text, 
+        result emailnotificationresulttype, 
+        resulttime timestamptz) 
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+    ROWS 1000
+
+AS $BODY$
+
+	BEGIN
+		RETURN QUERY
+		   SELECT o.sendersreference, n.alternateid, n.recipientorgno, n.recipientnin, n.toaddress, n.result, n.resulttime
+			FROM notifications.emailnotifications n
+            LEFT JOIN notifications.orders o ON n._orderid = o._id
+			WHERE o.alternateid = _alternateorderid
+			and o.creatorname = _creatorname;
+        IF NOT FOUND THEN
+            RETURN QUERY
+            SELECT o.sendersreference, NULL::uuid, NULL::text, NULL::text, NULL::text, NULL::emailnotificationresulttype, NULL::timestamptz
+            FROM notifications.orders o
+            WHERE o.alternateid = _alternateorderid
+            and o.creatorname = _creatorname;
+        END IF;
+	END;
+$BODY$;

--- a/src/Altinn.Notifications.Persistence/Repository/NotificationSummaryRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/NotificationSummaryRepository.cs
@@ -20,8 +20,8 @@ public class NotificationSummaryRepository : INotificationSummaryRepository
     private readonly NpgsqlDataSource _dataSource;
     private readonly TelemetryClient? _telemetryClient;
 
-    private const string _getEmailNotificationsByOrderIdSql = "select * from notifications.getemailsummary($1, $2)"; // (_alternateorderid, creatorname)
-    private const string _getSmsNotificationsByOrderIdSql = "select * from notifications.getsmssummary($1, $2)"; // (_alternateorderid, creatorname)
+    private const string _getEmailNotificationsByOrderIdSql = "select * from notifications.getemailsummary_v2($1, $2)"; // (_alternateorderid, creatorname)
+    private const string _getSmsNotificationsByOrderIdSql = "select * from notifications.getsmssummary_v2($1, $2)"; // (_alternateorderid, creatorname)
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EmailNotificationRepository"/> class.
@@ -45,7 +45,8 @@ public class NotificationSummaryRepository : INotificationSummaryRepository
                 reader.GetValue<Guid>("alternateid"),
                 new EmailRecipient()
                 {
-                    RecipientId = reader.GetValue<string>("recipientid"),
+                    OrganisationNumber = reader.GetValue<string?>("recipientorgno"),
+                    NationalIdentityNumber = reader.GetValue<string?>("recipientnin"),
                     ToAddress = reader.GetValue<string>("toaddress")
                 },
                 new NotificationResult<EmailNotificationResultType>(
@@ -75,7 +76,8 @@ public class NotificationSummaryRepository : INotificationSummaryRepository
                 reader.GetValue<Guid>("alternateid"),
                 new SmsRecipient()
                 {
-                    RecipientId = reader.GetValue<string>("recipientid"),
+                    OrganisationNumber = reader.GetValue<string?>("recipientorgno"),
+                    NationalIdentityNumber = reader.GetValue<string>("recipientnin"),
                     MobileNumber = reader.GetValue<string>("mobilenumber")
                 },
                 new NotificationResult<SmsNotificationResultType>(

--- a/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
@@ -21,9 +21,9 @@ public class SmsNotificationRepository : ISmsNotificationRepository
     private readonly NpgsqlDataSource _dataSource;
     private readonly TelemetryClient? _telemetryClient;
 
-    private const string _insertSmsNotificationSql = "call notifications.insertsmsnotification($1, $2, $3, $4, $5, $6)"; // (__orderid, _alternateid, _mobilenumber, _result, _resulttime, _expirytime)
+    private const string _insertSmsNotificationSql = "call notifications.insertsmsnotification($1, $2, $3, $4, $5, $6, $7, $8)"; // (__orderid, _alternateid, _recipientorgno, _recipientnin, _mobilenumber, _result, _resulttime, _expirytime)
     private const string _getSmsNotificationsSql = "select * from notifications.getsms_statusnew_updatestatus()";
-    private const string _getSmsRecipients = "select * from notifications.getsmsrecipients($1)"; // (_orderid)
+    private const string _getSmsRecipients = "select * from notifications.getsmsrecipients_v2($1)"; // (_orderid)
 
     private const string _updateSmsNotificationStatus =
         @"UPDATE notifications.smsnotifications 
@@ -51,7 +51,9 @@ public class SmsNotificationRepository : ISmsNotificationRepository
 
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notification.OrderId);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notification.Id);
-        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.RecipientNumber);
+        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, (object)DBNull.Value); // recipientorgno
+        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, (object)DBNull.Value); // recipientnin
+        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.Recipient.MobileNumber);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.SendResult.Result.ToString());
         pgcom.Parameters.AddWithValue(NpgsqlDbType.TimestampTz, notification.SendResult.ResultTime);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.TimestampTz, expiry);
@@ -74,7 +76,8 @@ public class SmsNotificationRepository : ISmsNotificationRepository
             {
                 searchResult.Add(new SmsRecipient()
                 {
-                    RecipientId = reader.GetValue<string>("recipientid"),
+                    OrganisationNumber = reader.GetValue<string?>("recipientorgno"),
+                    NationalIdentityNumber = reader.GetValue<string?>("recipientnin"),
                     MobileNumber = reader.GetValue<string>("mobilenumber")
                 });
             }

--- a/src/Altinn.Notifications/Mappers/EmailNotificationSummaryMapper.cs
+++ b/src/Altinn.Notifications/Mappers/EmailNotificationSummaryMapper.cs
@@ -43,6 +43,8 @@ namespace Altinn.Notifications.Mappers
                 Succeeded = notification.Succeeded,
                 Recipient = new()
                 {
+                    OrganisationNumber = notification.Recipient.OrganisationNumber,
+                    NationalIdentityNumber = notification.Recipient.NationalIdentityNumber,
                     EmailAddress = notification.Recipient.ToAddress
                 },
                 SendStatus = new()

--- a/src/Altinn.Notifications/Mappers/OrderMapper.cs
+++ b/src/Altinn.Notifications/Mappers/OrderMapper.cs
@@ -1,6 +1,7 @@
 ﻿using Altinn.Notifications.Core.Enums;
 using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.Address;
+using Altinn.Notifications.Core.Models.Notification;
 using Altinn.Notifications.Core.Models.NotificationTemplate;
 using Altinn.Notifications.Core.Models.Orders;
 using Altinn.Notifications.Extensions;
@@ -23,7 +24,7 @@ public static class OrderMapper
         var recipients = new List<Recipient>();
 
         recipients.AddRange(
-            extRequest.Recipients.Select(r => new Recipient(string.Empty, new List<IAddressPoint>() { new EmailAddressPoint(r.EmailAddress!) })));
+            extRequest.Recipients.Select(r => new Recipient(new List<IAddressPoint>() { new EmailAddressPoint(r.EmailAddress!) })));
 
         return new NotificationOrderRequest(
             extRequest.SendersReference,
@@ -44,7 +45,7 @@ public static class OrderMapper
         List<Recipient> recipients = new();
 
         recipients.AddRange(
-            extRequest.Recipients.Select(r => new Recipient(string.Empty, new List<IAddressPoint>() { new SmsAddressPoint(r.MobileNumber!) })));
+            extRequest.Recipients.Select(r => new Recipient(new List<IAddressPoint>() { new SmsAddressPoint(r.MobileNumber!) })));
 
         return new NotificationOrderRequest(
             extRequest.SendersReference,
@@ -172,6 +173,8 @@ public static class OrderMapper
         recipientExt.AddRange(
             recipients.Select(r => new RecipientExt
             {
+                OrganisationNumber = r.OrganisationNumber,
+                NationalIdentityNumber = r.NationalIdentityNumber,
                 EmailAddress = GetEmailFromAddressList(r.AddressInfo),
                 MobileNumber = GetMobileNumberFromAddressList(r.AddressInfo)
             }));

--- a/src/Altinn.Notifications/Mappers/SmsNotificationSummaryMapper.cs
+++ b/src/Altinn.Notifications/Mappers/SmsNotificationSummaryMapper.cs
@@ -43,6 +43,8 @@ namespace Altinn.Notifications.Mappers
                 Succeeded = notification.Succeeded,
                 Recipient = new()
                 {
+                    OrganisationNumber = notification.Recipient.OrganisationNumber,
+                    NationalIdentityNumber = notification.Recipient.NationalIdentityNumber,
                     MobileNumber = notification.Recipient.MobileNumber
                 },
                 SendStatus = new()

--- a/src/Altinn.Notifications/Models/RecipientExt.cs
+++ b/src/Altinn.Notifications/Models/RecipientExt.cs
@@ -21,4 +21,16 @@ public class RecipientExt
     /// </summary>
     [JsonPropertyName("mobileNumber")]
     public string? MobileNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the organisation number of the recipient
+    /// </summary>
+    [JsonPropertyName("organisationNumber")]
+    public string? OrganisationNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the national identity number of the recipient
+    /// </summary>
+    [JsonPropertyName("nationalIdentityNumber")]
+    public string? NationalIdentityNumber { get; set; }
 }

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Core/SmsNotificationSummaryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Core/SmsNotificationSummaryTests.cs
@@ -56,7 +56,7 @@ namespace Altinn.Notifications.IntegrationTests.Notifications.Core
                    Assert.Equal(SmsNotificationResultType.New, actualNotification.ResultStatus.Result);
                    Assert.NotEmpty(actualNotification.Recipient.MobileNumber);
                    Assert.Equal(notification.Id, actualNotification.Id);
-                   Assert.Equivalent(notification.RecipientNumber, actualNotification.Recipient.MobileNumber);
+                   Assert.Equivalent(notification.Recipient, actualNotification.Recipient);
                    return true;
                },
                error =>

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
@@ -49,8 +49,11 @@ public class SmsNotificationRepositoryTests : IAsyncLifetime
             Id = notificationId,
             OrderId = orderId,
             RequestedSendTime = DateTime.UtcNow,
-            RecipientId = "12345678",
-            RecipientNumber = "999999999",
+            Recipient = new()
+            {
+                NationalIdentityNumber = "16069412345",
+                MobileNumber = "999999999"
+            }
         };
 
         await repo.AddNotification(smsNotification, DateTime.UtcNow);
@@ -93,8 +96,7 @@ public class SmsNotificationRepositoryTests : IAsyncLifetime
 
         (NotificationOrder order, SmsNotification smsNotification) = await PostgreUtil.PopulateDBWithOrderAndSmsNotification();
         _orderIdsToDelete.Add(order.Id);
-        string expectedNumber = smsNotification.RecipientNumber;
-        string? expectedRecipientId = smsNotification.RecipientId;
+        SmsRecipient expectedRecipient = smsNotification.Recipient;
 
         // Act
         List<SmsRecipient> actual = await repo.GetRecipients(order.Id);
@@ -103,8 +105,9 @@ public class SmsNotificationRepositoryTests : IAsyncLifetime
 
         // Assert
         Assert.Single(actual);
-        Assert.Equal(expectedNumber, actualRecipient.MobileNumber);
-        Assert.Equal(expectedRecipientId, actualRecipient.RecipientId);
+        Assert.Equal(expectedRecipient.MobileNumber, actualRecipient.MobileNumber);
+        Assert.Equal(expectedRecipient.NationalIdentityNumber, actualRecipient.NationalIdentityNumber);
+        Assert.Equal(expectedRecipient.OrganisationNumber, actualRecipient.OrganisationNumber);
     }
 
     [Fact]

--- a/test/Altinn.Notifications.IntegrationTests/Utils/TestdataUtil.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Utils/TestdataUtil.cs
@@ -21,7 +21,10 @@ public static class TestdataUtil
             Id = Guid.NewGuid(),
             OrderId = order.Id,
             RequestedSendTime = order.RequestedSendTime,
-            RecipientNumber = addressPoint!.MobileNumber,
+            Recipient = new()
+            {
+                MobileNumber = addressPoint!.MobileNumber,
+            },
             SendResult = new(SmsNotificationResultType.New, DateTime.UtcNow)
         };
 
@@ -40,7 +43,10 @@ public static class TestdataUtil
             Id = Guid.NewGuid(),
             OrderId = order.Id,
             RequestedSendTime = order.RequestedSendTime,
-            ToAddress = addressPoint!.EmailAddress,
+            Recipient = new()
+            {
+                ToAddress = addressPoint!.EmailAddress
+            },
             SendResult = new(EmailNotificationResultType.New, DateTime.UtcNow)
         };
 

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/NotificationOrderTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/NotificationOrderTests.cs
@@ -46,7 +46,7 @@ public class NotificationOrderTests
             {
                 new Recipient()
                 {
-                    RecipientId = "recipient1",
+                    NationalIdentityNumber = "nationalidentitynumber",
                     AddressInfo = new()
                     {
                         new EmailAddressPoint()
@@ -92,7 +92,7 @@ public class NotificationOrderTests
                     new JsonObject()
                     {
                         {
-                            "recipientId", "recipient1"
+                            "nationalIdentityNumber", "nationalidentitynumber"
                         },
                         {
                             "addressInfo",  new JsonArray()

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailNotificationServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailNotificationServiceTests.cs
@@ -87,10 +87,13 @@ public class EmailNotificationServiceTests
         {
             Id = id,
             OrderId = orderId,
-            RecipientId = "skd",
+            Recipient = new()
+            {
+                OrganisationNumber = "skd-orgno",
+                ToAddress = "skd@norge.no"
+            },
             RequestedSendTime = requestedSendTime,
-            SendResult = new(EmailNotificationResultType.New, dateTimeOutput),
-            ToAddress = "skd@norge.no"
+            SendResult = new(EmailNotificationResultType.New, dateTimeOutput)           
         };
 
         var repoMock = new Mock<IEmailNotificationRepository>();
@@ -99,7 +102,7 @@ public class EmailNotificationServiceTests
         var service = GetTestService(repo: repoMock.Object, guidOutput: id, dateTimeOutput: dateTimeOutput);
 
         // Act
-        await service.CreateNotification(orderId, requestedSendTime, new Recipient("skd", new List<IAddressPoint>() { new EmailAddressPoint("skd@norge.no") }));
+        await service.CreateNotification(orderId, requestedSendTime, new Recipient(new List<IAddressPoint>() { new EmailAddressPoint("skd@norge.no") }, organisationNumber: "skd-orgno"));
 
         // Assert
         repoMock.Verify(r => r.AddNotification(It.Is<EmailNotification>(e => AssertUtils.AreEquivalent(expected, e)), It.Is<DateTime>(d => d == expectedExpiry)), Times.Once);
@@ -119,7 +122,10 @@ public class EmailNotificationServiceTests
         {
             Id = id,
             OrderId = orderId,
-            RecipientId = "skd",
+            Recipient = new()
+            {
+                OrganisationNumber = "skd-orgno"
+            },
             RequestedSendTime = requestedSendTime,
             SendResult = new(EmailNotificationResultType.Failed_RecipientNotIdentified, dateTimeOutput),
         };
@@ -130,7 +136,7 @@ public class EmailNotificationServiceTests
         var service = GetTestService(repo: repoMock.Object, guidOutput: id, dateTimeOutput: dateTimeOutput);
 
         // Act
-        await service.CreateNotification(orderId, requestedSendTime, new Recipient("skd", new List<IAddressPoint>()));
+        await service.CreateNotification(orderId, requestedSendTime, new Recipient(new List<IAddressPoint>(), organisationNumber: "skd-orgno"));
 
         // Assert
         repoMock.Verify();

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailOrderProcessingServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailOrderProcessingServiceTests.cs
@@ -60,7 +60,7 @@ public class EmailOrderProcessingServiceTests
             RequestedSendTime = requested,
             Recipients = new List<Recipient>()
             {
-                new Recipient(new List<IAddressPoint>() { new EmailAddressPoint("test@test.com") }, organisationNumber: "skd-orgno")
+                new(new List<IAddressPoint>() { new EmailAddressPoint("test@test.com") }, organisationNumber: "skd-orgno")
             }
         };
 
@@ -87,7 +87,7 @@ public class EmailOrderProcessingServiceTests
             NotificationChannel = NotificationChannel.Email,
             Recipients = new List<Recipient>()
             {
-                new Recipient()
+                new()
             }
         };
 
@@ -118,9 +118,10 @@ public class EmailOrderProcessingServiceTests
             NotificationChannel = NotificationChannel.Email,
             Recipients = new List<Recipient>()
             {
-                new Recipient(),
-                new Recipient(new List<IAddressPoint>() { new EmailAddressPoint("test@test.com") }, organisationNumber : "skd-orgno"),
-                new Recipient(new List<IAddressPoint>() { new EmailAddressPoint("test@domain.com") })
+                new(),
+                new(new List<IAddressPoint>() { new EmailAddressPoint("test2@test.com") }, nationalIdentityNumber: "enduser-nin"),
+                new(new List<IAddressPoint>() { new EmailAddressPoint("test@test.com") }, organisationNumber : "skd-orgno"),
+                new(new List<IAddressPoint>() { new EmailAddressPoint("test@domain.com") })
             }
         };
 
@@ -128,7 +129,11 @@ public class EmailOrderProcessingServiceTests
         serviceMock.Setup(s => s.CreateNotification(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<Recipient>()));
 
         var emailRepoMock = new Mock<IEmailNotificationRepository>();
-        emailRepoMock.Setup(e => e.GetRecipients(It.IsAny<Guid>())).ReturnsAsync(new List<EmailRecipient>() { new EmailRecipient() { OrganisationNumber = "skd-orgno", ToAddress = "test@test.com" } });
+        emailRepoMock.Setup(e => e.GetRecipients(It.IsAny<Guid>())).ReturnsAsync(new List<EmailRecipient>()
+        {
+            new() { OrganisationNumber = "skd-orgno", ToAddress = "test@test.com" },
+            new() { NationalIdentityNumber = "enduser-nin", ToAddress = "test2@test.com" }
+        });
 
         var service = GetTestService(emailRepo: emailRepoMock.Object, emailService: serviceMock.Object);
 

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailOrderProcessingServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailOrderProcessingServiceTests.cs
@@ -119,8 +119,8 @@ public class EmailOrderProcessingServiceTests
             Recipients = new List<Recipient>()
             {
                 new(),
-                new(new List<IAddressPoint>() { new EmailAddressPoint("test2@test.com") }, nationalIdentityNumber: "enduser-nin"),
-                new(new List<IAddressPoint>() { new EmailAddressPoint("test@test.com") }, organisationNumber : "skd-orgno"),
+                new(new List<IAddressPoint>() { new EmailAddressPoint("test@test.com") }, nationalIdentityNumber: "enduser-nin"),
+                new(new List<IAddressPoint>() { new EmailAddressPoint("test@test.com") }, organisationNumber : "skd-orgNo"),
                 new(new List<IAddressPoint>() { new EmailAddressPoint("test@domain.com") })
             }
         };
@@ -131,8 +131,8 @@ public class EmailOrderProcessingServiceTests
         var emailRepoMock = new Mock<IEmailNotificationRepository>();
         emailRepoMock.Setup(e => e.GetRecipients(It.IsAny<Guid>())).ReturnsAsync(new List<EmailRecipient>()
         {
-            new() { OrganisationNumber = "skd-orgno", ToAddress = "test@test.com" },
-            new() { NationalIdentityNumber = "enduser-nin", ToAddress = "test2@test.com" }
+            new() { OrganisationNumber = "skd-orgNo", ToAddress = "test@test.com" },
+            new() { NationalIdentityNumber = "enduser-nin", ToAddress = "test@test.com" }
         });
 
         var service = GetTestService(emailRepo: emailRepoMock.Object, emailService: serviceMock.Object);
@@ -141,8 +141,8 @@ public class EmailOrderProcessingServiceTests
         await service.ProcessOrderRetry(order);
 
         // Assert
-        serviceMock.Verify(s => s.CreateNotification(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<Recipient>()), Times.Exactly(2));
         emailRepoMock.Verify(e => e.GetRecipients(It.IsAny<Guid>()), Times.Once);
+        serviceMock.Verify(s => s.CreateNotification(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<Recipient>()), Times.Exactly(2));
     }
 
     private static EmailOrderProcessingService GetTestService(

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailOrderProcessingServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailOrderProcessingServiceTests.cs
@@ -60,11 +60,11 @@ public class EmailOrderProcessingServiceTests
             RequestedSendTime = requested,
             Recipients = new List<Recipient>()
             {
-                new Recipient("skd", new List<IAddressPoint>() { new EmailAddressPoint("test@test.com") })
+                new Recipient(new List<IAddressPoint>() { new EmailAddressPoint("test@test.com") }, organisationNumber: "skd-orgno")
             }
         };
 
-        Recipient expectedRecipient = new("skd", new List<IAddressPoint>() { new EmailAddressPoint("test@test.com") });
+        Recipient expectedRecipient = new(new List<IAddressPoint>() { new EmailAddressPoint("test@test.com") }, organisationNumber: "skd-orgno");
 
         var serviceMock = new Mock<IEmailNotificationService>();
         serviceMock.Setup(s => s.CreateNotification(It.IsAny<Guid>(), It.Is<DateTime>(d => d.Equals(requested)), It.Is<Recipient>(r => AssertUtils.AreEquivalent(expectedRecipient, r))));
@@ -119,7 +119,7 @@ public class EmailOrderProcessingServiceTests
             Recipients = new List<Recipient>()
             {
                 new Recipient(),
-                new Recipient("skd", new List<IAddressPoint>() { new EmailAddressPoint("test@test.com") }),
+                new Recipient(new List<IAddressPoint>() { new EmailAddressPoint("test@test.com") }, organisationNumber : "skd-orgno"),
                 new Recipient(new List<IAddressPoint>() { new EmailAddressPoint("test@domain.com") })
             }
         };
@@ -128,7 +128,7 @@ public class EmailOrderProcessingServiceTests
         serviceMock.Setup(s => s.CreateNotification(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<Recipient>()));
 
         var emailRepoMock = new Mock<IEmailNotificationRepository>();
-        emailRepoMock.Setup(e => e.GetRecipients(It.IsAny<Guid>())).ReturnsAsync(new List<EmailRecipient>() { new EmailRecipient() { RecipientId = "skd", ToAddress = "test@test.com" } });
+        emailRepoMock.Setup(e => e.GetRecipients(It.IsAny<Guid>())).ReturnsAsync(new List<EmailRecipient>() { new EmailRecipient() { OrganisationNumber = "skd-orgno", ToAddress = "test@test.com" } });
 
         var service = GetTestService(emailRepo: emailRepoMock.Object, emailService: serviceMock.Object);
 

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsNotificationServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsNotificationServiceTests.cs
@@ -43,7 +43,7 @@ public class SmsNotificationServiceTests
         var service = GetTestService(repo: repoMock.Object);
 
         // Act
-        await service.CreateNotification(Guid.NewGuid(), DateTime.UtcNow, new Recipient("recipientId", new List<IAddressPoint>() { new SmsAddressPoint("999999999") }));
+        await service.CreateNotification(Guid.NewGuid(), DateTime.UtcNow, new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("999999999") }, nationalIdentityNumber: "enduser-nin"));
 
         // Assert
         repoMock.Verify(r => r.AddNotification(It.IsAny<SmsNotification>(), It.IsAny<DateTime>()), Times.Once);
@@ -64,7 +64,10 @@ public class SmsNotificationServiceTests
             Id = id,
             OrderId = orderId,
             RequestedSendTime = requestedSendTime,
-            RecipientNumber = "+4799999999",
+            Recipient = new()
+            {
+                MobileNumber = "+4799999999"
+            },
             SendResult = new(SmsNotificationResultType.New, dateTimeOutput),
         };
 

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsOrderProcessingServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsOrderProcessingServiceTests.cs
@@ -89,8 +89,8 @@ public class SmsOrderProcessingServiceTests
             Recipients = new List<Recipient>()
             {
                 new Recipient(),
-                new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") },  nationalIdentityNumber: "enduser-nin"),
-                new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") },  organisationNumber: "skd-orgNo"),
+                new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") }, nationalIdentityNumber: "enduser-nin"),
+                new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") }, organisationNumber: "skd-orgNo"),
                 new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4749999999") })
             }
         };

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsOrderProcessingServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsOrderProcessingServiceTests.cs
@@ -41,7 +41,7 @@ public class SmsOrderProcessingServiceTests
 
         var serviceMock = new Mock<ISmsNotificationService>();
         serviceMock.Setup(s => s.CreateNotification(It.IsAny<Guid>(), It.Is<DateTime>(d => d.Equals(requested)), It.Is<Recipient>(r => AssertUtils.AreEquivalent(expectedRecipient, r))));
-               
+
         var service = GetTestService(smsService: serviceMock.Object);
 
         // Act
@@ -90,6 +90,7 @@ public class SmsOrderProcessingServiceTests
             {
                 new Recipient(),
                 new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") },  nationalIdentityNumber: "enduser-nin"),
+                new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") },  organisationNumber: "skd-orgNo"),
                 new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4749999999") })
             }
         };
@@ -98,7 +99,12 @@ public class SmsOrderProcessingServiceTests
         serviceMock.Setup(s => s.CreateNotification(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<Recipient>()));
 
         var smsRepoMock = new Mock<ISmsNotificationRepository>();
-        smsRepoMock.Setup(e => e.GetRecipients(It.IsAny<Guid>())).ReturnsAsync(new List<SmsRecipient>() { new SmsRecipient() { NationalIdentityNumber = "enduser-nin", MobileNumber = "+4799999999" } });
+        smsRepoMock.Setup(e => e.GetRecipients(It.IsAny<Guid>())).ReturnsAsync(
+            new List<SmsRecipient>()
+            {
+                new SmsRecipient() { NationalIdentityNumber = "enduser-nin", MobileNumber = "+4799999999" },
+                new SmsRecipient() { OrganisationNumber = "skd-orgNo", MobileNumber = "+4799999999" }
+            });
 
         var service = GetTestService(smsRepo: smsRepoMock.Object, smsService: serviceMock.Object);
 

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsOrderProcessingServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsOrderProcessingServiceTests.cs
@@ -33,11 +33,11 @@ public class SmsOrderProcessingServiceTests
             RequestedSendTime = requested,
             Recipients = new List<Recipient>()
             {
-                new Recipient("end-user", new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") })
+                new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") }, nationalIdentityNumber: "enduser-nin")
             }
         };
 
-        Recipient expectedRecipient = new("end-user", new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") });
+        Recipient expectedRecipient = new(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") }, nationalIdentityNumber: "enduser-nin");
 
         var serviceMock = new Mock<ISmsNotificationService>();
         serviceMock.Setup(s => s.CreateNotification(It.IsAny<Guid>(), It.Is<DateTime>(d => d.Equals(requested)), It.Is<Recipient>(r => AssertUtils.AreEquivalent(expectedRecipient, r))));
@@ -89,7 +89,7 @@ public class SmsOrderProcessingServiceTests
             Recipients = new List<Recipient>()
             {
                 new Recipient(),
-                new Recipient("end-user", new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") }),
+                new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") },  nationalIdentityNumber: "enduser-nin"),
                 new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4749999999") })
             }
         };
@@ -98,7 +98,7 @@ public class SmsOrderProcessingServiceTests
         serviceMock.Setup(s => s.CreateNotification(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<Recipient>()));
 
         var smsRepoMock = new Mock<ISmsNotificationRepository>();
-        smsRepoMock.Setup(e => e.GetRecipients(It.IsAny<Guid>())).ReturnsAsync(new List<SmsRecipient>() { new SmsRecipient() { RecipientId = "end-user", MobileNumber = "+4799999999" } });
+        smsRepoMock.Setup(e => e.GetRecipients(It.IsAny<Guid>())).ReturnsAsync(new List<SmsRecipient>() { new SmsRecipient() { NationalIdentityNumber = "enduser-nin", MobileNumber = "+4799999999" } });
 
         var service = GetTestService(smsRepo: smsRepoMock.Object, smsService: serviceMock.Object);
 

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/EmailNotificationSummaryMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/EmailNotificationSummaryMapperTests.cs
@@ -37,6 +37,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingMappers
                 Succeeded = false,
                 Recipient = new()
                 {
+                    NationalIdentityNumber = "16069412345",
                     EmailAddress = "recipient@domain.com"
                 },
                 SendStatus = new()
@@ -80,6 +81,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingMappers
                 Succeeded = true,
                 Recipient = new()
                 {
+                    OrganisationNumber = "12345678910",
                     EmailAddress = "recipient@domain.com"
                 },
                 SendStatus = new()

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/EmailNotificationSummaryMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/EmailNotificationSummaryMapperTests.cs
@@ -52,7 +52,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingMappers
                 false,
                 new EmailRecipient()
                 {
-                    RecipientId = "12345678910",
+                    NationalIdentityNumber = "16069412345",
                     ToAddress = "recipient@domain.com"
                 },
                 new NotificationResult<EmailNotificationResultType>(
@@ -95,7 +95,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingMappers
                 true,
                 new EmailRecipient()
                 {
-                    RecipientId = "12345678910",
+                    OrganisationNumber = "12345678910",
                     ToAddress = "recipient@domain.com"
                 },
                 new NotificationResult<EmailNotificationResultType>(

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -84,7 +84,7 @@ public class OrderMapperTests
         // Arrange 
         Recipient input = new()
         {
-            RecipientId = "16069412345",
+            NationalIdentityNumber = "nationalidentitynumber",
             AddressInfo = new List<IAddressPoint>()
             {
                 new EmailAddressPoint("input@domain.com"),

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -84,7 +84,7 @@ public class OrderMapperTests
         // Arrange 
         Recipient input = new()
         {
-            NationalIdentityNumber = "nationalidentitynumber",
+            NationalIdentityNumber = "16069412345",
             AddressInfo = new List<IAddressPoint>()
             {
                 new EmailAddressPoint("input@domain.com"),
@@ -94,6 +94,7 @@ public class OrderMapperTests
 
         RecipientExt expected = new()
         {
+            NationalIdentityNumber = "16069412345",
             EmailAddress = "input@domain.com",
             MobileNumber = "+4740000001"
         };

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/SmsNotificationSummaryMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/SmsNotificationSummaryMapperTests.cs
@@ -52,7 +52,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingMappers
                 false,
                 new SmsRecipient()
                 {
-                    RecipientId = "12345678910",
+                    OrganisationNumber = "12345678910",
                     MobileNumber = "+4799999999"
                 },
                 new NotificationResult<SmsNotificationResultType>(
@@ -95,7 +95,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingMappers
                 true,
                 new SmsRecipient()
                 {
-                    RecipientId = "12345678910",
+                    NationalIdentityNumber = "16069412345",
                     MobileNumber = "+4799999999"
                 },
                 new NotificationResult<SmsNotificationResultType>(

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/SmsNotificationSummaryMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/SmsNotificationSummaryMapperTests.cs
@@ -37,6 +37,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingMappers
                 Succeeded = false,
                 Recipient = new()
                 {
+                    OrganisationNumber = "12345678910",
                     MobileNumber = "+4799999999"
                 },
                 SendStatus = new()
@@ -80,6 +81,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingMappers
                 Succeeded = true,
                 Recipient = new()
                 {
+                    NationalIdentityNumber = "16069412345",
                     MobileNumber = "+4799999999"
                 },
                 SendStatus = new()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Database: 
- RecipientId column removed from notification tables and all procedures/funcs mentioning it
- OrganisationNumber and NationalIdentityNumber included in notifications tables and functions
- Service and repository logic updated to reflect model changes. 

- API: orgNo or nationalIdentity number in orderRequest is ignored for now.
## Related Issue(s)
- #436 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
