### PR TITLE
Update OrderMapper.cs

### DIFF
--- a/src/Altinn.Notifications/Mappers/OrderMapper.cs
+++ b/src/Altinn.Notifications/Mappers/OrderMapper.cs
@@ -58,7 +58,7 @@ public static class OrderMapper
             creator,
             templateList,
             extRequest.RequestedSendTime.ToUniversalTime(),
-            NotificationChannel.Email,
+            (NotificationChannel)extRequest.NotificationChannel!,
             recipients,
             extRequest.IgnoreReservation,
             extRequest.ResourceId,

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -316,7 +316,7 @@ public class OrderMapperTests
             Recipients = new List<Recipient>()
             {
                         new Recipient() { AddressInfo = new List<IAddressPoint>() { new EmailAddressPoint("recipient1@domain.com") } },
-                        new Recipient() {NationalIdentityNumber = "123456" }
+                        new Recipient() { NationalIdentityNumber = "123456" }
             },
             ConditionEndpoint = new Uri("https://vg.no"),
             IgnoreReservation = true,

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -266,6 +266,72 @@ public class OrderMapperTests
         Assert.Equivalent(expected, actual, true);
     }
 
+    [Theory]
+    [InlineData(NotificationChannelExt.Email, NotificationChannel.Email)]
+    [InlineData(NotificationChannelExt.EmailPreferred, NotificationChannel.EmailPreferred)]
+    [InlineData(NotificationChannelExt.Sms, NotificationChannel.Sms)]
+    [InlineData(NotificationChannelExt.SmsPreferred, NotificationChannel.SmsPreferred)]
+    public void MapToOrderRequest_AreEquivalent(NotificationChannelExt extChannel, NotificationChannel expectedChannel)
+    {
+        // Arrange
+        DateTime sendTime = DateTime.UtcNow;
+
+        NotificationOrderRequestExt ext = new()
+        {
+            NotificationChannel = extChannel,
+            EmailTemplate = new()
+            {
+                Subject = "email-subject",
+                Body = "email-body",
+                ContentType = EmailContentTypeExt.Html
+            },
+            SmsTemplate = new()
+            {
+                Body = "sms-body",
+            },
+            Recipients = new List<RecipientExt>() { new RecipientExt() { EmailAddress = "recipient1@domain.com" }, new RecipientExt() { NationalIdentityNumber = "123456" } },
+            SendersReference = "senders-reference",
+            RequestedSendTime = sendTime,
+            ConditionEndpoint = new Uri("https://vg.no"),
+            IgnoreReservation = true,
+            ResourceId = "urn:altinn:resource:test"
+        };
+
+        NotificationOrderRequest expected = new()
+        {
+            SendersReference = "senders-reference",
+            Creator = new Creator("ttd"),
+            Templates = new List<INotificationTemplate>()
+            {
+                new EmailTemplate(
+                    string.Empty,
+                    "email-subject",
+                    "email-body",
+                    EmailContentType.Html),
+                new SmsTemplate(
+                    string.Empty,
+                    "sms-body")
+            },
+            RequestedSendTime = sendTime,
+            Recipients = new List<Recipient>()
+            {
+                        new Recipient() { AddressInfo = new List<IAddressPoint>() { new EmailAddressPoint("recipient1@domain.com") } },
+                        new Recipient() {NationalIdentityNumber = "123456" }
+            },
+            ConditionEndpoint = new Uri("https://vg.no"),
+            IgnoreReservation = true,
+            ResourceId = "urn:altinn:resource:test"
+        };
+
+        expected.NotificationChannel = expectedChannel;
+
+        // Act
+        var actual = ext.MapToOrderRequest("ttd");
+
+        // Assert
+        Assert.Equivalent(expected, actual);
+    }
+
     [Fact]
     public void MapToNotificationOrderWithStatusExt_EmailStatusProvided_AreEquivalent()
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix for email always being used as notification channel regardless of user input. 

## Related Issue(s)
- #541 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
