### PR TITLE
added basic validation of recipient nin and orgno

### DIFF
--- a/src/Altinn.Notifications/Validators/SmsNotificationOrderRequestValidator.cs
+++ b/src/Altinn.Notifications/Validators/SmsNotificationOrderRequestValidator.cs
@@ -16,21 +16,37 @@ public class SmsNotificationOrderRequestValidator : AbstractValidator<SmsNotific
     public SmsNotificationOrderRequestValidator()
     {
         RuleFor(order => order.Recipients)
-            .NotEmpty()
-            .WithMessage("One or more recipient is required.")
-            .Must(recipients => recipients.TrueForAll(a =>
-             {
-                 return
-                     (!string.IsNullOrWhiteSpace(a.MobileNumber) && MobileNumberHelper.IsValidMobileNumber(a.MobileNumber)) ||
-                     (!string.IsNullOrWhiteSpace(a.OrganizationNumber) ^ !string.IsNullOrWhiteSpace(a.NationalIdentityNumber));
-             }))
-            .WithMessage("Either a valid mobile number starting with country code, organization number, or national identity number must be provided for each recipient.");
+              .NotEmpty()
+              .WithMessage("One or more recipient is required.");
+
+        RuleForEach(order => order.Recipients)
+        .ChildRules(recipient =>
+        {
+            recipient.RuleFor(r => r)
+                .Must(r => !string.IsNullOrEmpty(r.MobileNumber) || !string.IsNullOrEmpty(r.OrganizationNumber) || !string.IsNullOrEmpty(r.NationalIdentityNumber))
+                .WithMessage("Either a valid mobile number starting with country code, organization number, or national identity number must be provided for each recipient.");
+
+            recipient.RuleFor(r => r.MobileNumber)
+                .Must(mobileNumber => MobileNumberHelper.IsValidMobileNumber(mobileNumber))
+                .When(r => !string.IsNullOrEmpty(r.MobileNumber))
+                .WithMessage("Invalid mobile number format.");
+
+            recipient.RuleFor(a => a.NationalIdentityNumber)
+                .Must(nin => nin?.Length == ValidationConstants.NationalIdentityNumberLength && nin.All(char.IsDigit))
+                .When(r => !string.IsNullOrEmpty(r.NationalIdentityNumber))
+                .WithMessage($"National identity number must be {ValidationConstants.NationalIdentityNumberLength} digits long.");
+
+            recipient.RuleFor(a => a.OrganizationNumber)
+                .Must(on => on?.Length == ValidationConstants.OrganizationNumberLength && on.All(char.IsDigit))
+                .When(r => !string.IsNullOrEmpty(r.OrganizationNumber))
+                .WithMessage($"Organization number must be {ValidationConstants.OrganizationNumberLength} digits long.");
+        });
 
         RuleFor(order => order.RequestedSendTime)
-            .Must(sendTime => sendTime.Kind != DateTimeKind.Unspecified)
-            .WithMessage("The requested send time value must have specified a time zone.")
-            .Must(sendTime => sendTime >= DateTime.UtcNow.AddMinutes(-5))
-            .WithMessage("Send time must be in the future. Leave blank to send immediately.");
+                .Must(sendTime => sendTime.Kind != DateTimeKind.Unspecified)
+                .WithMessage("The requested send time value must have specified a time zone.")
+                .Must(sendTime => sendTime >= DateTime.UtcNow.AddMinutes(-5))
+                .WithMessage("Send time must be in the future. Leave blank to send immediately.");
 
         RuleFor(order => order.Body).NotEmpty();
     }

--- a/src/Altinn.Notifications/Validators/ValidationConstants.cs
+++ b/src/Altinn.Notifications/Validators/ValidationConstants.cs
@@ -1,0 +1,18 @@
+﻿namespace Altinn.Notifications.Validators
+{
+    /// <summary>
+    /// Class comprised of all shared validation constants
+    /// </summary>
+    public static class ValidationConstants
+    {
+        /// <summary>
+        /// Required lenth for a national identity number
+        /// </summary>
+        public const int NationalIdentityNumberLength = 11;
+
+        /// <summary>
+        /// Required length for an organization number
+        /// </summary>
+        public const int OrganizationNumberLength = 9;
+    }
+}

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
@@ -34,6 +34,40 @@ public class EmailNotificationOrderRequestValidatorTests
         Assert.True(actual.IsValid);
     }
 
