### PR TITLE
added builder classes for notification order models

### DIFF
--- a/src/Altinn.Notifications.Core/Models/Orders/NotificationOrder.cs
+++ b/src/Altinn.Notifications.Core/Models/Orders/NotificationOrder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 
 using Altinn.Notifications.Core.Enums;
 using Altinn.Notifications.Core.Models.NotificationTemplate;
@@ -8,68 +9,44 @@ namespace Altinn.Notifications.Core.Models.Orders;
 /// <summary>
 /// Class representing a notification order
 /// </summary>
-public class NotificationOrder : IBaseNotificationOrder
+public partial class NotificationOrder : IBaseNotificationOrder
 {
     /// <inheritdoc/>>
-    public Guid Id { get; internal set; } = Guid.Empty;
+    public Guid Id { get; init; } = Guid.Empty;
 
     /// <inheritdoc/>>
-    public string? SendersReference { get; internal set; }
+    public string? SendersReference { get; init; }
 
     /// <inheritdoc/>>
-    public DateTime RequestedSendTime { get; internal set; }
+    public DateTime RequestedSendTime { get; init; }
 
     /// <inheritdoc/>>
-    public NotificationChannel NotificationChannel { get; internal set; }
-
-    /// <inheritdoc/>>    
-    public bool IgnoreReservation { get; internal set; }
+    public NotificationChannel NotificationChannel { get; init; }
 
     /// <inheritdoc/>>
-    public Creator Creator { get; internal set; }
+    public bool IgnoreReservation { get; init; }
 
     /// <inheritdoc/>>
-    public DateTime Created { get; internal set; }
+    public Creator Creator { get; init; }
+
+    /// <inheritdoc/>>
+    public DateTime Created { get; init; }
 
     /// <summary>
     /// Gets the templates to create notifications based of
     /// </summary>
-    public List<INotificationTemplate> Templates { get; internal set; } = new List<INotificationTemplate>();
+    public List<INotificationTemplate> Templates { get; init; } = new List<INotificationTemplate>();
 
     /// <summary>
     /// Gets a list of recipients
     /// </summary>
-    public List<Recipient> Recipients { get; internal set; } = new List<Recipient>();
+    public List<Recipient> Recipients { get; init; } = new List<Recipient>();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NotificationOrder"/> class.
     /// </summary>
-    public NotificationOrder(
-        Guid id,
-        string? sendersReference,
-        List<INotificationTemplate> templates,
-        DateTime requestedSendTime,
-        NotificationChannel notificationChannel,
-        Creator creator,
-        DateTime created,
-        List<Recipient> recipients,
-        bool ignoreReservation)
-    {
-        Id = id;
-        SendersReference = sendersReference;
-        Templates = templates;
-        RequestedSendTime = requestedSendTime;
-        NotificationChannel = notificationChannel;
-        Creator = creator;
-        Created = created;
-        Recipients = recipients;
-        IgnoreReservation = ignoreReservation;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="NotificationOrder"/> class.
-    /// </summary>
-    internal NotificationOrder()
+    [JsonConstructor]
+    private NotificationOrder()
     {
         Creator = new Creator(string.Empty);
     }
@@ -116,5 +93,13 @@ public class NotificationOrder : IBaseNotificationOrder
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Static method to get the builder
+    /// </summary>
+    public static NotificationOrderBuilder GetBuilder()
+    {
+        return new NotificationOrderBuilder();
     }
 }

--- a/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderBuilder.cs
+++ b/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderBuilder.cs
@@ -177,7 +177,6 @@ namespace Altinn.Notifications.Core.Models.Orders
 
                 return order;
             }
-
         }
     }
 }

--- a/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderBuilder.cs
+++ b/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderBuilder.cs
@@ -1,0 +1,183 @@
+﻿using Altinn.Notifications.Core.Enums;
+using Altinn.Notifications.Core.Models.NotificationTemplate;
+
+namespace Altinn.Notifications.Core.Models.Orders
+{
+    /// <summary>
+    /// Partial class implementation containing the builder logic
+    /// </summary>
+    public partial class NotificationOrder
+    {
+        /// <summary>
+        /// Builder for the <see cref="NotificationOrder"/> object
+        /// </summary>
+        public class NotificationOrderBuilder
+        {
+            /// <summary>
+            /// Boolean indicating whether the id has been set.
+            /// </summary> 
+            internal bool IdSet { get; private set; }
+
+            /// <summary>
+            /// Boolean indicating whether the requested send time has been set.
+            /// </summary>
+            internal bool RequestedSendTimeSet { get; private set; }
+
+            /// <summary>
+            /// Boolean indicating whether the notification channel has been set.
+            /// </summary>
+            internal bool NotificationChannelSet { get; private set; }
+
+            /// <summary>
+            /// Boolean indicating whether the creator has been set.
+            /// </summary>
+            internal bool CreatorSet { get; private set; }
+
+            /// <summary>
+            /// Boolean indicating whether the created date has been set.
+            /// </summary>
+            internal bool CreatedSet { get; private set; }
+
+            /// <summary>
+            /// Boolean indicating whether the templates have been set.
+            /// </summary>
+            internal bool TemplatesSet { get; private set; }
+
+            /// <summary>
+            /// Boolean indicating whether the recipients have been set.
+            /// </summary>
+            internal bool RecipientsSet { get; private set; }
+
+            private Guid _id;
+            private string? _sendersReference;
+            private DateTime _requestedSendTime;
+            private NotificationChannel _notificationChannel;
+            private bool _ignoreReservation;
+            private Creator? _creator;
+            private DateTime _created;
+            private List<INotificationTemplate>? _templates;
+            private List<Recipient>? _recipients;
+
+            /// <summary>
+            /// Sets the Id of the NotificationOrder.
+            /// </summary>
+            public NotificationOrderBuilder SetId(Guid id)
+            {
+                _id = id;
+                IdSet = true;
+                return this;
+            }
+
+            /// <summary>
+            /// Sets the SendersReference of the NotificationOrder.
+            /// </summary>
+            public NotificationOrderBuilder SetSendersReference(string? sendersReference)
+            {
+                _sendersReference = sendersReference;
+                return this;
+            }
+
+            /// <summary>
+            /// Sets the RequestedSendTime of the NotificationOrder.
+            /// </summary>
+            public NotificationOrderBuilder SetRequestedSendTime(DateTime requestedSendTime)
+            {
+                _requestedSendTime = requestedSendTime;
+                RequestedSendTimeSet = true;
+                return this;
+            }
+
+            /// <summary>
+            /// Sets the NotificationChannel of the NotificationOrder.
+            /// </summary>
+            public NotificationOrderBuilder SetNotificationChannel(NotificationChannel notificationChannel)
+            {
+                _notificationChannel = notificationChannel;
+                NotificationChannelSet = true;
+                return this;
+            }
+
+            /// <summary>
+            /// Sets the IgnoreReservation of the NotificationOrder.
+            /// </summary>
+            public NotificationOrderBuilder SetIgnoreReservation(bool ignoreReservation)
+            {
+                _ignoreReservation = ignoreReservation;
+                return this;
+            }
+
+            /// <summary>
+            /// Sets the Creator of the NotificationOrder.
+            /// </summary>
+            public NotificationOrderBuilder SetCreator(Creator creator)
+            {
+                _creator = creator;
+                CreatorSet = true;
+                return this;
+            }
+
+            /// <summary>
+            /// Sets the Created date of the NotificationOrder.
+            /// </summary>
+            public NotificationOrderBuilder SetCreated(DateTime created)
+            {
+                _created = created;
+                CreatedSet = true;
+                return this;
+            }
+
+            /// <summary>
+            /// Sets the Templates of the NotificationOrder.
+            /// </summary>
+            public NotificationOrderBuilder SetTemplates(List<INotificationTemplate> templates)
+            {
+                _templates = templates;
+                TemplatesSet = true;
+                return this;
+            }
+
+            /// <summary>
+            /// Sets the Recipients of the NotificationOrder.
+            /// </summary>
+            public NotificationOrderBuilder SetRecipients(List<Recipient> recipients)
+            {
+                _recipients = recipients;
+                RecipientsSet = true;
+                return this;
+            }
+
+            /// <summary>
+            /// Constructs a new <see cref="NotificationOrder"/> object
+            /// </summary>
+            public NotificationOrder Build()
+            {
+                if (!IdSet ||
+                    !RequestedSendTimeSet ||
+                    !NotificationChannelSet ||
+                    !CreatorSet ||
+                    !CreatedSet ||
+                    !TemplatesSet ||
+                    !RecipientsSet)
+                {
+                    throw new ArgumentException("Not all required properties are set for the notification order.");
+                }
+
+                var order = new NotificationOrder()
+                {
+                    Id = _id,
+                    SendersReference = _sendersReference,
+                    RequestedSendTime = _requestedSendTime,
+                    NotificationChannel = _notificationChannel,
+                    IgnoreReservation = _ignoreReservation,
+                    Creator = _creator!,
+                    Created = _created,
+                    Templates = _templates!,
+                    Recipients = _recipients!
+                };
+
+                return order;
+            }
+
+        }
+    }
+}

--- a/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderRequest.cs
+++ b/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderRequest.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Enums;
+﻿using System.Text.Json.Serialization;
+
+using Altinn.Notifications.Core.Enums;
 using Altinn.Notifications.Core.Models.NotificationTemplate;
 
 namespace Altinn.Notifications.Core.Models.Orders;
@@ -46,31 +48,19 @@ public class NotificationOrderRequest
     /// <summary>
     /// Initializes a new instance of the <see cref="NotificationOrderRequest"/> class.
     /// </summary>
