### PR TITLE
Support for registering email delivery report result

### DIFF
--- a/src/Altinn.Notifications.Core/Enums/EmailNotificationResultType.cs
+++ b/src/Altinn.Notifications.Core/Enums/EmailNotificationResultType.cs
@@ -51,5 +51,20 @@ public enum EmailNotificationResultType
     /// <remarks>
     /// Should not be used externally or persisted in db.
     /// Only used for processing and logic in service layer.</remarks>
-    Failed_TransientError
+    Failed_TransientError,
+
+    /// <summary>
+    /// Failed, bounced
+    /// </summary>
+    Failed_Bounced,
+
+    /// <summary>
+    /// Failed, filtered spam
+    /// </summary>
+    Failed_FilteredSpam,
+
+    /// <summary>
+    /// Failed, quarantined
+    /// </summary>
+    Failed_Quarantined
 }

--- a/src/Altinn.Notifications.Core/Models/Notification/EmailSendOperationResult.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/EmailSendOperationResult.cs
@@ -12,7 +12,7 @@ public class EmailSendOperationResult
     /// <summary>
     /// The notification id
     /// </summary>
-    public Guid NotificationId { get; set; }
+    public Guid? NotificationId { get; set; }
 
     /// <summary>
     /// The send operation id

--- a/src/Altinn.Notifications.Core/Persistence/IEmailNotificationRepository.cs
+++ b/src/Altinn.Notifications.Core/Persistence/IEmailNotificationRepository.cs
@@ -24,7 +24,7 @@ public interface IEmailNotificationRepository
     /// <summary>
     /// Sets result status of an email notification and update operation id
     /// </summary>
-    public Task UpdateSendStatus(Guid notificationId, EmailNotificationResultType status, string? operationId = null);
+    public Task UpdateSendStatus(Guid? notificationId, EmailNotificationResultType status, string? operationId = null);
 
     /// <summary>
     /// Retrieves all processed email recipients for an order

--- a/src/Altinn.Notifications.Core/Services/EmailNotificationSummaryService.cs
+++ b/src/Altinn.Notifications.Core/Services/EmailNotificationSummaryService.cs
@@ -22,7 +22,10 @@ namespace Altinn.Notifications.Core.Services
                 { EmailNotificationResultType.Failed_RecipientNotIdentified, "The email was not sent because the recipient's email address was not found." },
                 { EmailNotificationResultType.Failed_InvalidEmailFormat, "The email was not sent because the recipient’s email address is in an invalid format." },
                 { EmailNotificationResultType.Failed_SupressedRecipient, "The email was not sent because the recipient’s email address is suppressed by the third party email service." },
-                { EmailNotificationResultType.Failed_TransientError, "The email was not sent due to a transient error. We will retry sending the email." }
+                { EmailNotificationResultType.Failed_TransientError, "The email was not sent due to a transient error. We will retry sending the email." },
+                { EmailNotificationResultType.Failed_Bounced, "The email hard bounced, which may have happened because the email address does not exist or the domain is invalid." },
+                { EmailNotificationResultType.Failed_FilteredSpam, "The email was was identified as spam, and was rejected or blocked (not quarantined)." },
+                { EmailNotificationResultType.Failed_Quarantined, "The email was quarantined (as spam, bulk mail, or phising)." }
             };
 
         private readonly static List<EmailNotificationResultType> _successResults = new()

