### PR TITLE
check on id or operationId defined

### DIFF
--- a/src/Altinn.Notifications.Core/Models/Notification/EmailSendOperationResult.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/EmailSendOperationResult.cs
@@ -59,7 +59,7 @@ public class EmailSendOperationResult
             parsedOutput = Deserialize(input!);
 
             value = parsedOutput!;
-            return value.NotificationId != Guid.Empty;
+            return value.NotificationId != Guid.Empty || !string.IsNullOrEmpty(value.OperationId);
         }
         catch
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bug fix for deserialization of email send operation result. Notification id optional, so should check on multiple properties
