### PR TITLE
#439 only persist national identity number on notification

### DIFF
--- a/src/Altinn.Notifications.Core/Models/Recipient.cs
+++ b/src/Altinn.Notifications.Core/Models/Recipient.cs
@@ -41,18 +41,18 @@ public class Recipient
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="Recipient"/> class.
+    /// </summary>
+    public Recipient()
+    {
+    }
+
+    /// <summary>
     /// Creates a deep copy of the recipient object
     /// </summary>
     internal Recipient DeepCopy()
     {
         string json = JsonSerializer.Serialize(this);
-        return JsonSerializer.Deserialize<Recipient>(json);
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Recipient"/> class.
-    /// </summary>
-    public Recipient()
-    {
+        return JsonSerializer.Deserialize<Recipient>(json)!;
     }
 }

--- a/src/Altinn.Notifications.Core/Models/Recipient.cs
+++ b/src/Altinn.Notifications.Core/Models/Recipient.cs
@@ -1,4 +1,7 @@
-﻿using Altinn.Notifications.Core.Models.Address;
+﻿using System.Runtime.Serialization.Formatters.Binary;
+using System.Text.Json;
+
+using Altinn.Notifications.Core.Models.Address;
 
 namespace Altinn.Notifications.Core.Models;
 
@@ -35,6 +38,15 @@ public class Recipient
         OrganisationNumber = organisationNumber;
         NationalIdentityNumber = nationalIdentityNumber;
         AddressInfo = addressInfo;
+    }
+
+    /// <summary>
+    /// Creates a deep copy of the recipient object
+    /// </summary>
+    internal Recipient DeepCopy()
+    {
+        string json = JsonSerializer.Serialize(this);
+        return JsonSerializer.Deserialize<Recipient>(json);
     }
 
     /// <summary>

--- a/src/Altinn.Notifications.Core/Models/Recipient.cs
+++ b/src/Altinn.Notifications.Core/Models/Recipient.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.Serialization.Formatters.Binary;
-using System.Text.Json;
+﻿using System.Text.Json;
 
 using Altinn.Notifications.Core.Models.Address;
 

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -47,7 +47,9 @@ public class OrderRequestService : IOrderRequestService
         Guid orderId = _guid.NewGuid();
         DateTime created = _dateTime.UtcNow();
 
-        var lookupResult = await GetRecipientLookupResult(orderRequest.Recipients, orderRequest.NotificationChannel);
+        // copying recipients by value to not alter the orderRequest that will be persisted
+        var copiedRecipents = orderRequest.Recipients.Select(r => r.DeepCopy()).ToList();
+        var lookupResult = await GetRecipientLookupResult(copiedRecipents, orderRequest.NotificationChannel);
 
         if (lookupResult?.Status == RecipientLookupStatus.Failed)
         {

--- a/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
@@ -51,7 +51,7 @@ public class EmailNotificationRepository : IEmailNotificationRepository
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notification.OrderId);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notification.Id);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, (object)DBNull.Value); // recipientorgno
-        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, (object)DBNull.Value); // recipientnin
+        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.Recipient.NationalIdentityNumber ?? (object)DBNull.Value);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.Recipient.ToAddress);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.SendResult.Result.ToString());
         pgcom.Parameters.AddWithValue(NpgsqlDbType.TimestampTz, notification.SendResult.ResultTime);

--- a/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
@@ -52,7 +52,7 @@ public class SmsNotificationRepository : ISmsNotificationRepository
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notification.OrderId);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notification.Id);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, (object)DBNull.Value); // recipientorgno
-        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, (object)DBNull.Value); // recipientnin
+        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.Recipient.NationalIdentityNumber ?? (object)DBNull.Value); 
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.Recipient.MobileNumber);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.SendResult.Result.ToString());
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Integer, smsCount);

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/RecipientTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/RecipientTests.cs
@@ -1,0 +1,29 @@
+﻿using Altinn.Notifications.Core.Models;
+using Altinn.Notifications.Core.Models.Address;
+
+using Xunit;
+
+namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
+{
+    public class RecipientTests
+    {
+        [Fact]
+        public void DeepCopy_ReturnsNewInstance_ObjectsAreEquivalent()
+        {
+            // Arrange
+            var recipient = new Recipient()
+            {
+                NationalIdentityNumber = "16069412345",
+                IsReserved = true,
+                AddressInfo = [new SmsAddressPoint("+4781549300"), new EmailAddressPoint("test@digdir.no")]
+            };
+
+            // Act
+            var result = recipient.DeepCopy();
+
+            // Assert
+            Assert.NotSame(recipient, result);
+            Assert.Equivalent(recipient, result);
+        }
+    }
+}

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -262,8 +262,8 @@ public class OrderRequestServiceTests
             NotificationChannel = NotificationChannel.Sms,
             RequestedSendTime = sendTime,
             Recipients = [
-                new Recipient() { NationalIdentityNumber = "16069412345", IsReserved = false, AddressInfo = [new SmsAddressPoint("+4799999999")] },
-                new Recipient() { NationalIdentityNumber = "14029112345", IsReserved = true }
+                new Recipient() { NationalIdentityNumber = "16069412345" },
+                new Recipient() { NationalIdentityNumber = "14029112345" }
                 ],
             Templates = { new SmsTemplate { Body = "sms-body", SenderNumber = "TestDefaultSmsSenderNumberNumber" } }
         };
@@ -334,7 +334,7 @@ public class OrderRequestServiceTests
             NotificationChannel = NotificationChannel.Sms,
             RequestedSendTime = sendTime,
             Recipients = [
-                new Recipient() { NationalIdentityNumber = "16069412345", IsReserved = false, AddressInfo = [new SmsAddressPoint("+4799999999")] },
+                new Recipient() { NationalIdentityNumber = "16069412345" },
                 ],
             Templates = { new SmsTemplate { Body = "sms-body", SenderNumber = "TestDefaultSmsSenderNumberNumber" } }
         };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fixed bug where national identity number is persisted in db on the generated notification
- Changed implementation to ensure that intial lookup of contact details & reservation is not persisted to the notification order in db. 


### Consideration: 

Merging this PR will result in reservation status being made available for TE in order request response, and through orders/{id}/notifications/sms endpoint. 

  - The orders/{id} returns original order without reserve status or contact details. Should this endpoint rather check if notifications have been generated and merge the original order with the recipient data we used when actually sending the notification? How would this look for an org, where a single order recipient results in multiple notification recipients? 


## Related Issue(s)
- #439