--- a/src/Altinn.Notifications.Persistence/Migration/v0.28/01-alter-types.sql
+++ b/src/Altinn.Notifications.Persistence/Migration/v0.28/01-alter-types.sql
@@ -1,0 +1,18 @@
+ALTER TYPE public.emailnotificationresulttype ADD VALUE IF NOT EXISTS 'Delivered';
+ALTER TYPE public.emailnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_InvalidEmailFormat';
+ALTER TYPE public.emailnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_SupressedRecipient';
+ALTER TYPE public.emailnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_TransientError';
+ALTER TYPE public.emailnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_Bounced';
+ALTER TYPE public.emailnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_FilteredSpam';
+ALTER TYPE public.emailnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_Quarantined';
+
+
+
+ALTER TYPE public.smsnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_InvalidRecipient';
+ALTER TYPE public.smsnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_RecipientReserved';
+ALTER TYPE public.smsnotificationresulttype ADD VALUE IF NOT EXISTS 'Delivered';
+ALTER TYPE public.smsnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_BarredReceiver';
+ALTER TYPE public.smsnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_Deleted';
+ALTER TYPE public.smsnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_Expired';
+ALTER TYPE public.smsnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_Undelivered';
+ALTER TYPE public.smsnotificationresulttype ADD VALUE IF NOT EXISTS 'Failed_Rejected';

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/EmailNotificationRepositoryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/EmailNotificationRepositoryTests.cs
@@ -1,0 +1,226 @@
+﻿using Altinn.Notifications.Core.Enums;
+using Altinn.Notifications.Core.Models;
+using Altinn.Notifications.Core.Models.Notification;
+using Altinn.Notifications.Core.Models.Orders;
+using Altinn.Notifications.Core.Models.Recipients;
+using Altinn.Notifications.Core.Persistence;
+using Altinn.Notifications.IntegrationTests.Utils;
+using Altinn.Notifications.Persistence.Repository;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Altinn.Notifications.IntegrationTests.Notifications.Persistence;
+
+public class EmailNotificationRepositoryTests : IAsyncLifetime
+{
+    private readonly List<Guid> _orderIdsToDelete;
+
+    public EmailNotificationRepositoryTests()
+    {
+        _orderIdsToDelete = [];
+    }
+
+    public async Task InitializeAsync()
+    {
+        await Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        string deleteSql = $@"DELETE from notifications.orders o where o.alternateid in ('{string.Join("','", _orderIdsToDelete)}')";
+        await PostgreUtil.RunSql(deleteSql);
+    }
+
+    [Fact]
+    public async Task AddNotification()
+    {
+        // Arrange
+        Guid orderId = await PostgreUtil.PopulateDBWithEmailOrderAndReturnId();
+        _orderIdsToDelete.Add(orderId);
+
+        // Arrange
+        EmailNotificationRepository repo = (EmailNotificationRepository)ServiceUtil
+            .GetServices(new List<Type>() { typeof(IEmailNotificationRepository) })
+            .First(i => i.GetType() == typeof(EmailNotificationRepository));
+
+        Guid notificationId = Guid.NewGuid();
+        EmailNotification emailNotification = new()
+        {
+            Id = notificationId,
+            OrderId = orderId,
+            RequestedSendTime = DateTime.UtcNow,
+            Recipient = new()
+            {
+                NationalIdentityNumber = "16069412345",
+                ToAddress = "test@email.com"
+            }
+        };
+
+        await repo.AddNotification(emailNotification, DateTime.UtcNow);
+
+        // Assert
+        string sql = $@"SELECT count(1) 
+              FROM notifications.emailnotifications o
+              WHERE o.alternateid = '{notificationId}'";
+
+        int actualCount = await PostgreUtil.RunSqlReturnOutput<int>(sql);
+
+        Assert.Equal(1, actualCount);
+    }
+
+    [Fact]
+    public async Task GetNewNotifications()
+    {
+        // Arrange
+        (NotificationOrder order, EmailNotification emailNotification) = await PostgreUtil.PopulateDBWithOrderAndEmailNotification();
+        _orderIdsToDelete.Add(order.Id);
+
+        EmailNotificationRepository repo = (EmailNotificationRepository)ServiceUtil
+          .GetServices(new List<Type>() { typeof(IEmailNotificationRepository) })
+          .First(i => i.GetType() == typeof(EmailNotificationRepository));
+
+        // Act
+        List<Email> emailToBeSent = await repo.GetNewNotifications();
+
+        // Assert
+        Assert.NotEmpty(emailToBeSent.Where(s => s.NotificationId == emailNotification.Id));
+    }
+
+    [Fact]
+    public async Task GetRecipients()
+    {
+        // Arrange
+        EmailNotificationRepository repo = (EmailNotificationRepository)ServiceUtil
+           .GetServices(new List<Type>() { typeof(IEmailNotificationRepository) })
+           .First(i => i.GetType() == typeof(EmailNotificationRepository));
+
+        (NotificationOrder order, EmailNotification emailNotification) = await PostgreUtil.PopulateDBWithOrderAndEmailNotification();
+        _orderIdsToDelete.Add(order.Id);
+        EmailRecipient expectedRecipient = emailNotification.Recipient;
+
+        // Act
+        List<EmailRecipient> actual = await repo.GetRecipients(order.Id);
+
+        EmailRecipient actualRecipient = actual[0];
+
+        // Assert
+        Assert.Single(actual);
+        Assert.Equal(expectedRecipient.ToAddress, actualRecipient.ToAddress);
+        Assert.Equal(expectedRecipient.NationalIdentityNumber, actualRecipient.NationalIdentityNumber);
+        Assert.Equal(expectedRecipient.OrganisationNumber, actualRecipient.OrganisationNumber);
+    }
+
+    [Fact]
+    public async Task UpdateSendStatus_WithNotificationId_WithGatewayRef()
+    {
+        // Arrange
+        (NotificationOrder order, EmailNotification emailNotification) = await PostgreUtil.PopulateDBWithOrderAndEmailNotification();
+        _orderIdsToDelete.Add(order.Id);
+
+        EmailNotificationRepository repo = (EmailNotificationRepository)ServiceUtil
+          .GetServices(new List<Type>() { typeof(IEmailNotificationRepository) })
+          .First(i => i.GetType() == typeof(EmailNotificationRepository));
+
+        string operationId = Guid.NewGuid().ToString();
+
+        // Act
+        await repo.UpdateSendStatus(emailNotification.Id, EmailNotificationResultType.Succeeded, operationId);
+
+        // Assert
+        string sql = $@"SELECT count(1) 
+              FROM notifications.emailnotifications email
+              WHERE email.alternateid = '{emailNotification.Id}' 
+              AND email.result  = '{EmailNotificationResultType.Succeeded}' 
+              AND email.operationid = '{operationId}'";
+
+        int actualCount = await PostgreUtil.RunSqlReturnOutput<int>(sql);
+
+        Assert.Equal(1, actualCount);
+    }
+
+    [Fact]
+    public async Task UpdateSendStatus_WithoutNotificationId_WithGatewayRef()
+    {
+        // Arrange
+        (NotificationOrder order, EmailNotification emailNotification) = await PostgreUtil.PopulateDBWithOrderAndEmailNotification();
+        _orderIdsToDelete.Add(order.Id);
+
+        EmailNotificationRepository repo = (EmailNotificationRepository)ServiceUtil
+          .GetServices(new List<Type>() { typeof(IEmailNotificationRepository) })
+          .First(i => i.GetType() == typeof(EmailNotificationRepository));
+
+        string operationId = Guid.NewGuid().ToString();
+
+        string setGateqwaySql = $@"Update notifications.emailnotifications 
+                SET operationid = '{operationId}'
+                WHERE alternateid = '{emailNotification.Id}'";
+
+        await PostgreUtil.RunSql(setGateqwaySql);
+
+        // Act
+        await repo.UpdateSendStatus(null, EmailNotificationResultType.Succeeded, operationId);
+
+        // Assert
+        string sql = $@"SELECT count(1) 
+              FROM notifications.emailnotifications email
+              WHERE email.alternateid = '{emailNotification.Id}'
+              AND email.result = '{EmailNotificationResultType.Succeeded}'
+              AND email.operationid = '{operationId}'";
+
+        int actualCount = await PostgreUtil.RunSqlReturnOutput<int>(sql);
+
+        Assert.Equal(1, actualCount);
+    }
+
+    [Fact]
+    public async Task UpdateSendStatus_WithNotificationId_WithoutGatewayRef()
+    {
+        // Arrange
+        (NotificationOrder order, EmailNotification emailNotification) = await PostgreUtil.PopulateDBWithOrderAndEmailNotification();
+        _orderIdsToDelete.Add(order.Id);
+
+        EmailNotificationRepository repo = (EmailNotificationRepository)ServiceUtil
+          .GetServices(new List<Type>() { typeof(IEmailNotificationRepository) })
+          .First(i => i.GetType() == typeof(EmailNotificationRepository));
+
+        // Act
+        await repo.UpdateSendStatus(emailNotification.Id, EmailNotificationResultType.Failed);
+
+        // Assert
+        string sql = $@"SELECT count(1) 
+              FROM notifications.emailnotifications email
+              WHERE email.alternateid = '{emailNotification.Id}' 
+              AND email.result  = '{EmailNotificationResultType.Failed}'";
+
+        int actualCount = await PostgreUtil.RunSqlReturnOutput<int>(sql);
+
+        Assert.Equal(1, actualCount);
+    }
+
+    [Fact]
+    public async Task SetEmailResult_AllEnumValuesExistInDb()
+    {
+        // Arrange
+        (NotificationOrder order, EmailNotification emailNotification) = await PostgreUtil.PopulateDBWithOrderAndEmailNotification();
+        _orderIdsToDelete.Add(order.Id);
+
+        // Act & Assert
+        foreach (EmailNotificationResultType resultType in Enum.GetValues(typeof(EmailNotificationResultType)))
+        {
+            try
+            {
+                string sql = $@"
+                UPDATE notifications.emailnotifications 
+                SET result = '{resultType}'
+                WHERE alternateid = '{emailNotification.Id}';";
+
+                await PostgreUtil.RunSql(sql);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Exception thrown for EmailNotificationResultType: {resultType}. Exception: {ex.Message}");
+            }
+        }
+    }
+}

