### PR TITLE
Ensure all address points get a notification

### DIFF
--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailNotificationServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailNotificationServiceTests.cs
@@ -212,6 +212,28 @@ public class EmailNotificationServiceTests
     }
 
     [Fact]
+    public async Task CreateNotification_RecipientHasTwoEmailAddresses_RepositoryCalledOnceForEachAddress()
+    {
+        // Arrange        
+        Recipient recipient = new()
+        {
+            OrganizationNumber = "org",
+            AddressInfo = [new EmailAddressPoint("user_1@domain.com"), new EmailAddressPoint("user_2@domain.com")]
+        };
+
+        var repoMock = new Mock<IEmailNotificationRepository>();
+        repoMock.Setup(r => r.AddNotification(It.Is<EmailNotification>(s => s.Recipient.OrganizationNumber == "org"), It.IsAny<DateTime>()));
+
+        var service = GetTestService(repo: repoMock.Object);
+
+        // Act
+        await service.CreateNotification(Guid.NewGuid(), DateTime.UtcNow, recipient);
+
+        // Assert
+        repoMock.Verify(r => r.AddNotification(It.Is<EmailNotification>(s => s.Recipient.OrganizationNumber == "org"), It.IsAny<DateTime>()), Times.Exactly(2));
+    }
+
+    [Fact]
     public async Task UpdateSendStatus_SendResultDefined_Succeded()
     {
         // Arrange

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsNotificationServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsNotificationServiceTests.cs
@@ -189,7 +189,7 @@ public class SmsNotificationServiceTests
         Recipient recipient = new()
         {
             OrganizationNumber = "org",
-            AddressInfo = [ new SmsAddressPoint("+4748123456"), new SmsAddressPoint("+4799123456")]
+            AddressInfo = [new SmsAddressPoint("+4748123456"), new SmsAddressPoint("+4799123456")]
         };
 
         var repoMock = new Mock<ISmsNotificationRepository>();

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsNotificationServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsNotificationServiceTests.cs
@@ -183,6 +183,28 @@ public class SmsNotificationServiceTests
     }
 
     [Fact]
+    public async Task CreateNotification_RecipientHasTwoMobileNumbers_RepositoryCalledOnceForEachNumber()
+    {
+        // Arrange        
+        Recipient recipient = new()
+        {
+            OrganizationNumber = "org",
+            AddressInfo = [ new SmsAddressPoint("+4748123456"), new SmsAddressPoint("+4799123456")]
+        };
+
+        var repoMock = new Mock<ISmsNotificationRepository>();
+        repoMock.Setup(r => r.AddNotification(It.Is<SmsNotification>(s => s.Recipient.OrganizationNumber == "org"), It.IsAny<DateTime>(), It.IsAny<int>()));
+
+        var service = GetTestService(repo: repoMock.Object);
+
+        // Act
+        await service.CreateNotification(Guid.NewGuid(), DateTime.UtcNow, recipient, 1, true);
+
+        // Assert
+        repoMock.Verify(r => r.AddNotification(It.Is<SmsNotification>(s => s.Recipient.OrganizationNumber == "org"), It.IsAny<DateTime>(), It.IsAny<int>()), Times.Exactly(2));
+    }
+
+    [Fact]
     public async Task SendNotifications_ProducerCalledOnceForEachRetrievedSms()
     {
         // Arrange 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed bug where only first address point was used to generate notifications for a recipient. 

## Related Issue(s)
- #456 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
