### PR TITLE
Update threshold to use checks metrics instead of errors

### DIFF
--- a/test/k6/readme.md
+++ b/test/k6/readme.md
@@ -1,20 +1,16 @@
-## k6 test project for automated tests
+# Automated tests using k6
 
-# Getting started
-
-
-Install pre-requisites
-## Install k6
+## Install prerequisites
 
 *We recommend running the tests through a docker container.*
 
 From the command line:
 
-> docker pull grafana/k6
-
+```
+docker pull grafana/k6
+```
 
 Further information on [installing k6 for running in docker is available here.](https://k6.io/docs/get-started/installation/#docker)
-
 
 Alternatively, it is possible to run the tests directly on your machine as well.
 
@@ -25,32 +21,38 @@ Alternatively, it is possible to run the tests directly on your machine as well.
 
 All tests are defined in `src/tests` and in the top of each test file an example of the cmd to run the test is available.
 
-The command should be run from the root of the k6 folder.
+The command should be run from the k6 folder.
 
->$> cd /altinn-notifications/test/k6
+```
+$> cd /altinn-notifications/test/k6
+```
 
 Run test suite by specifying filename.
 
 For example:
 
- >$> podman compose run k6 run /src/tests/orders_email.js `
-    -e tokenGeneratorUserName=autotest `
+ ```
+ $> podman compose run k6 run /src/tests/orders_email.js `
+    -e tokenGeneratorUserName=*** `
     -e tokenGeneratorUserPwd=*** `
     -e env=*** `
-    -e toAddress=*** `
+    -e emailRecipient=*** `
+    -e ninRecipient=*** `
     -e runFullTestSet=true
+```
 
-The comand consists of three sections
+The command consists of three parts
 
 `podman compose run` to run the test in a docker container
 
-`k6 run {path to test file}` pointing to the test file you want to run e.g. `/src/tests/orders_email.js.js`
+`k6 run {path to test file}` pointing to the test file you want to run e.g. `/src/tests/orders_email.js`
 
+The last part is all script parameters provided as environment variables for the container.
 ```
- -e tokenGeneratorUserName=autotest
+ -e tokenGeneratorUserName=***
  -e tokenGeneratorUserPwd=***
  -e env=***
- -e toAddress=***
+ -e emailRecipient=***
+ -e ninRecipient=***
  -e runFullTestSet=true
 ````
- all environment variables that should be included in the request.

--- a/test/k6/src/api/authentication.js
+++ b/test/k6/src/api/authentication.js
@@ -17,12 +17,9 @@ export function exchangeToAltinnToken(token, test) {
     "// Setup // Authentication towards Altinn 3 Success": (r) =>
       r.status === 200,
   });
+  
   addErrorCount(success);
-  stopIterationOnFail(
-    "// Setup // Authentication towards Altinn 3  Failed",
-    success,
-    res
-  );
+  stopIterationOnFail("// Setup // Authentication towards Altinn 3  Failed", success);
 
   return res.body;
 }

--- a/test/k6/src/api/authentication.js
+++ b/test/k6/src/api/authentication.js
@@ -5,7 +5,7 @@ import {
   buildHeaderWithBearer
 } from "../apiHelpers.js";
 import { platformAuthentication } from "../config.js";
-import { stopIterationOnFail, addErrorCount } from "../errorhandler.js";
+import { stopIterationOnFail } from "../errorhandler.js";
 
 
 export function exchangeToAltinnToken(token, test) {
@@ -18,7 +18,6 @@ export function exchangeToAltinnToken(token, test) {
       r.status === 200,
   });
   
-  addErrorCount(success);
   stopIterationOnFail("// Setup // Authentication towards Altinn 3  Failed", success);
 
   return res.body;

--- a/test/k6/src/api/maskinporten.js
+++ b/test/k6/src/api/maskinporten.js
@@ -40,12 +40,9 @@ export function generateAccessToken(scopes) {
     "// Setup // Authentication towards Maskinporten Success": (r) =>
       r.status === 200,
   });
+  
   addErrorCount(success);