--- a/test/Altinn.Notifications.IntegrationTests/Utils/PostgreUtil.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Utils/PostgreUtil.cs
@@ -16,6 +16,12 @@ public static class PostgreUtil
         return order.Id;
     }
 
+    public static async Task<Guid> PopulateDBWithSmsOrderAndReturnId(string? sendersReference = null)
+    {
+        var order = await PopulateDBWithSmsOrder(sendersReference);
+        return order.Id;
+    }
+
     public static async Task<NotificationOrder> PopulateDBWithEmailOrder(string? sendersReference = null)
     {
         var serviceList = ServiceUtil.GetServices(new List<Type>() { typeof(IOrderRepository) });

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailNotificationSummaryServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailNotificationSummaryServiceTests.cs
@@ -31,6 +31,9 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices
         [InlineData(EmailNotificationResultType.Failed, "The email was not sent due to an unspecified failure.")]
         [InlineData(EmailNotificationResultType.Failed_RecipientNotIdentified, "The email was not sent because the recipient's email address was not found.")]
         [InlineData(EmailNotificationResultType.Failed_InvalidEmailFormat, "The email was not sent because the recipient’s email address is in an invalid format.")]
+        [InlineData(EmailNotificationResultType.Failed_Bounced, "The email hard bounced, which may have happened because the email address does not exist or the domain is invalid.")]
+        [InlineData(EmailNotificationResultType.Failed_FilteredSpam, "The email was was identified as spam, and was rejected or blocked (not quarantined).")]
+        [InlineData(EmailNotificationResultType.Failed_Quarantined, "The email was quarantined (as spam, bulk mail, or phising).")]
         public void GetResultDescription_ExpectedDescription(EmailNotificationResultType result, string expected)
         {
             string actual = EmailNotificationSummaryService.GetResultDescription(result);
@@ -64,7 +67,7 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices
 
             // Act 
             EmailNotificationSummaryService.ProcessNotificationResults(summary);
-            
+
             // Assert
             Assert.Equal(1, summary.Generated);
             Assert.Equal(1, summary.Succeeded);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Updated db enum to reflect values for send result for email and sms
- Fixed repository logic to update send result for email with/without notification id and operationid
- Added integration tests 

## Related Issue(s)
- #281

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