+    [Theory]
+    [InlineData("123456789", true)]
+    [InlineData("12345678", false)]
+    [InlineData("abc456789", false)]
+    public void Validate_RecipientOrganizationNumber_MustBe9Digits(string organizationNumber, bool expectedResult)
+    {
+        var order = new EmailNotificationOrderRequestExt()
+        {
+            Subject = "This is an email subject",
+            Recipients = new List<RecipientExt>() { new RecipientExt() { OrganizationNumber = organizationNumber } },
+            Body = "This is an email body"
+        };
+
+        var validationResult = _validator.Validate(order);
+        Assert.Equal(expectedResult, validationResult.IsValid);
+    }
+
+    [Theory]
+    [InlineData("16069412345", true)]
+    [InlineData("ab069412345", false)]
+    [InlineData("123456784651", false)]
+    public void Validate_RecipientNationalIdentityNumber_MustBe11Digits(string nationalIdentityNumber, bool expectedResult)
+    {
+        var order = new EmailNotificationOrderRequestExt()
+        {
+            Subject = "This is an email subject",
+            Recipients = new List<RecipientExt>() { new RecipientExt() { NationalIdentityNumber = nationalIdentityNumber } },
+            Body = "This is an email body"
+        };
+
+        var validationResult = _validator.Validate(order);
+        Assert.Equal(expectedResult, validationResult.IsValid);
+    }
+
     [Fact]
     public void Validate_InvalidEmailFormatProvided_ReturnsFalse()
     {
@@ -47,7 +81,7 @@ public class EmailNotificationOrderRequestValidatorTests
         var actual = _validator.Validate(order);
 
         Assert.False(actual.IsValid);
-        Assert.Contains(actual.Errors, a => a.ErrorMessage.Equals("Either a valid email address, organization number, or national identity number must be provided for each recipient."));
+        Assert.Contains(actual.Errors, a => a.ErrorMessage.Equals("Invalid email address format."));
     }
 
     [Fact]

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/SmsNotificationOrderRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/SmsNotificationOrderRequestValidatorTests.cs
@@ -34,6 +34,40 @@ public class SmsNotificationOrderRequestValidatorTests
         Assert.True(actual.IsValid);
     }
 
+    [Theory]
+    [InlineData("123456789", true)]
+    [InlineData("12345678", false)]
+    [InlineData("abc456789", false)]
+    public void Validate_RecipientOrganizationNumber_MustBe9Digits(string organizationNumber, bool expectedResult)
+    {
+        var order = new SmsNotificationOrderRequestExt()
+        {
+            SenderNumber = "+4740000000",
+            Recipients = new List<RecipientExt>() { new RecipientExt() { OrganizationNumber = organizationNumber } },
+            Body = "This is an SMS body"
+        };
+
+        var validationResult = _validator.Validate(order);
+        Assert.Equal(expectedResult, validationResult.IsValid);
+    }
+
+    [Theory]
+    [InlineData("16069412345", true)]
+    [InlineData("ab069412345", false)]
+    [InlineData("123456784651", false)]
+    public void Validate_RecipientNationalIdentityNumber_MustBe11Digits(string nationalIdentityNumber, bool expectedResult)
+    {
+        var order = new SmsNotificationOrderRequestExt()
+        {
+            SenderNumber = "+4740000000",
+            Recipients = new List<RecipientExt>() { new RecipientExt() { NationalIdentityNumber = nationalIdentityNumber } },
+            Body = "This is an SMS body"
+        };
+
+        var validationResult = _validator.Validate(order);
+        Assert.Equal(expectedResult, validationResult.IsValid);
+    }
+
     [Fact]
     public void Validate_InvalidMobileNumberFormatProvided_ReturnsFalse()
     {
@@ -47,7 +81,7 @@ public class SmsNotificationOrderRequestValidatorTests
         var actual = _validator.Validate(order);
 
         Assert.False(actual.IsValid);
-        Assert.Contains(actual.Errors, a => a.ErrorMessage.Equals("Either a valid mobile number starting with country code, organization number, or national identity number must be provided for each recipient."));
+        Assert.Contains(actual.Errors, a => a.ErrorMessage.Equals("Invalid mobile number format."));
     }
 
     [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Validation of digits and length when organization number or national identity number is provided for recipient. 

## Related Issue(s)
- #536 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