-  stopIterationOnFail(
-    "// Setup // Authentication towards Maskinporten Failed",
-    success,
-    res
-  );
+  stopIterationOnFail("// Setup // Authentication towards Maskinporten Failed", success);
 
   let accessToken = JSON.parse(res.body)['access_token'];
   return accessToken;

--- a/test/k6/src/api/maskinporten.js
+++ b/test/k6/src/api/maskinporten.js
@@ -7,7 +7,7 @@ import KJUR from "https://unpkg.com/jsrsasign@10.8.6/lib/jsrsasign.js";
 
 import { buildHeaderWithContentType}  from "../apiHelpers.js";
 import * as config from "../config.js";
-import { stopIterationOnFail, addErrorCount } from "../errorhandler.js";
+import { stopIterationOnFail } from "../errorhandler.js";
 
 const encodedJwk = __ENV.encodedJwk;
 const mpClientId = __ENV.mpClientId;
@@ -41,7 +41,6 @@ export function generateAccessToken(scopes) {
       r.status === 200,
   });
   
-  addErrorCount(success);
   stopIterationOnFail("// Setup // Authentication towards Maskinporten Failed", success);
 
   let accessToken = JSON.parse(res.body)['access_token'];

--- a/test/k6/src/api/token-generator.js
+++ b/test/k6/src/api/token-generator.js
@@ -37,7 +37,7 @@ function generateToken(endpoint) {
   var response = http.get(endpoint, params);
 
   if (response.status != 200) {
-    stopIterationOnFail("Token generation failed", false, response);
+    stopIterationOnFail("Token generation failed", false);
   }
 
   var token = response.body;

--- a/test/k6/src/errorhandler.js
+++ b/test/k6/src/errorhandler.js
@@ -1,17 +1,4 @@
-import { Counter } from "k6/metrics";
 import { fail } from "k6";
-
-let ErrorCount = new Counter("errors");
-
-/**
- * Increment the custom error count metric if success is false
- * @param {boolean} success The result of a check
- */
-export function addErrorCount(success) {
-  if (!success) {
-    ErrorCount.add(1);
-  }
-}
 
 /**
  * Stops k6 iteration when success is false and prints test name with response code

--- a/test/k6/src/errorhandler.js
+++ b/test/k6/src/errorhandler.js
@@ -3,7 +3,10 @@ import { fail } from "k6";
 
 let ErrorCount = new Counter("errors");
 
-//Adds a count to the error counter when value of success is false
+/**
+ * Increment the custom error count metric if success is false
+ * @param {boolean} success The result of a check
+ */
 export function addErrorCount(success) {
   if (!success) {
     ErrorCount.add(1);
@@ -12,14 +15,11 @@ export function addErrorCount(success) {
 
 /**
  * Stops k6 iteration when success is false and prints test name with response code
- * @param {String} testName
- * @param {boolean} success
- * @param {JSON} res
+ * @param {String} failReason The reason for stopping the tests
+ * @param {boolean} success The result of a check
  */
-export function stopIterationOnFail(testName, success, res) {
-  if (!success && res != null) {
-    fail(testName + ": Response code: " + res.status + ". Response message: " + res.body);
-  } else if (!success) {
-    fail(testName);
+export function stopIterationOnFail(failReason, success) {
+  if (!success) {
+    fail(failReason);
   }
 }

--- a/test/k6/src/tests/orders_email.js
+++ b/test/k6/src/tests/orders_email.js
@@ -1,54 +1,51 @@
 /*
-    Test script of platform notifications api with org token
+    Test script of platform notifications api with application owner token
     Command:
-    docker-compose run k6 run /src/tests/orders_email.js `
+    podman compose run k6 run /src/tests/orders_email.js `
     -e tokenGeneratorUserName=autotest `
-    -e tokenGeneratorUserPwd=*** `
-    -e mpClientId=*** `
-    -e mpKid=altinn-usecase-events `
-    -e encodedJwk=*** `
-    -e env=*** `
-    -e emailRecipient=*** `
-    -e ninRecipient=*** `
+    -e tokenGeneratorUserPwd={the password to access the token generator}`
+    -e mpClientId={the id of an integration defined in maskinporten} `
+    -e mpKid={the key id of the JSON web key used to sign the maskinporten token request} `
+    -e encodedJwk={the encoded JSON web key used to sign the maskinporten token request} `
+    -e env={environment: at21, at22, at23, at24, tt02, prod}`
+    -e emailRecipient={an email address to add as a notification recipient}`
+    -e ninRecipient={a national identity number of a person to include as a notification recipient}`
     -e runFullTestSet=true
 
     For use case tests omit environment variable runFullTestSet or set value to false
 */
 
 import { check } from "k6";
+import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
+import { stopIterationOnFail } from "../errorhandler.js";
+
 import * as setupToken from "../setup.js";
 import * as notificationsApi from "../api/notifications/notifications.js";
 import * as ordersApi from "../api/notifications/orders.js";
-import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
-const emailOrderRequestJson = JSON.parse(
-  open("../data/orders/01-email-request.json")
-);
 
-import { generateJUnitXML, reportPath } from "../report.js";
-import { addErrorCount, stopIterationOnFail } from "../errorhandler.js";
-const scopes = "altinn:serviceowner/notifications.create";
-const emailRecipient = __ENV.emailRecipient.toLowerCase();
-const ninRecipient = __ENV.ninRecipient.toLowerCase();
+const emailOrderRequestJson = open("../data/orders/01-email-request.json");
+
 export const options = {
   thresholds: {
-    errors: ["count<1"],
-  },
+    // Checks rate should be 100%. Raise error if any check has failed.
+    checks: ['rate>=1']
+  }
 };
 
 export function setup() {
-  var token = setupToken.getAltinnTokenForOrg(scopes);
-  var sendersReference = uuidv4();
+  const token = setupToken.getAltinnTokenForOrg("altinn:serviceowner/notifications.create");
+  const sendersReference = uuidv4();
 
-  var emailOrderRequest = emailOrderRequestJson;
+  var emailOrderRequest = JSON.parse(emailOrderRequestJson);
+  emailOrderRequest.sendersReference = sendersReference;
   emailOrderRequest.recipients = [
     {
-      emailAddress: emailRecipient,
+      emailAddress: __ENV.emailRecipient.toLowerCase(),
     },
     {
-      nationalIdentityNumber: ninRecipient
+      nationalIdentityNumber: __ENV.ninRecipient.toLowerCase()
     }
   ];
-  emailOrderRequest.sendersReference = sendersReference;
 
   const runFullTestSet = __ENV.runFullTestSet
     ? __ENV.runFullTestSet.toLowerCase().includes("true")
@@ -64,169 +61,119 @@ export function setup() {
   return data;
 }
 
-// 01 - POST email notification order request
 function TC01_PostEmailNotificationOrderRequest(data) {
-  var response, success;
+  let success;
 
-  response = ordersApi.postEmailNotificationOrder(
+  const response = ordersApi.postEmailNotificationOrder(
     JSON.stringify(data.emailOrderRequest),
     data.token
   );
-  var selfLink = response.headers["Location"];
 
   success = check(response, {
-    "POST email notification order request. Status is 202 Accepted": (r) =>
-      r.status === 202,
+    "POST email notification order request. Status is 202 Accepted": 
+      (r) => r.status === 202
+  });
+
+  stopIterationOnFail("POST email notification order request failed", success);
+
+  success = check(response, {
     "POST email notification order request. Location header providedStatus is 202 Accepted":
-      (r) => selfLink,
+      (r) => r.headers["Location"],
     "POST email notification order request. Recipient lookup was successful":
       (r) => JSON.parse(r.body).recipientLookup.status == 'Success'
   });
 
-  addErrorCount(success);
-
-  if (!success) {
-    stopIterationOnFail(success);
-  }
-
-  return selfLink;
+  return response.headers["Location"];
 }
 
-// 02 - GET notification order by id
 function TC02_GetNotificationOrderById(data, selfLink, orderId) {
-  var response, success;
-  response = ordersApi.getByUrl(selfLink, data.token);
+  let success;
+
+  const response = ordersApi.getByUrl(selfLink, data.token);
 
   success = check(response, {
-    "GET notification order by id. Status is 200 OK": (r) => r.status === 200,
+    "GET notification order by id. Status is 200 OK": 
+      (r) => r.status === 200,
   });
 
-  addErrorCount(success);
-  if (!success) {
-    // only continue to parse and check content if success response code
-    stopIterationOnFail(success);
-  }
+  stopIterationOnFail("GET notification order by id request failed", success);
 
   success = check(JSON.parse(response.body), {
-    "GET notification order by id. Id property is a match": (order) =>
-      order.id === orderId,
-    "GET notification order by id. Creator property is a match": (order) =>
-      order.creator === "ttd",
+    "GET notification order by id. Id property is a match": 
+      (order) => order.id === orderId,
+    "GET notification order by id. Creator property is a match": 
+      (order) => order.creator === "ttd",
   });
-  addErrorCount(success);
 }
 
-// 03 - GET notification order by senders reference
 function TC03_GetNotificationOrderBySendersReference(data) {
-  var response, success;
+  let success;
 
-  response = ordersApi.getBySendersReference(data.sendersReference, data.token);
+  const response = ordersApi.getBySendersReference(data.sendersReference, data.token);
 
   success = check(response, {
-    "GET notification order by senders reference. Status is 200 OK": (r) =>
-      r.status === 200,
+    "GET notification order by senders reference. Status is 200 OK": 
+      (r) => r.status === 200,
   });
 
-  addErrorCount(success);
-  if (!success) {
-    // only continue to parse and check content if success response code
-    stopIterationOnFail(success);
-  }
+  stopIterationOnFail("GET notification order by senders reference request failed", success);
 
   success = check(JSON.parse(response.body), {
-    "GET notification order by senders reference. Count is equal to 1": (
-      orderList
-    ) => orderList.count === 1,
+    "GET notification order by senders reference. Count is equal to 1": 
+      (orderList) => orderList.count === 1,
     "GET notification order by senders reference. Orderlist contains one element":
-      (orderList) =>
-        Array.isArray(orderList.orders) && orderList.orders.length == 1,
+      (orderList) => Array.isArray(orderList.orders) && orderList.orders.length == 1,
   });
 }
 
-// 04 - GET notification order with status
 function TC04_GetNotificationOrderWithStatus(data, orderId) {
-  var response, success;
+  let success;
 
-  response = ordersApi.getWithStatus(orderId, data.token);
+  const response = ordersApi.getWithStatus(orderId, data.token);
+
   success = check(response, {
-    "GET notification order with status. Status is 200 OK": (r) =>
-      r.status === 200,
+    "GET notification order with status. Status is 200 OK": 
+      (r) => r.status === 200,
   });
 
-  addErrorCount(success);
-  if (!success) {
-    // only continue to parse and check content if success response code
-    stopIterationOnFail(success);
-  }
+  stopIterationOnFail("GET notification order with status request failed", success);
 
   success = check(JSON.parse(response.body), {
-    "GET notification order with status. Id property is a match": (order) =>
-      order.id === orderId,
-    "GET notification order with status. NotificationChannel is email": (
-      order
-    ) => order.notificationChannel === "Email",
-    "GET notification order with status. ProcessingStatus is defined": (
-      order
-    ) => order.processingStatus,
+    "GET notification order with status. Id property is a match": 
+      (order) => order.id === orderId,
+    "GET notification order with status. NotificationChannel is email": 
+      (order) => order.notificationChannel === "Email",
+    "GET notification order with status. ProcessingStatus is defined": 
+      (order) => order.processingStatus,
   });
-  addErrorCount(success);
 }
 
-// 05 - GET email notification summary
 function TC05_GetEmailNotificationSummary(data, orderId) {
-  var response, success;
+  let success;
 
-  response = notificationsApi.getEmailNotifications(orderId, data.token);
+  const response = notificationsApi.getEmailNotifications(orderId, data.token);
+
   success = check(response, {
     "GET email notifications. Status is 200 OK": (r) => r.status === 200,
   });
 
-  addErrorCount(success);
-  if (!success) {
-    // only continue to parse and check content if success response code
-    stopIterationOnFail(success);
-  }
+  stopIterationOnFail("GET email notifications request failed", success);
 
   success = check(JSON.parse(response.body), {
-    "GET email notifications. OrderId property is a match": (
-      notificationSummary
-    ) => notificationSummary.orderId === orderId,
+    "GET email notifications. OrderId property is a match": 
+      (notificationSummary) => notificationSummary.orderId === orderId,
   });
 }
 
-/*
- * 01 - POST email notification order request
- * 02 - GET notification order by id
- * 03 - GET notification order by senders reference
- * 04 - GET notification order with status
- * 05 - GET email notification summary
- */
 export default function (data) {
-  try {
-    if (data.runFullTestSet) {
-      var selfLink = TC01_PostEmailNotificationOrderRequest(data);
-      let id = selfLink.split("/").pop();
-      TC02_GetNotificationOrderById(data, selfLink, id);
-      TC03_GetNotificationOrderBySendersReference(data);
-      TC04_GetNotificationOrderWithStatus(data, id);
-      TC05_GetEmailNotificationSummary(data, id);
-    } else {
-      // Limited test set for use case tests
-      var selfLink = TC01_PostEmailNotificationOrderRequest(data);
-      let id = selfLink.split("/").pop();
-      TC05_GetEmailNotificationSummary(data, id);
-    }
-  } catch (error) {
-    addErrorCount(false);
-    throw error;
+  var selfLink = TC01_PostEmailNotificationOrderRequest(data);
+  let id = selfLink.split("/").pop();
+
+  if (data.runFullTestSet) {
+    TC02_GetNotificationOrderById(data, selfLink, id);
+    TC03_GetNotificationOrderBySendersReference(data);
+    TC04_GetNotificationOrderWithStatus(data, id);
   }
-}
 
-/*
-export function handleSummary(data) {
-  let result = {};
-  result[reportPath("events.xml")] = generateJUnitXML(data, "events");
-
-  return result;
+  TC05_GetEmailNotificationSummary(data, id);
 }
-*/

--- a/test/k6/src/tests/orders_sms.js
+++ b/test/k6/src/tests/orders_sms.js
@@ -16,19 +16,22 @@
 
 import { check } from "k6";
 import { randomString } from "https://jslib.k6.io/k6-utils/1.2.0/index.js";
+import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
+import { stopIterationOnFail } from "../errorhandler.js";
+
 import * as setupToken from "../setup.js";
 import * as notificationsApi from "../api/notifications/notifications.js";
 import * as ordersApi from "../api/notifications/orders.js";
-import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
-import { generateJUnitXML, reportPath } from "../report.js";
-import { addErrorCount, stopIterationOnFail } from "../errorhandler.js";
-const scopes = "altinn:serviceowner/notifications.create";
-const smsRecipient = __ENV.smsRecipient.toLowerCase();
+
 export const options = {
   thresholds: {
-    errors: ["count<1"],
-  },
+    // Checks rate should be 100%. Raise error if any check has failed.
+    checks: ['rate>=1']
+  }
 };
+
+const scopes = "altinn:serviceowner/notifications.create";
+const smsRecipient = __ENV.smsRecipient.toLowerCase();
 
 export function setup() {
   var token = setupToken.getAltinnTokenForOrg(scopes);
@@ -78,11 +81,7 @@ function TC01_PostSmsNotificationOrderRequest(data) {
       (r) => r.body,
   });
 
-  addErrorCount(success);
-
-  if (!success) {
-    stopIterationOnFail(success);
-  }
+  stopIterationOnFail("POST sms notification order request failed", success);
 
   return selfLink;
 }
@@ -96,11 +95,7 @@ function TC02_GetNotificationOrderById(data, selfLink, orderId) {
     "GET notification order by id. Status is 200 OK": (r) => r.status === 200,
   });
 
-  addErrorCount(success);
-  if (!success) {
-    // only continue to parse and check content if success response code
-    stopIterationOnFail(success);
-  }
+  stopIterationOnFail("GET notification order by id request failed", success);
 
   success = check(JSON.parse(response.body), {
     "GET notification order by id. Id property is a match": (order) =>
@@ -108,7 +103,6 @@ function TC02_GetNotificationOrderById(data, selfLink, orderId) {
     "GET notification order by id. Creator property is a match": (order) =>
       order.creator === "ttd",
   });
-  addErrorCount(success);
 }
 
 // 03 - GET notification order by senders reference
@@ -122,11 +116,7 @@ function TC03_GetNotificationOrderBySendersReference(data) {
       r.status === 200,
   });
 
-  addErrorCount(success);
-  if (!success) {
-    // only continue to parse and check content if success response code
-    stopIterationOnFail(success);
-  }
+  stopIterationOnFail("GET notification order by senders reference request failed", success);
 
   success = check(JSON.parse(response.body), {
     "GET notification order by senders reference. Count is equal to 1": (
@@ -148,11 +138,7 @@ function TC04_GetNotificationOrderWithStatus(data, orderId) {
       r.status === 200,
   });
 
-  addErrorCount(success);
-  if (!success) {
-    // only continue to parse and check content if success response code
-    stopIterationOnFail(success);
-  }
+  stopIterationOnFail("GET notification order with status request failed", success);
 
   success = check(JSON.parse(response.body), {
     "GET notification order with status. Id property is a match": (order) =>
@@ -163,7 +149,6 @@ function TC04_GetNotificationOrderWithStatus(data, orderId) {
       order
     ) => order.processingStatus,
   });
-  addErrorCount(success);
 }
 
 // 05 - GET sms notification summary
@@ -175,11 +160,7 @@ function TC05_GetSmsNotificationSummary(data, orderId) {
     "GET sms notifications. Status is 200 OK": (r) => r.status === 200,
   });
 
-  addErrorCount(success);
-  if (!success) {
-    // only continue to parse and check content if success response code
-    stopIterationOnFail(success);
-  }
+  stopIterationOnFail("Get sms notification summary request failed", success);
 
   success = check(JSON.parse(response.body), {
     "GET sms notifications. OrderId property is a match": (
@@ -196,31 +177,14 @@ function TC05_GetSmsNotificationSummary(data, orderId) {
  * 05 - GET sms notification summary
  */
 export default function (data) {
-  try {
-    if (data.runFullTestSet) {
-      var selfLink = TC01_PostSmsNotificationOrderRequest(data);
-      let id = selfLink.split("/").pop();
-      TC02_GetNotificationOrderById(data, selfLink, id);
-      TC03_GetNotificationOrderBySendersReference(data);
-      TC04_GetNotificationOrderWithStatus(data, id);
-      TC05_GetSmsNotificationSummary(data, id);
-    } else {
-      // Limited test set for use case tests
-      var selfLink = TC01_PostSmsNotificationOrderRequest(data);
-      let id = selfLink.split("/").pop();
-      TC05_GetSmsNotificationSummary(data, id);
-    }
-  } catch (error) {
-    addErrorCount(false);
-    throw error;
+  var selfLink = TC01_PostSmsNotificationOrderRequest(data);
+  let id = selfLink.split("/").pop();
+
+  if (data.runFullTestSet) {
+    TC02_GetNotificationOrderById(data, selfLink, id);
+    TC03_GetNotificationOrderBySendersReference(data);
+    TC04_GetNotificationOrderWithStatus(data, id);
   }
-}
 
-/*
-export function handleSummary(data) {
-  let result = {};
-  result[reportPath("events.xml")] = generateJUnitXML(data, "events");
-
-  return result;
+  TC05_GetSmsNotificationSummary(data, id);
 }
-*/


### PR DESCRIPTION
## Description
I've been using this time to learn more about k6 in preparation for issue #562 and this pull request is the result.

- Changing the threshold rule for all tests and removing the custom "error" metric. 
- Simplified the `stopInterationOnFail` method and updated call points.

## Related Issue(s)
- #562

## Verification
- [x] Your code builds clean without any errors or warnings
- [x] Manual testing done (required)