-    public NotificationOrderRequest(
-        string? sendersReference, 
-        string creatorShortName, 
-        List<INotificationTemplate> templates, 
-        DateTime requestedSendTime, 
-        NotificationChannel notificationChannel,
-        List<Recipient> recipients,
-        bool ignoreReservation = false)
-    {
-        SendersReference = sendersReference;
-        Creator = new(creatorShortName);
-        Templates = templates;
-        RequestedSendTime = requestedSendTime;
-        NotificationChannel = notificationChannel;
-        Recipients = recipients;
-        IgnoreReservation = ignoreReservation;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="NotificationOrderRequest"/> class.
-    /// </summary>
+    [JsonConstructor]
     internal NotificationOrderRequest()
     {
         Creator = new Creator(string.Empty);
         Templates = new List<INotificationTemplate>();
         Recipients = new List<Recipient>();
+    }
+
+    /// <summary>
+    /// Static method to get the builder
+    /// </summary>
+    public static NotificationOrderRequestBuilder GetBuilder()
+    {
+        return new NotificationOrderRequestBuilder();
     }
 }

--- a/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderRequestBuilder.cs
+++ b/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderRequestBuilder.cs
@@ -1,0 +1,130 @@
+﻿using Altinn.Notifications.Core.Enums;
+using Altinn.Notifications.Core.Models.NotificationTemplate;
+
+namespace Altinn.Notifications.Core.Models.Orders
+{
+    /// <summary>
+    /// Builder for the <see cref="NotificationOrderRequest"/> object
+    /// </summary>
+    public class NotificationOrderRequestBuilder
+    {
+        private string? _sendersReference;
+        private bool _sendersReferenceSet;
+
+        private List<INotificationTemplate>? _templates;
+        private bool _templatesSet;
+
+        private DateTime _requestedSendTime;
+        private bool _requestedSendTimeSet;
+
+        private NotificationChannel _notificationChannel;
+        private bool _notificationChannelSet;
+
+        private List<Recipient>? _recipients;
+        private bool _recipientsSet;
+
+        private Creator? _creator;
+        private bool _creatorSet;
+
+        private bool _ignoreReservation;
+        private bool _ignoreReservationSet;
+
+        /// <summary>
+        /// Sets the senders reference
+        /// </summary>
+        public NotificationOrderRequestBuilder SetSendersReference(string? value)
+        {
+            _sendersReference = value;
+            _sendersReferenceSet = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the notification templates
+        /// </summary>
+        public NotificationOrderRequestBuilder SetTemplates(List<INotificationTemplate> value)
+        {
+            _templates = value;
+            _templatesSet = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the requested send time
+        /// </summary>
+        public NotificationOrderRequestBuilder SetRequestedSendTime(DateTime value)
+        {
+            _requestedSendTime = value;
+            _requestedSendTimeSet = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the notification channel
+        /// </summary>
+        public NotificationOrderRequestBuilder SetNotificationChannel(NotificationChannel value)
+        {
+            _notificationChannel = value;
+            _notificationChannelSet = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the recipients
+        /// </summary>
+        public NotificationOrderRequestBuilder SetRecipients(List<Recipient> value)
+        {
+            _recipients = value;
+            _recipientsSet = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the creator
+        /// </summary>
+        public NotificationOrderRequestBuilder SetCreator(string value)
+        {
+            _creator = new(value);
+            _creatorSet = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the ignore reservations
+        /// </summary>
+        public NotificationOrderRequestBuilder SetIgnoreReservation(bool value)
+        {
+            _ignoreReservation = value;
+            _ignoreReservationSet = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="NotificationOrderRequest"/> object
+        /// </summary>
+        public NotificationOrderRequest Build()
+        {
+            if (!_sendersReferenceSet ||
+                !_templatesSet ||
+                !_requestedSendTimeSet ||
+                !_notificationChannelSet ||
+                !_recipientsSet ||
+                !_creatorSet ||
+                !_ignoreReservationSet)
+            {
+                throw new ArgumentException("Not all required properties are set.");
+            }
+
+            return new NotificationOrderRequest()
+            {
+                SendersReference = _sendersReference,
+                Creator = _creator!,
+                Templates = _templates!,
+                RequestedSendTime = _requestedSendTime,
+                NotificationChannel = _notificationChannel,
+                Recipients = _recipients!,
+                IgnoreReservation = _ignoreReservation,
+            };
+        }
+    }
+}

--- a/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderWithStatus.cs
+++ b/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderWithStatus.cs
@@ -43,20 +43,7 @@ public class NotificationOrderWithStatus : IBaseNotificationOrder
     /// <summary>
     /// Initializes a new instance of the <see cref="NotificationOrderWithStatus"/> class.
     /// </summary>
-    public NotificationOrderWithStatus(Guid id, string? sendersReference, DateTime requestedSendTime, Creator creator, DateTime created, NotificationChannel notificationChannel, ProcessingStatus processingStatus)
-    {
-        Id = id;
-        SendersReference = sendersReference;
-        RequestedSendTime = requestedSendTime;
-        Creator = creator;
-        Created = created;
-        NotificationChannel = notificationChannel;
-        ProcessingStatus = processingStatus;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="NotificationOrderWithStatus"/> class.
-    /// </summary>
+    [JsonConstructor]
     internal NotificationOrderWithStatus()
     {
     }
@@ -67,6 +54,14 @@ public class NotificationOrderWithStatus : IBaseNotificationOrder
     public void SetNotificationStatuses(NotificationTemplateType type, int generated, int succeeded)
     {
         NotificationStatuses.Add(type, new NotificationStatus() { Generated = generated, Succeeded = succeeded });
+    }
+
+    /// <summary>
+    /// Static method to get the builder
+    /// </summary>
+    public static NotificationOrderWithStatusBuilder GetBuilder()
+    {
+        return new NotificationOrderWithStatusBuilder();
     }
 }
 

--- a/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderWithStatusBuilder.cs
+++ b/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderWithStatusBuilder.cs
@@ -10,8 +10,6 @@ public class NotificationOrderWithStatusBuilder
     private Guid _id;
     private bool _idSet;
 
-    private string? _sendersReference;
-
     private DateTime _requestedSendTime;
     private bool _requestedSendTimeSet;
 
@@ -24,10 +22,12 @@ public class NotificationOrderWithStatusBuilder
     private NotificationChannel _notificationChannel;
     private bool _notificationChannelSet;
 
-    private bool _ignoreReservation;
-
     private ProcessingStatus? _processingStatus;
     private bool _processingStatusSet;
+
+    private string? _sendersReference;
+
+    private bool _ignoreReservation;
 
     /// <summary>
     /// Sets the id

--- a/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderWithStatusBuilder.cs
+++ b/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderWithStatusBuilder.cs
@@ -1,0 +1,139 @@
+using Altinn.Notifications.Core.Enums;
+
+namespace Altinn.Notifications.Core.Models.Orders;
+
+/// <summary>
+/// Builder for the <see cref="NotificationOrderWithStatus"/> object
+/// </summary>
+public class NotificationOrderWithStatusBuilder
+{
+    private Guid _id;
+    private bool _idSet;
+
+    private string? _sendersReference;
+
+    private DateTime _requestedSendTime;
+    private bool _requestedSendTimeSet;
+
+    private Creator? _creator;
+    private bool _creatorSet;
+
+    private DateTime _created;
+    private bool _createdSet;
+
+    private NotificationChannel _notificationChannel;
+    private bool _notificationChannelSet;
+
+    private bool _ignoreReservation;
+
+    private ProcessingStatus? _processingStatus;
+    private bool _processingStatusSet;
+
+    /// <summary>
+    /// Sets the id
+    /// </summary>
+    public NotificationOrderWithStatusBuilder SetId(Guid id)
+    {
+        _id = id;
+        _idSet = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the senders reference
+    /// </summary>
+    public NotificationOrderWithStatusBuilder SetSendersReference(string sendersReference)
+    {
+        _sendersReference = sendersReference;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the requested send time
+    /// </summary>
+    public NotificationOrderWithStatusBuilder SetRequestedSendTime(DateTime requestedSendTime)
+    {
+        _requestedSendTime = requestedSendTime;
+        _requestedSendTimeSet = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the creator
+    /// </summary>
+    public NotificationOrderWithStatusBuilder SetCreator(string creatorName)
+    {
+        _creator = new(creatorName);
+        _creatorSet = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the created date tim
+    /// </summary>
+    public NotificationOrderWithStatusBuilder SetCreated(DateTime created)
+    {
+        _created = created;
+        _createdSet = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Sts the notificaiton channel
+    /// </summary>
+    public NotificationOrderWithStatusBuilder SetNotificationChannel(NotificationChannel notificationChannel)
+    {
+        _notificationChannel = notificationChannel;
+        _notificationChannelSet = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the ignore reservation
+    /// </summary>
+    public NotificationOrderWithStatusBuilder SetIgnoreReservation(bool ignoreReservation)
+    {
+        _ignoreReservation = ignoreReservation;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the processing status
+    /// </summary>
+    public NotificationOrderWithStatusBuilder SetProcessingStatus(ProcessingStatus processingStatus)
+    {
+        _processingStatus = processingStatus;
+        _processingStatusSet = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Constructs a new <see cref="NotificationOrderWithStatus"/> object
+    /// </summary>
+    public NotificationOrderWithStatus Build()
+    {
+        if (!_idSet ||
+            !_requestedSendTimeSet ||
+            !_creatorSet ||
+            !_createdSet ||
+            !_notificationChannelSet ||
+            !_processingStatusSet)
+        {
+            throw new ArgumentException("Not all required properties are set.");
+        }
+
+        var order = new NotificationOrderWithStatus()
+        {
+            Id = _id,
+            SendersReference = _sendersReference,
+            RequestedSendTime = _requestedSendTime,
+            Creator = _creator!,
+            Created = _created,
+            NotificationChannel = _notificationChannel,
+            IgnoreReservation = _ignoreReservation,
+            ProcessingStatus = _processingStatus!,
+        };
+
+        return order;
+    }
+}

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -53,16 +53,18 @@ public class OrderRequestService : IOrderRequestService
 
         var templates = SetSenderIfNotDefined(orderRequest.Templates);
 
-        var order = new NotificationOrder(
-            orderId,
-            orderRequest.SendersReference,
-            templates,
-            orderRequest.RequestedSendTime,
-            orderRequest.NotificationChannel,
-            orderRequest.Creator,
-            created,
-            orderRequest.Recipients, 
-            orderRequest.IgnoreReservation);
+        var order = NotificationOrder
+            .GetBuilder()
+            .SetId(orderId)
+            .SetSendersReference(orderRequest.SendersReference)
+            .SetTemplates(templates)
+            .SetRequestedSendTime(orderRequest.RequestedSendTime)
+            .SetNotificationChannel(orderRequest.NotificationChannel)
+            .SetCreator(orderRequest.Creator)
+            .SetCreated(created)
+            .SetRecipients(orderRequest.Recipients)
+            .SetIgnoreReservation(orderRequest.IgnoreReservation)
+            .Build();
 
         NotificationOrder savedOrder = await _repository.Create(order);
 
@@ -104,7 +106,7 @@ public class OrderRequestService : IOrderRequestService
         }
 
         var isReserved = recipients.Where(r => r.IsReserved.HasValue && r.IsReserved.Value).Select(r => r.NationalIdentityNumber!).ToList();
-            
+
         RecipientLookupResult lookupResult = new()
         {
             IsReserved = isReserved,

--- a/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
@@ -160,16 +160,19 @@ public class OrderRepository : IOrderRepository
         {
             while (await reader.ReadAsync())
             {
-                order = new(
-                    reader.GetValue<Guid>("alternateid"),
-                    reader.GetValue<string>("sendersreference"),
-                    reader.GetValue<DateTime>("requestedsendtime"), // all decimals are not included
-                    new Creator(reader.GetValue<string>("creatorname")),
-                    reader.GetValue<DateTime>("created"),
-                    reader.GetValue<NotificationChannel>("notificationchannel"),
-                    new ProcessingStatus(
-                        reader.GetValue<OrderProcessingStatus>("processedstatus"),
-                        reader.GetValue<DateTime>("processed")));
+                order = NotificationOrderWithStatus
+                    .GetBuilder()
+                    .SetId(reader.GetValue<Guid>("alternateid"))
+                    .SetSendersReference(reader.GetValue<string>("sendersreference"))
+                    .SetRequestedSendTime(reader.GetValue<DateTime>("requestedsendtime")) // all decimals are not included
+                    .SetCreator(reader.GetValue<string>("creatorname"))
+                    .SetCreated(reader.GetValue<DateTime>("created"))
+                    .SetNotificationChannel(reader.GetValue<NotificationChannel>("notificationchannel"))
+                    .SetProcessingStatus(
+                        new ProcessingStatus(
+                            reader.GetValue<OrderProcessingStatus>("processedstatus"),
+                            reader.GetValue<DateTime>("processed")))
+                    .Build();
 
                 int generatedEmail = (int)reader.GetValue<long>("generatedEmailCount");
                 int succeededEmail = (int)reader.GetValue<long>("succeededEmailCount");

--- a/src/Altinn.Notifications/Mappers/OrderMapper.cs
+++ b/src/Altinn.Notifications/Mappers/OrderMapper.cs
@@ -35,14 +35,16 @@ public static class OrderMapper
             })
             .ToList();
 
-        return new NotificationOrderRequest(
-            extRequest.SendersReference,
-            creator,
-            [emailTemplate],
-            extRequest.RequestedSendTime.ToUniversalTime(),
-            NotificationChannel.Email,
-            recipients,
-            extRequest.IgnoreReservation);
+        return NotificationOrderRequest
+            .GetBuilder()
+            .SetSendersReference(extRequest.SendersReference)
+            .SetCreator(creator)
+            .SetTemplates([emailTemplate])
+            .SetRequestedSendTime(extRequest.RequestedSendTime.ToUniversalTime())
+            .SetNotificationChannel(NotificationChannel.Email)
+            .SetRecipients(recipients)
+            .SetIgnoreReservation(extRequest.IgnoreReservation)
+            .Build();
     }
 
     /// <summary>
@@ -67,14 +69,16 @@ public static class OrderMapper
           })
           .ToList();
 
-        return new NotificationOrderRequest(
-            extRequest.SendersReference,
-            creator,
-            [smsTemplate],
-            extRequest.RequestedSendTime.ToUniversalTime(),
-            NotificationChannel.Sms,
-            recipients,
-            extRequest.IgnoreReservation);
+        return NotificationOrderRequest
+          .GetBuilder()
+          .SetSendersReference(extRequest.SendersReference)
+          .SetCreator(creator)
+          .SetTemplates([smsTemplate])
+          .SetRequestedSendTime(extRequest.RequestedSendTime.ToUniversalTime())
+          .SetNotificationChannel(NotificationChannel.Sms)
+          .SetRecipients(recipients)
+          .SetIgnoreReservation(extRequest.IgnoreReservation)
+          .Build();
     }
 
     /// <summary>

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/OrderRepositoryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/OrderRepositoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using Altinn.Notifications.Core.Enums;
+using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.NotificationTemplate;
 using Altinn.Notifications.Core.Models.Orders;
 using Altinn.Notifications.Core.Persistence;
@@ -37,17 +38,10 @@ namespace Altinn.Notifications.IntegrationTests.Notifications.Persistence
                 .GetServices(new List<Type>() { typeof(IOrderRepository) })
                 .First(i => i.GetType() == typeof(OrderRepository));
 
-            NotificationOrder order = new()
-            {
-                Id = Guid.NewGuid(),
-                Created = DateTime.UtcNow,
-                Creator = new("test"),
-                Templates = new List<INotificationTemplate>()
-                {
-                    new SmsTemplate("Altinn", "This is the body")
-                },
-                RequestedSendTime = DateTime.UtcNow
-            };
+            NotificationOrder order = TestdataUtil.GetOrderForTest(
+                NotificationOrder
+                   .GetBuilder()
+                   .SetTemplates([new SmsTemplate("Altinn", "This is the body")]));
 
             _orderIdsToDelete.Add(order.Id);
 
@@ -73,16 +67,10 @@ namespace Altinn.Notifications.IntegrationTests.Notifications.Persistence
                 .GetServices(new List<Type>() { typeof(IOrderRepository) })
                 .First(i => i.GetType() == typeof(OrderRepository));
 
-            NotificationOrder order = new()
-            {
-                Id = Guid.NewGuid(),
-                Created = DateTime.UtcNow,
-                Creator = new("test"),
-                Templates = new List<INotificationTemplate>()
-                {
-                    new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)
-                }
-            };
+            NotificationOrder order = TestdataUtil.GetOrderForTest(
+                NotificationOrder
+                 .GetBuilder()
+                 .SetTemplates([new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)]));
 
             _orderIdsToDelete.Add(order.Id);
 
@@ -108,17 +96,14 @@ namespace Altinn.Notifications.IntegrationTests.Notifications.Persistence
                 .GetServices(new List<Type>() { typeof(IOrderRepository) })
                 .First(i => i.GetType() == typeof(OrderRepository));
 
-            NotificationOrder order = new()
-            {
-                Id = Guid.NewGuid(),
-                Created = DateTime.UtcNow,
-                Creator = new("test"),
-                Templates = new List<INotificationTemplate>()
-                {
+            NotificationOrder order = TestdataUtil.GetOrderForTest(
+                NotificationOrder
+                 .GetBuilder()
+                 .SetTemplates(
+                 [
                     new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain),
-                    new SmsTemplate("Altinn", "This is the body")
-                }
-            };
+                     new SmsTemplate("Altinn", "This is the body")
+                 ]));
 
             _orderIdsToDelete.Add(order.Id);
 

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/OrdersController/OrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/OrdersController/OrdersControllerTests.cs
@@ -36,25 +36,30 @@ public class OrdersControllerTests : IClassFixture<IntegrationTestWebApplication
     {
         _factory = factory;
 
-        _order = new(
-            Guid.NewGuid(),
-            "senders-reference",
-            new List<INotificationTemplate>(),
-            DateTime.UtcNow,
-            NotificationChannel.Email,
-            new Creator("ttd"),
-            DateTime.UtcNow,
-            new List<Recipient>(),
-            false);
+        _order = NotificationOrder
+           .GetBuilder()
+           .SetId(Guid.NewGuid())
+           .SetSendersReference("senders-reference")
+           .SetRequestedSendTime(DateTime.UtcNow)
+           .SetNotificationChannel(NotificationChannel.Email)
+           .SetIgnoreReservation(false)
+           .SetCreator(new Creator("ttd"))
+           .SetCreated(DateTime.UtcNow)
+           .SetTemplates([])
+           .SetRecipients([])
+           .Build();
 
-        _orderWithStatus = new(
-            Guid.NewGuid(),
-            "senders-reference",
-            DateTime.UtcNow,
-            new Creator("ttd"),
-            DateTime.UtcNow,
-            NotificationChannel.Email,
-            new ProcessingStatus());
+        _orderWithStatus = NotificationOrderWithStatus
+                            .GetBuilder()
+                            .SetId(Guid.NewGuid())
+                            .SetSendersReference("senders-reference")
+                            .SetRequestedSendTime(DateTime.UtcNow)
+                            .SetCreator("ttd")
+                            .SetCreated(DateTime.UtcNow)
+                            .SetNotificationChannel(NotificationChannel.Email)
+                            .SetIgnoreReservation(false)
+                            .SetProcessingStatus(new ProcessingStatus())
+                            .Build();
     }
 
     [Fact]

--- a/test/Altinn.Notifications.IntegrationTests/Utils/PostgreUtil.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Utils/PostgreUtil.cs
@@ -26,13 +26,7 @@ public static class PostgreUtil
     {
         var serviceList = ServiceUtil.GetServices(new List<Type>() { typeof(IOrderRepository) });
         OrderRepository repository = (OrderRepository)serviceList.First(i => i.GetType() == typeof(OrderRepository));
-        var order = TestdataUtil.NotificationOrder_EmailTemplate_OneRecipient();
-        order.Id = Guid.NewGuid();
-
-        if (sendersReference != null)
-        {
-            order.SendersReference = sendersReference;
-        }
+        var order = TestdataUtil.NotificationOrder_EmailTemplate_OneRecipient(sendersReference);
 
         var persistedOrder = await repository.Create(order);
         return persistedOrder;
@@ -42,13 +36,7 @@ public static class PostgreUtil
     {
         var serviceList = ServiceUtil.GetServices(new List<Type>() { typeof(IOrderRepository) });
         OrderRepository repository = (OrderRepository)serviceList.First(i => i.GetType() == typeof(OrderRepository));
-        var order = TestdataUtil.NotificationOrder_SmsTemplate_OneRecipient();
-        order.Id = Guid.NewGuid();
-
-        if (sendersReference != null)
-        {
-            order.SendersReference = sendersReference;
-        }
+        var order = TestdataUtil.NotificationOrder_SmsTemplate_OneRecipient(sendersReference);
 
         var persistedOrder = await repository.Create(order);
         return persistedOrder;
@@ -57,16 +45,11 @@ public static class PostgreUtil
     public static async Task<(NotificationOrder Order, EmailNotification EmailNotification)>
         PopulateDBWithOrderAndEmailNotification(string? sendersReference = null)
     {
-        (NotificationOrder o, EmailNotification e) = TestdataUtil.GetOrderAndEmailNotification();
+        (NotificationOrder o, EmailNotification e) = TestdataUtil.GetOrderAndEmailNotification(sendersReference);
         var serviceList = ServiceUtil.GetServices(new List<Type>() { typeof(IOrderRepository), typeof(IEmailNotificationRepository) });
 
         OrderRepository orderRepo = (OrderRepository)serviceList.First(i => i.GetType() == typeof(OrderRepository));
         EmailNotificationRepository notificationRepo = (EmailNotificationRepository)serviceList.First(i => i.GetType() == typeof(EmailNotificationRepository));
-
-        if (sendersReference != null)
-        {
-            o.SendersReference = sendersReference;
-        }
 
         await orderRepo.Create(o);
         await notificationRepo.AddNotification(e, DateTime.UtcNow.AddDays(1));
@@ -76,16 +59,11 @@ public static class PostgreUtil
 
     public static async Task<NotificationOrder> PopulateDBWithOrderAndEmailNotificationReturnOrder(string? sendersReference = null)
     {
-        (NotificationOrder o, EmailNotification e) = TestdataUtil.GetOrderAndEmailNotification();
+        (NotificationOrder o, EmailNotification e) = TestdataUtil.GetOrderAndEmailNotification(sendersReference);
         var serviceList = ServiceUtil.GetServices(new List<Type>() { typeof(IOrderRepository), typeof(IEmailNotificationRepository) });
 
         OrderRepository orderRepo = (OrderRepository)serviceList.First(i => i.GetType() == typeof(OrderRepository));
         EmailNotificationRepository notificationRepo = (EmailNotificationRepository)serviceList.First(i => i.GetType() == typeof(EmailNotificationRepository));
-
-        if (sendersReference != null)
-        {
-            o.SendersReference = sendersReference;
-        }
 
         await orderRepo.Create(o);
         await notificationRepo.AddNotification(e, DateTime.UtcNow.AddDays(1));
@@ -95,16 +73,11 @@ public static class PostgreUtil
 
     public static async Task<(NotificationOrder Order, SmsNotification SmsNotification)> PopulateDBWithOrderAndSmsNotification(string? sendersReference = null)
     {
-        (NotificationOrder order, SmsNotification smsNotification) = TestdataUtil.GetOrderAndSmsNotification();
+        (NotificationOrder order, SmsNotification smsNotification) = TestdataUtil.GetOrderAndSmsNotification(sendersReference);
         var serviceList = ServiceUtil.GetServices(new List<Type>() { typeof(IOrderRepository), typeof(ISmsNotificationRepository) });
 
         OrderRepository orderRepo = (OrderRepository)serviceList.First(i => i.GetType() == typeof(OrderRepository));
         SmsNotificationRepository notificationRepo = (SmsNotificationRepository)serviceList.First(i => i.GetType() == typeof(SmsNotificationRepository));
-
-        if (sendersReference != null)
-        {
-            order.SendersReference = sendersReference;
-        }
 
         await orderRepo.Create(order);
         await notificationRepo.AddNotification(smsNotification, DateTime.UtcNow.AddDays(1), 1);

--- a/test/Altinn.Notifications.IntegrationTests/Utils/TestdataUtil.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Utils/TestdataUtil.cs
@@ -5,14 +5,15 @@ using Altinn.Notifications.Core.Models.Notification;
 using Altinn.Notifications.Core.Models.NotificationTemplate;
 using Altinn.Notifications.Core.Models.Orders;
 
+using static Altinn.Notifications.Core.Models.Orders.NotificationOrder;
+
 namespace Altinn.Notifications.IntegrationTests.Utils;
 
 public static class TestdataUtil
 {
-    public static (NotificationOrder Order, SmsNotification Notification) GetOrderAndSmsNotification()
+    public static (NotificationOrder Order, SmsNotification Notification) GetOrderAndSmsNotification(string? sendersReference)
     {
-        NotificationOrder order = NotificationOrder_SmsTemplate_OneRecipient();
-        order.Id = Guid.NewGuid();
+        NotificationOrder order = NotificationOrder_SmsTemplate_OneRecipient(sendersReference);
         var recipient = order.Recipients[0];
         SmsAddressPoint? addressPoint = recipient.AddressInfo.Find(a => a.AddressType == AddressType.Sms) as SmsAddressPoint;
 
@@ -31,10 +32,9 @@ public static class TestdataUtil
         return (order, smsNotification);
     }
 
-    public static (NotificationOrder Order, EmailNotification Notification) GetOrderAndEmailNotification()
+    public static (NotificationOrder Order, EmailNotification Notification) GetOrderAndEmailNotification(string? sendersReference)
     {
-        NotificationOrder order = NotificationOrder_EmailTemplate_OneRecipient();
-        order.Id = Guid.NewGuid();
+        NotificationOrder order = NotificationOrder_EmailTemplate_OneRecipient(sendersReference);
         var recipient = order.Recipients[0];
         EmailAddressPoint? addressPoint = recipient.AddressInfo.Find(a => a.AddressType == AddressType.Email) as EmailAddressPoint;
 
@@ -56,78 +56,133 @@ public static class TestdataUtil
     /// <summary>
     /// NOTE! Overwrite id with a new GUID to ensure it is unique in the test scope.
     /// </summary>
-    public static NotificationOrder NotificationOrder_EmailTemplate_OneRecipient()
+    public static NotificationOrder NotificationOrder_EmailTemplate_OneRecipient(string? sendersReference)
     {
-        return new NotificationOrder()
-        {
-            SendersReference = "local-testing",
-            Templates = new List<INotificationTemplate>()
+        return NotificationOrder
+         .GetBuilder()
+         .SetId(Guid.NewGuid())
+         .SetSendersReference(sendersReference)
+         .SetTemplates([
+
+            new EmailTemplate()
             {
-                new EmailTemplate()
-                {
-                    Type = NotificationTemplateType.Email,
-                    FromAddress = "sender@domain.com",
-                    Subject = "email-subject",
-                    Body = "email-body",
-                    ContentType = EmailContentType.Html
-                }
-            },
-            RequestedSendTime = new DateTime(2023, 06, 16, 08, 50, 00, DateTimeKind.Utc),
-            NotificationChannel = NotificationChannel.Email,
-            Creator = new("ttd"),
-            Created = new DateTime(2023, 06, 16, 08, 45, 00, DateTimeKind.Utc),
-            Recipients = new List<Recipient>()
-            {
-                new Recipient()
-                {
-                    AddressInfo = new()
-                    {
-                        new EmailAddressPoint()
-                        {
-                            AddressType = AddressType.Email,
-                            EmailAddress = "recipient1@domain.com"
-                        }
-                    }
-                }
+                Type = NotificationTemplateType.Email,
+                FromAddress = "sender@domain.com",
+                Subject = "email-subject",
+                Body = "email-body",
+                ContentType = EmailContentType.Html
             }
-        };
+         ])
+         .SetRequestedSendTime(new DateTime(2023, 06, 16, 08, 50, 00, DateTimeKind.Utc))
+         .SetNotificationChannel(NotificationChannel.Email)
+         .SetCreator(new Creator("ttd"))
+         .SetCreated(new DateTime(2023, 06, 16, 08, 45, 00, DateTimeKind.Utc))
+         .SetIgnoreReservation(false)
+         .SetRecipients([
+
+            new Recipient()
+            {
+                AddressInfo = [
+
+                    new EmailAddressPoint()
+                    {
+                        AddressType = AddressType.Email,
+                        EmailAddress = "recipient1@domain.com"
+                    }
+                ]
+            }
+         ])
+         .Build();
     }
 
     /// <summary>
     /// NOTE! Overwrite id with a new GUID to ensure it is unique in the test scope.
     /// </summary>
-    public static NotificationOrder NotificationOrder_SmsTemplate_OneRecipient()
+    public static NotificationOrder NotificationOrder_SmsTemplate_OneRecipient(string? sendersReference)
     {
-        return new NotificationOrder()
-        {
-            SendersReference = "local-testing",
-            Templates = new List<INotificationTemplate>()
+        return NotificationOrder
+        .GetBuilder()
+        .SetId(Guid.NewGuid())
+        .SetSendersReference(sendersReference)
+        .SetTemplates(
+        [
+            new SmsTemplate()
             {
-                new SmsTemplate()
-                {
-                    Type = NotificationTemplateType.Sms,
-                    Body = "sms-body",
-                    SenderNumber = "Altinn local test"
-                }
-            },
-            RequestedSendTime = new DateTime(2023, 06, 16, 08, 50, 00, DateTimeKind.Utc),
-            NotificationChannel = NotificationChannel.Sms,
-            Creator = new("ttd"),
-            Created = new DateTime(2023, 06, 16, 08, 45, 00, DateTimeKind.Utc),
-            Recipients = new List<Recipient>()
-            {
-                new Recipient()
-                {
-                    AddressInfo = new()
-                    {
-                        new SmsAddressPoint()
-                        {
-                            AddressType = AddressType.Sms,
-                            MobileNumber = "+4799999999"
-                        }
-                    }
-                }
+                Type = NotificationTemplateType.Sms,
+                Body = "sms-body",
+                SenderNumber = "Altinn local test"
             }
-        };
+        ])
+        .SetRequestedSendTime(new DateTime(2023, 06, 16, 08, 50, 00, DateTimeKind.Utc))
+        .SetNotificationChannel(NotificationChannel.Sms)
+        .SetCreator(new Creator("ttd"))
+        .SetCreated(new DateTime(2023, 06, 16, 08, 45, 00, DateTimeKind.Utc))
+        .SetIgnoreReservation(false)
+        .SetRecipients(
+        [
+            new Recipient()
+            {
+                AddressInfo = [
+
+                    new SmsAddressPoint()
+                    {
+                        AddressType = AddressType.Sms,
+                        MobileNumber = "+4799999999"
+                    }
+                ]
+            }
+        ])
+        .Build();
+    }
+
+    /// <summary>
+    /// Generates a notification order using the default value for each missing property. 
+    /// </summary>
+    public static NotificationOrder GetOrderForTest(NotificationOrderBuilder builder)
+    {
+        if (!builder.IdSet)
+        {
+            builder.SetId(Guid.NewGuid());
+        }
+
+        if (!builder.RequestedSendTimeSet)
+        {
+            builder.SetRequestedSendTime(DateTime.UtcNow);
+        }
+
+        if (!builder.NotificationChannelSet)
+        {
+            builder.SetNotificationChannel(NotificationChannel.Email);
+        }
+
+        if (!builder.CreatorSet)
+        {
+            builder.SetCreator(new Creator("ttd"));
+        }
+
+        if (!builder.CreatedSet)
+        {
+            builder.SetCreated(DateTime.UtcNow);
+        }
+
+        if (!builder.TemplatesSet)
+        {
+            builder.SetTemplates(new List<INotificationTemplate>());
+        }
+
+        if (!builder.RecipientsSet)
+        {
+            builder.SetRecipients(new List<Recipient>());
+        }
+
+        return builder.Build();
+    }
+
+    /// <summary>
+    /// Generates a notification order using the default value for all properties 
+    /// </summary>
+    public static NotificationOrder GetOrderForTest()
+    {
+        return GetOrderForTest(GetBuilder());
     }
 }

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/NotificationOrderBuilderTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/NotificationOrderBuilderTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Altinn.Notifications.Core.Enums;
+using Altinn.Notifications.Core.Models;
+using Altinn.Notifications.Core.Models.NotificationTemplate;
+using Altinn.Notifications.Core.Models.Orders;
+
+using Xunit;
+
+namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
+{
+    public class NotificationOrderBuilderTests
+    {
+        [Fact]
+        public void Build_ThrowsExceptionWhenIdIsNotSet()
+        {
+            Assert.Throws<ArgumentException>(() => NotificationOrder.GetBuilder().Build());
+        }
+
+        [Fact]
+        public void Build_NoPropertiesHaveDefaultValues()
+        {
+            var builder = new NotificationOrder.NotificationOrderBuilder();
+            var id = Guid.NewGuid();
+            var sendersReference = "reference";
+            var requestedSendTime = DateTime.UtcNow;
+            var notificationChannel = NotificationChannel.Sms;
+            var ignoreReservation = true;
+            var creator = new Creator("ssb");
+            var created = DateTime.UtcNow;
+            var templates = new List<INotificationTemplate>() { new SmsTemplate("Altinn", "SMS body") };
+            var recipients = new List<Recipient>();
+
+            builder.SetId(id);
+            builder.SetSendersReference(sendersReference);
+            builder.SetRequestedSendTime(requestedSendTime);
+            builder.SetNotificationChannel(notificationChannel);
+            builder.SetIgnoreReservation(ignoreReservation);
+            builder.SetCreator(creator);
+            builder.SetCreated(created);
+            builder.SetTemplates(templates);
+            builder.SetRecipients(recipients);
+
+            var order = builder.Build();
+
+            var properties = typeof(NotificationOrder).GetProperties();
+
+            foreach (var property in properties)
+            {
+                var value = property.GetValue(order);
+                var defaultValue = GetDefault(property.PropertyType);
+
+                Assert.NotEqual(defaultValue, value);
+            }
+        }
+
+        private object? GetDefault(Type type)
+        {
+            if (type.IsValueType)
+            {
+                return Activator.CreateInstance(type);
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/NotificationOrderRequestBuilderTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/NotificationOrderRequestBuilderTests.cs
@@ -10,45 +10,42 @@ using Xunit;
 
 namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
 {
-    public class NotificationOrderBuilderTests
+    public class NotificationOrderRequestBuilderTests
     {
         [Fact]
-        public void Build_ThrowsExceptionWhenIdIsNotSet()
+        public void Build_ThrowsExceptionWhenNotAllPropertiesAreSet()
         {
-            Assert.Throws<ArgumentException>(() => NotificationOrder.GetBuilder().Build());
+            var builder = new NotificationOrderRequestBuilder();
+            Assert.Throws<ArgumentException>(() => builder.Build());
         }
 
         [Fact]
         public void Build_NoPropertiesHaveDefaultValues()
         {
-            var builder = new NotificationOrder.NotificationOrderBuilder();
-            var id = Guid.NewGuid();
+            var builder = new NotificationOrderRequestBuilder();
             var sendersReference = "reference";
             var requestedSendTime = DateTime.UtcNow;
             var notificationChannel = NotificationChannel.Sms;
-            var ignoreReservation = true;
-            var creator = new Creator("ssb");
-            var created = DateTime.UtcNow;
             var templates = new List<INotificationTemplate>() { new SmsTemplate("Altinn", "SMS body") };
             var recipients = new List<Recipient>();
+            var creator = "ssb";
+            var ignoreReservation = true;
 
-            builder.SetId(id);
             builder.SetSendersReference(sendersReference);
             builder.SetRequestedSendTime(requestedSendTime);
             builder.SetNotificationChannel(notificationChannel);
-            builder.SetIgnoreReservation(ignoreReservation);
-            builder.SetCreator(creator);
-            builder.SetCreated(created);
             builder.SetTemplates(templates);
             builder.SetRecipients(recipients);
+            builder.SetCreator(creator);
+            builder.SetIgnoreReservation(ignoreReservation);
 
-            var order = builder.Build();
+            var orderRequest = builder.Build();
 
-            var properties = typeof(NotificationOrder).GetProperties();
+            var properties = typeof(NotificationOrderRequest).GetProperties();
 
             foreach (var property in properties)
             {
-                var value = property.GetValue(order);
+                var value = property.GetValue(orderRequest);
                 var defaultValue = TestdataUtil.GetDefaultValue(property.PropertyType);
 
                 Assert.NotEqual(defaultValue, value);

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/NotificationOrderTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/NotificationOrderTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text.Json.Nodes;
 
 using Altinn.Notifications.Core.Enums;
@@ -23,43 +22,42 @@ public class NotificationOrderTests
     {
         Guid id = Guid.NewGuid();
 
-        _order = new()
-        {
-            Id = id,
-            SendersReference = "senders-reference",
-            Templates = new List<INotificationTemplate>()
-            {
-                 new EmailTemplate()
-                 {
-                     Type = NotificationTemplateType.Email,
-                     FromAddress = "sender@domain.com",
-                     Subject = "email-subject",
-                     Body = "email-body",
-                     ContentType = EmailContentType.Html
-                 }
-            },
-            RequestedSendTime = _requestedSendTime,
-            NotificationChannel = NotificationChannel.Email,
-            IgnoreReservation = false,
-            Creator = new("ttd"),
-            Created = _createdTime,
-            Recipients = new List<Recipient>()
-            {
+        _order = NotificationOrder
+            .GetBuilder()
+            .SetId(id)
+            .SetSendersReference("senders-reference")
+            .SetTemplates(
+            [
+                new EmailTemplate()
+                {
+                    Type = NotificationTemplateType.Email,
+                    FromAddress = "sender@domain.com",
+                    Subject = "email-subject",
+                    Body = "email-body",
+                    ContentType = EmailContentType.Html
+                }
+            ])
+            .SetRequestedSendTime(_requestedSendTime)
+            .SetNotificationChannel(NotificationChannel.Email)
+            .SetIgnoreReservation(false)
+            .SetCreator(new Creator("ttd"))
+            .SetCreated(_createdTime)
+            .SetRecipients([
                 new Recipient()
                 {
                     NationalIdentityNumber = "nationalidentitynumber",
                     IsReserved = false,
-                    AddressInfo = new()
-                    {
+                    AddressInfo =
+                    [
                         new EmailAddressPoint()
                         {
                             AddressType = AddressType.Email,
                             EmailAddress = "recipient1@domain.com"
                         }
-                    }
+                    ]
                 }
-            }
-        };
+            ])
+            .Build();
 
         _serializedOrder = new JsonObject()
         {
@@ -113,7 +111,7 @@ public class NotificationOrderTests
                         }
                     }
                 }
-            }           
+            }
         }.ToJsonString();
     }
 
@@ -141,16 +139,6 @@ public class NotificationOrderTests
 
         // Assert
         Assert.Equal(expected, actual);
-    }
-
-    [Theory]
-    [InlineData(1, "{ \"id\": \"4fec2be9-7f52-4d32-9554-467908c3c629\", \"created\": \"2023-07-14T07:39:19.088978Z\", \"creator\": { \"shortName\": \"ttd\" }, \"requestedSendTime\": \"2023-08-14T08:15:00Z\", \"templates\": [ { \"$\": \"email\", \"body\": \"email-body\", \"type\": \"Email\", \"subject\": \"email-subject\", \"contentType\": \"Html\", \"fromAddress\": \"sender@domain.com\" } ], \"recipients\": [ { \"addressInfo\": [ { \"$\": \"email\", \"addressType\": \"Email\", \"emailAddress\": \"recipient1@domain.com\" } ], \"recipientId\": \"\" }, { \"addressInfo\": [ { \"$\": \"email\", \"addressType\": \"Email\", \"emailAddress\": \"recipient2@domain.com\" } ], \"recipientId\": \"\" } ], \"sendersReference\": \"senders-reference\", \"notificationChannel\": \"Email\" }")]
-#pragma warning disable xUnit1026, IDE0060// Theory methods should use all of their parameters and Remove unused parameter
-    public void Deserialize(int exampleNo, string serializedOrder)
-#pragma warning restore xUnit1026, IDE0060
-    {
-        var actual = NotificationOrder.Deserialize(serializedOrder);
-        Assert.NotNull(actual);
     }
 
     [Fact]

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/NotificationOrderWithStatusBuilderTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/NotificationOrderWithStatusBuilderTests.cs
@@ -10,41 +10,33 @@ using Xunit;
 
 namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
 {
-    public class NotificationOrderBuilderTests
+    public class NotificationOrderWithStatusBuilderTests
     {
-        [Fact]
-        public void Build_ThrowsExceptionWhenIdIsNotSet()
-        {
-            Assert.Throws<ArgumentException>(() => NotificationOrder.GetBuilder().Build());
-        }
-
         [Fact]
         public void Build_NoPropertiesHaveDefaultValues()
         {
-            var builder = new NotificationOrder.NotificationOrderBuilder();
+            var builder = new NotificationOrderWithStatusBuilder();
             var id = Guid.NewGuid();
-            var sendersReference = "reference";
             var requestedSendTime = DateTime.UtcNow;
-            var notificationChannel = NotificationChannel.Sms;
-            var ignoreReservation = true;
-            var creator = new Creator("ssb");
+            var creator = "ssb";
             var created = DateTime.UtcNow;
-            var templates = new List<INotificationTemplate>() { new SmsTemplate("Altinn", "SMS body") };
-            var recipients = new List<Recipient>();
+            var notificationChannel = NotificationChannel.Sms;
+            var processingStatus = new ProcessingStatus { Status = OrderProcessingStatus.Registered };
+            var sendersReference = "reference";
+            var ignoreReservation = true;
 
             builder.SetId(id);
-            builder.SetSendersReference(sendersReference);
             builder.SetRequestedSendTime(requestedSendTime);
-            builder.SetNotificationChannel(notificationChannel);
-            builder.SetIgnoreReservation(ignoreReservation);
             builder.SetCreator(creator);
             builder.SetCreated(created);
-            builder.SetTemplates(templates);
-            builder.SetRecipients(recipients);
+            builder.SetNotificationChannel(notificationChannel);
+            builder.SetProcessingStatus(processingStatus);
+            builder.SetSendersReference(sendersReference);
+            builder.SetIgnoreReservation(ignoreReservation);
 
             var order = builder.Build();
 
-            var properties = typeof(NotificationOrder).GetProperties();
+            var properties = typeof(NotificationOrderWithStatus).GetProperties();
 
             foreach (var property in properties)
             {

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/GetOrderServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/GetOrderServiceTests.cs
@@ -40,10 +40,10 @@ public class GetOrderServiceTests
            async actualOrder => await Task.CompletedTask,
            async actuallError =>
            {
-            await Task.CompletedTask;
-            Assert.NotNull(actuallError);
-            Assert.Equal(404, actuallError.ErrorCode);
-        });
+               await Task.CompletedTask;
+               Assert.NotNull(actuallError);
+               Assert.Equal(404, actuallError.ErrorCode);
+           });
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class GetOrderServiceTests
         var repoMock = new Mock<IOrderRepository>();
         repoMock
             .Setup(r => r.GetOrderById(It.Is<Guid>(g => g == _id), It.Is<string>(s => s.Equals("ttd"))))
-            .ReturnsAsync(new NotificationOrder() { Id = Guid.Parse(_id.ToString()) });
+            .ReturnsAsync(TestdataUtil.GetOrderForTest(NotificationOrder.GetBuilder().SetId(_id)));
 
         var service = GetTestService(repoMock.Object);
 
@@ -110,7 +110,7 @@ public class GetOrderServiceTests
         var repoMock = new Mock<IOrderRepository>();
         repoMock
             .Setup(r => r.GetOrdersBySendersReference(It.Is<string>(s => s.Equals("sendersRef")), It.Is<string>(s => s.Equals("ttd"))))
-            .ReturnsAsync(new List<NotificationOrder>() { new NotificationOrder(), new NotificationOrder(), new NotificationOrder() });
+            .ReturnsAsync(new List<NotificationOrder>() { TestdataUtil.GetOrderForTest(), TestdataUtil.GetOrderForTest(), TestdataUtil.GetOrderForTest() });
 
         var service = GetTestService(repoMock.Object);
 

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderProcessingServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderProcessingServiceTests.cs
@@ -15,8 +15,6 @@ using Moq;
 
 using Xunit;
 
-using static Altinn.Authorization.ABAC.Constants.XacmlConstants;
-
 namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices;
 
 public class OrderProcessingServiceTests
@@ -27,7 +25,7 @@ public class OrderProcessingServiceTests
     public async Task StartProcessingPastDueOrders_ProducerCalledOnceForEachOrder()
     {
         // Arrange 
-        NotificationOrder order = new();
+        NotificationOrder order = TestdataUtil.GetOrderForTest();
 
         var repoMock = new Mock<IOrderRepository>();
         repoMock.Setup(r => r.GetPastDueOrdersAndSetProcessingState())
@@ -50,10 +48,10 @@ public class OrderProcessingServiceTests
     public async Task ProcessOrder_EmailOrder_EmailServiceCalled()
     {
         // Arrange 
-        NotificationOrder order = new()
-        {
-            NotificationChannel = NotificationChannel.Email,
-        };
+        NotificationOrder order = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+             .GetBuilder()
+             .SetNotificationChannel(NotificationChannel.Email));
 
         var emailMockService = new Mock<IEmailOrderProcessingService>();
         emailMockService.Setup(e => e.ProcessOrder(It.IsAny<NotificationOrder>()));
@@ -75,10 +73,10 @@ public class OrderProcessingServiceTests
     public async Task ProcessOrder_SmsOrder_SmsServiceCalled()
     {
         // Arrange 
-        NotificationOrder order = new()
-        {
-            NotificationChannel = NotificationChannel.Sms,
-        };
+        NotificationOrder order = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+              .GetBuilder()
+              .SetNotificationChannel(NotificationChannel.Sms));
 
         var smsMockService = new Mock<ISmsOrderProcessingService>();
         smsMockService.Setup(s => s.ProcessOrder(It.IsAny<NotificationOrder>()));
@@ -100,10 +98,10 @@ public class OrderProcessingServiceTests
     public async Task ProcessOrder_SerivceThrowsException_ProcessingStatusIsNotSet()
     {
         // Arrange 
-        NotificationOrder order = new()
-        {
-            NotificationChannel = NotificationChannel.Sms,
-        };
+        NotificationOrder order = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+                  .GetBuilder()
+                  .SetNotificationChannel(NotificationChannel.Sms));
 
         var smsMockService = new Mock<ISmsOrderProcessingService>();
         smsMockService.Setup(s => s.ProcessOrder(It.IsAny<NotificationOrder>())).Throws(new Exception());
@@ -127,10 +125,10 @@ public class OrderProcessingServiceTests
     public async Task ProcessOrderRetry_SmsOrder_SmsServiceCalled()
     {
         // Arrange 
-        NotificationOrder order = new()
-        {
-            NotificationChannel = NotificationChannel.Sms,
-        };
+        NotificationOrder order = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+                .GetBuilder()
+                .SetNotificationChannel(NotificationChannel.Sms));
 
         var smsMockService = new Mock<ISmsOrderProcessingService>();
         smsMockService.Setup(s => s.ProcessOrderRetry(It.IsAny<NotificationOrder>()));
@@ -152,10 +150,11 @@ public class OrderProcessingServiceTests
     public async Task ProcessOrderRetry_SerivceThrowsException_ProcessingStatusIsNotSet()
     {
         // Arrange 
-        NotificationOrder order = new()
-        {
-            NotificationChannel = NotificationChannel.Sms,
-        };
+        NotificationOrder order = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+                .GetBuilder()
+                .SetId(Guid.NewGuid())
+                .SetNotificationChannel(NotificationChannel.Sms));
 
         var smsMockService = new Mock<ISmsOrderProcessingService>();
         smsMockService.Setup(s => s.ProcessOrderRetry(It.IsAny<NotificationOrder>())).Throws(new Exception());

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -32,17 +32,16 @@ public class OrderRequestServiceTests
         DateTime createdTime = DateTime.UtcNow.AddMinutes(-2);
         Guid id = Guid.NewGuid();
 
-        NotificationOrder expectedRepoInput = new()
-        {
-            Id = id,
-            Created = createdTime,
-            Creator = new("ttd"),
-            NotificationChannel = NotificationChannel.Email,
-            RequestedSendTime = sendTime,
-            Recipients = { },
-            SendersReference = "senders-reference",
-            Templates = { new EmailTemplate { Body = "email-body", FromAddress = "dontreply@skatteetaten.no" } }
-        };
+        NotificationOrder expectedRepoInput = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+                .GetBuilder()
+                .SetId(id)
+                .SetCreated(createdTime)
+                .SetCreator(new Creator("ttd"))
+                .SetNotificationChannel(NotificationChannel.Email)
+                .SetRequestedSendTime(sendTime)
+                .SetSendersReference("senders-reference")
+                .SetTemplates([new EmailTemplate { Body = "email-body", FromAddress = "dontreply@skatteetaten.no" }]));
 
         NotificationOrderRequest input = new()
         {
@@ -79,17 +78,17 @@ public class OrderRequestServiceTests
         DateTime createdTime = DateTime.UtcNow.AddMinutes(-2);
         Guid id = Guid.NewGuid();
 
-        NotificationOrder expectedRepoInput = new()
-        {
-            Id = id,
-            Created = createdTime,
-            Creator = new("ttd"),
-            NotificationChannel = NotificationChannel.Email,
-            RequestedSendTime = sendTime,
-            Recipients = { },
-            SendersReference = "senders-reference",
-            Templates = { new EmailTemplate { Body = "email-body", FromAddress = "noreply@altinn.no" } }
-        };
+        NotificationOrder expectedRepoInput = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+                .GetBuilder()
+                .SetId(id)
+                .SetCreated(createdTime)
+                .SetCreator(new Creator("ttd"))
+                .SetNotificationChannel(NotificationChannel.Email)
+                .SetRequestedSendTime(sendTime)
+                .SetRecipients([])
+                .SetSendersReference("senders-reference")
+                .SetTemplates([new EmailTemplate { Body = "email-body", FromAddress = "noreply@altinn.no" }]));
 
         NotificationOrderRequest input = new()
         {
@@ -126,17 +125,17 @@ public class OrderRequestServiceTests
         DateTime createdTime = DateTime.UtcNow.AddMinutes(-2);
         Guid id = Guid.NewGuid();
 
-        NotificationOrder expectedRepoInput = new()
-        {
-            Id = id,
-            Created = createdTime,
-            Creator = new("ttd"),
-            NotificationChannel = NotificationChannel.Sms,
-            RequestedSendTime = sendTime,
-            Recipients = { },
-            SendersReference = "senders-reference",
-            Templates = { new SmsTemplate { Body = "sms-body", SenderNumber = "Skatteetaten" } }
-        };
+        NotificationOrder expectedRepoInput = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+                .GetBuilder()
+                .SetId(id)
+                .SetCreated(createdTime)
+                .SetCreator(new Creator("ttd"))
+                .SetNotificationChannel(NotificationChannel.Sms)
+                .SetRequestedSendTime(sendTime)
+                .SetRecipients([])
+                .SetSendersReference("senders-reference")
+                .SetTemplates([new SmsTemplate { Body = "sms-body", SenderNumber = "Skatteetaten" }]));
 
         NotificationOrderRequest input = new()
         {
@@ -173,22 +172,20 @@ public class OrderRequestServiceTests
         DateTime createdTime = DateTime.UtcNow.AddMinutes(-2);
         Guid id = Guid.NewGuid();
 
-        NotificationOrder expectedRepoInput = new()
-        {
-            Id = id,
-            Created = createdTime,
-            Creator = new("ttd"),
-            NotificationChannel = NotificationChannel.Sms,
-            RequestedSendTime = sendTime,
-            Recipients = { },
-            SendersReference = "senders-reference",
-            Templates = { new SmsTemplate { Body = "sms-body", SenderNumber = "TestDefaultSmsSenderNumberNumber" } }
-        };
+        NotificationOrder expectedRepoInput = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+             .GetBuilder()
+             .SetId(id)
+             .SetCreated(createdTime)
+             .SetCreator(new Creator("ttd"))
+             .SetNotificationChannel(NotificationChannel.Sms)
+             .SetRequestedSendTime(sendTime)
+             .SetSendersReference("senders-reference")
+             .SetTemplates([new SmsTemplate { Body = "sms-body", SenderNumber = "TestDefaultSmsSenderNumberNumber" }]));
 
         NotificationOrderRequest input = new()
         {
             Creator = new Creator("ttd"),
-
             NotificationChannel = NotificationChannel.Sms,
             Recipients = { },
             SendersReference = "senders-reference",
@@ -254,19 +251,20 @@ public class OrderRequestServiceTests
         DateTime createdTime = DateTime.UtcNow.AddMinutes(-2);
         Guid id = Guid.NewGuid();
 
-        NotificationOrder expectedRepoInput = new()
-        {
-            Id = id,
-            Created = createdTime,
-            Creator = new("ttd"),
-            NotificationChannel = NotificationChannel.Sms,
-            RequestedSendTime = sendTime,
-            Recipients = [
-                new Recipient() { NationalIdentityNumber = "16069412345" },
-                new Recipient() { NationalIdentityNumber = "14029112345" }
-                ],
-            Templates = { new SmsTemplate { Body = "sms-body", SenderNumber = "TestDefaultSmsSenderNumberNumber" } }
-        };
+        NotificationOrder expectedRepoInput = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+                 .GetBuilder()
+                 .SetId(id)
+                 .SetCreated(createdTime)
+                 .SetCreator(new Creator("ttd"))
+                 .SetNotificationChannel(NotificationChannel.Sms)
+                 .SetRequestedSendTime(sendTime)
+                 .SetRecipients(
+                    [
+                        new Recipient() { NationalIdentityNumber = "16069412345" },
+                        new Recipient() { NationalIdentityNumber = "14029112345" }
+                    ])
+                 .SetTemplates([new SmsTemplate { Body = "sms-body", SenderNumber = "TestDefaultSmsSenderNumberNumber" }]));
 
         NotificationOrderRequest input = new()
         {
@@ -317,7 +315,7 @@ public class OrderRequestServiceTests
         repoMock.VerifyAll();
         contactPointMock.VerifyAll();
     }
-    
+
     [Fact]
     public async Task RegisterNotificationOrder_ForSms_LookupSuccess_OrderCreated()
     {
@@ -326,18 +324,16 @@ public class OrderRequestServiceTests
         DateTime createdTime = DateTime.UtcNow.AddMinutes(-2);
         Guid id = Guid.NewGuid();
 
-        NotificationOrder expectedRepoInput = new()
-        {
-            Id = id,
-            Created = createdTime,
-            Creator = new("ttd"),
-            NotificationChannel = NotificationChannel.Sms,
-            RequestedSendTime = sendTime,
-            Recipients = [
-                new Recipient() { NationalIdentityNumber = "16069412345" },
-                ],
-            Templates = { new SmsTemplate { Body = "sms-body", SenderNumber = "TestDefaultSmsSenderNumberNumber" } }
-        };
+        NotificationOrder expectedRepoInput = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+                .GetBuilder()
+                .SetId(id)
+                .SetCreated(createdTime)
+                .SetCreator(new("ttd"))
+                .SetNotificationChannel(NotificationChannel.Sms)
+                .SetRequestedSendTime(sendTime)
+                .SetRecipients([new Recipient() { NationalIdentityNumber = "16069412345" }])
+                .SetTemplates([new SmsTemplate { Body = "sms-body", SenderNumber = "TestDefaultSmsSenderNumberNumber" }]));
 
         NotificationOrderRequest input = new()
         {
@@ -346,7 +342,7 @@ public class OrderRequestServiceTests
             NotificationChannel = NotificationChannel.Sms,
             Recipients = [
                 new Recipient() { NationalIdentityNumber = "16069412345" },
-                ],
+            ],
             RequestedSendTime = sendTime,
             Templates = { new SmsTemplate { Body = "sms-body" } }
         };
@@ -354,23 +350,23 @@ public class OrderRequestServiceTests
         Mock<IOrderRepository> repoMock = new();
         repoMock
             .Setup(r => r.Create(It.IsAny<NotificationOrder>()))
-            .Callback<NotificationOrder>(o => Assert.Equivalent(expectedRepoInput, o))
-            .ReturnsAsync((NotificationOrder order) => order);
+                .Callback<NotificationOrder>(o => Assert.Equivalent(expectedRepoInput, o))
+                .ReturnsAsync((NotificationOrder order) => order);
 
         Mock<IContactPointService> contactPointMock = new();
         contactPointMock
             .Setup(cp => cp.AddSmsContactPoints(It.IsAny<List<Recipient>>()))
-            .Callback<List<Recipient>>(recipients =>
-            {
-                foreach (var recipient in recipients)
+                .Callback<List<Recipient>>(recipients =>
                 {
-                    if (recipient.NationalIdentityNumber == "16069412345")
+                    foreach (var recipient in recipients)
                     {
-                        recipient.AddressInfo.Add(new SmsAddressPoint("+4799999999"));
-                        recipient.IsReserved = false;
+                        if (recipient.NationalIdentityNumber == "16069412345")
+                        {
+                            recipient.AddressInfo.Add(new SmsAddressPoint("+4799999999"));
+                            recipient.IsReserved = false;
+                        }
                     }
-                }
-            });
+                });
 
         var service = GetTestService(repoMock.Object, contactPointMock.Object, id, createdTime);
 

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsOrderProcessingServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsOrderProcessingServiceTests.cs
@@ -29,17 +29,16 @@ public class SmsOrderProcessingServiceTests
         DateTime requested = DateTime.UtcNow;
         Guid orderId = Guid.NewGuid();
 
-        var order = new NotificationOrder()
-        {
-            Id = orderId,
-            NotificationChannel = NotificationChannel.Sms,
-            RequestedSendTime = requested,
-            Recipients = new List<Recipient>()
-            {
-                new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") }, nationalIdentityNumber: "enduser-nin")
-            },
-            Templates = [new SmsTemplate("Altinn", "this is the body")]
-        };
+        var order = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+                .GetBuilder()
+                .SetRequestedSendTime(requested)
+                .SetNotificationChannel(NotificationChannel.Sms)
+                .SetRecipients(new List<Recipient>()
+                    {
+                        new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") }, nationalIdentityNumber: "enduser-nin")
+                    })
+                .SetTemplates([new SmsTemplate("Altinn", "this is the body")]));
 
         Recipient expectedRecipient = new(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") }, nationalIdentityNumber: "enduser-nin");
 
@@ -59,25 +58,25 @@ public class SmsOrderProcessingServiceTests
     public async Task ProcessOrder_NotificationServiceCalledOnceForEachRecipient()
     {
         // Arrange
-        var order = new NotificationOrder()
-        {
-            Id = Guid.NewGuid(),
-            NotificationChannel = NotificationChannel.Sms,
-            Recipients = new List<Recipient>()
-            {
-                new()
-                {
-                OrganizationNumber = "123456",
-                AddressInfo = [new SmsAddressPoint("+4799999999")]
-                },
-                new()
-                {
-                OrganizationNumber = "654321",
-                AddressInfo = [new SmsAddressPoint("+4799999999")]
-                }
-            },
-            Templates = [new SmsTemplate("Altinn", "this is the body")]
-        };
+        var order = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+              .GetBuilder()
+              .SetId(Guid.NewGuid())
+              .SetNotificationChannel(NotificationChannel.Sms)
+              .SetRecipients(new List<Recipient>()
+              {
+                    new()
+                    {
+                    OrganizationNumber = "123456",
+                    AddressInfo = [new SmsAddressPoint("+4799999999")]
+                    },
+                    new()
+                    {
+                    OrganizationNumber = "654321",
+                    AddressInfo = [new SmsAddressPoint("+4799999999")]
+                    }
+              })
+              .SetTemplates([new SmsTemplate("Altinn", "this is the body")]));
 
         var notificationServiceMock = new Mock<ISmsNotificationService>();
         notificationServiceMock.Setup(s => s.CreateNotification(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<Recipient>(), It.IsAny<int>(), It.IsAny<bool>()));
@@ -95,19 +94,19 @@ public class SmsOrderProcessingServiceTests
     public async Task ProcessOrder_RecipientMissingMobileNumber_ContactPointServiceCalled()
     {
         // Arrange
-        var order = new NotificationOrder()
-        {
-            Id = Guid.NewGuid(),
-            NotificationChannel = NotificationChannel.Sms,
-            Recipients = new List<Recipient>()
-            {
-                new()
+        var order = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+                .GetBuilder()
+                .SetId(Guid.NewGuid())
+                .SetNotificationChannel(NotificationChannel.Sms)
+                .SetRecipients(new List<Recipient>()
                 {
-                NationalIdentityNumber = "123456",
-                }
-            },
-            Templates = [new SmsTemplate("Altinn", "this is the body")]
-        };
+                    new()
+                    {
+                    NationalIdentityNumber = "123456",
+                    }
+                })
+                .SetTemplates([new SmsTemplate("Altinn", "this is the body")]));
 
         var notificationServiceMock = new Mock<ISmsNotificationService>();
         notificationServiceMock.Setup(
@@ -124,7 +123,7 @@ public class SmsOrderProcessingServiceTests
             {
                 Recipient augumentedRecipient = new() { AddressInfo = [new SmsAddressPoint("+4712345678")], NationalIdentityNumber = r[0].NationalIdentityNumber };
                 r.Clear();
-                r.Add(augumentedRecipient); 
+                r.Add(augumentedRecipient);
             });
 
         var service = GetTestService(smsService: notificationServiceMock.Object, contactPointService: contactPointServiceMock.Object);
@@ -141,19 +140,19 @@ public class SmsOrderProcessingServiceTests
     public async Task ProcessOrderRetry_NotificationServiceCalledIfRecipientNotInDatabase()
     {
         // Arrange
-        var order = new NotificationOrder()
-        {
-            Id = Guid.NewGuid(),
-            NotificationChannel = NotificationChannel.Sms,
-            Recipients = new List<Recipient>()
-            {
-                new Recipient(),
-                new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") }, nationalIdentityNumber: "enduser-nin"),
-                new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") }, organizationNumber: "skd-orgNo"),
-                new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4749999999") })
-            },
-            Templates = [new SmsTemplate("Altinn", "this is the body")]
-        };
+        var order = TestdataUtil.GetOrderForTest(
+            NotificationOrder
+                .GetBuilder()
+                .SetId(Guid.NewGuid())
+                .SetNotificationChannel(NotificationChannel.Sms)
+                .SetRecipients(new List<Recipient>()
+                    {
+                        new Recipient(),
+                        new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") }, nationalIdentityNumber: "enduser-nin"),
+                        new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4799999999") }, organizationNumber: "skd-orgNo"),
+                        new Recipient(new List<IAddressPoint>() { new SmsAddressPoint("+4749999999") })
+                    })
+                .SetTemplates([new SmsTemplate("Altinn", "this is the body")]));
 
         var notificationServiceMock = new Mock<ISmsNotificationService>();
         notificationServiceMock.Setup(s => s.CreateNotification(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<Recipient>(), It.IsAny<int>(), It.IsAny<bool>()));

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -28,21 +28,20 @@ public class OrderMapperTests
         DateTime sendTime = DateTime.UtcNow;
         DateTime created = DateTime.UtcNow;
 
-        NotificationOrder order = new()
-        {
-            Id = Guid.NewGuid(),
-            SendersReference = "ref1337",
-            Templates = [
+        NotificationOrder order = NotificationOrder
+            .GetBuilder()
+            .SetId(Guid.NewGuid())
+            .SetSendersReference("ref1337")
+            .SetRequestedSendTime(sendTime)
+            .SetNotificationChannel(NotificationChannel.Email)
+            .SetIgnoreReservation(true)
+            .SetCreator(new Creator("ttd"))
+            .SetCreated(created)
+            .SetTemplates([
                 new EmailTemplate("from@domain.com", "email-subject", "email-body", EmailContentType.Plain),
-                new SmsTemplate("Altinn-test", "This is a text message")
-            ],
-            RequestedSendTime = sendTime,
-            NotificationChannel = NotificationChannel.Email,
-            Creator = new Creator("ttd"),
-            Created = created,
-            Recipients = [],
-            IgnoreReservation = true
-        };
+                new SmsTemplate("Altinn-test", "This is a text message")])
+            .SetRecipients([])
+            .Build();
 
         NotificationOrderExt expected = new()
         {

--- a/test/Altinn.Notifications.Tests/TestdataUtil.cs
+++ b/test/Altinn.Notifications.Tests/TestdataUtil.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Altinn.Notifications.Core.Enums;
+using Altinn.Notifications.Core.Models;
+using Altinn.Notifications.Core.Models.NotificationTemplate;
+using Altinn.Notifications.Core.Models.Orders;
+
+using static Altinn.Notifications.Core.Models.Orders.NotificationOrder;
+
+namespace Altinn.Notifications.Tests;
+
+public static class TestdataUtil
+{
+    /// <summary>
+    /// Generates a notification order using the default value for each missing property. 
+    /// </summary>
+    public static NotificationOrder GetOrderForTest(NotificationOrderBuilder builder)
+    {
+        if (!builder.IdSet)
+        {
+            builder.SetId(Guid.NewGuid());
+        }
+
+        if (!builder.RequestedSendTimeSet)
+        {
+            builder.SetRequestedSendTime(DateTime.Now);
+        }
+
+        if (!builder.NotificationChannelSet)
+        {
+            builder.SetNotificationChannel(NotificationChannel.Email);
+        }
+
+        if (!builder.CreatorSet)
+        {
+            builder.SetCreator(new Creator("test"));
+        }
+
+        if (!builder.CreatedSet)
+        {
+            builder.SetCreated(DateTime.Now);
+        }
+
+        if (!builder.TemplatesSet)
+        {
+            builder.SetTemplates(new List<INotificationTemplate>());
+        }
+
+        if (!builder.RecipientsSet)
+        {
+            builder.SetRecipients(new List<Recipient>());
+        }
+
+        return builder.Build();
+    }
+
+    /// <summary>
+    /// Generates a notification order using the default value for all properties 
+    /// </summary>
+    public static NotificationOrder GetOrderForTest()
+    {
+        return GetOrderForTest(GetBuilder());
+    }
+}

--- a/test/Altinn.Notifications.Tests/TestdataUtil.cs
+++ b/test/Altinn.Notifications.Tests/TestdataUtil.cs
@@ -62,4 +62,17 @@ public static class TestdataUtil
     {
         return GetOrderForTest(GetBuilder());
     }
+
+    /// <summary>
+    /// Gets the default value of the provided type
+    /// </summary>  
+    public static object? GetDefaultValue(Type type)
+    {
+        if (type.IsValueType)
+        {
+            return Activator.CreateInstance(type);
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactoring. 
Added builder class for notification order models in Core. This way we avoid the lengthy constructors. 


## Related Issue(s)
- N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
