### PR TITLE
Add SMS address point in NotificationOrderRequest for recipients with only phone no. 

### DIFF
--- a/src/Altinn.Notifications/Mappers/OrderMapper.cs
+++ b/src/Altinn.Notifications/Mappers/OrderMapper.cs
@@ -29,6 +29,11 @@ public static class OrderMapper
                   addresses.Add(new EmailAddressPoint(r.EmailAddress));
               }
 
+              if (!string.IsNullOrEmpty(r.MobileNumber))
+              {
+                  addresses.Add(new SmsAddressPoint(r.MobileNumber));
+              }
+
               return new Recipient(addresses, r.OrganizationNumber, r.NationalIdentityNumber);
           })
           .ToList();

--- a/src/Altinn.Notifications/Models/NotificationOrderRequestResponseExt.cs
+++ b/src/Altinn.Notifications/Models/NotificationOrderRequestResponseExt.cs
@@ -6,7 +6,7 @@ namespace Altinn.Notifications.Models;
 /// A class representing a container for an order id.
 /// </summary>
 /// <remarks>
-/// External representaion to be used in the API.
+/// External representation to be used in the API.
 /// </remarks>
 public class NotificationOrderRequestResponseExt
 {

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -140,8 +140,8 @@ public class OrderMapperTests
             NotificationChannel = NotificationChannel.Email,
             Recipients = new List<Recipient>()
             {
-                        new Recipient() { AddressInfo = new List<IAddressPoint>() { new EmailAddressPoint("recipient1@domain.com") } },
-                        new Recipient() { AddressInfo = new List<IAddressPoint>() { new EmailAddressPoint("recipient2@domain.com") } }
+                new Recipient() { AddressInfo = new List<IAddressPoint>() { new EmailAddressPoint("recipient1@domain.com") } },
+                new Recipient() { AddressInfo = new List<IAddressPoint>() { new EmailAddressPoint("recipient2@domain.com") } }
             }
         };
 
@@ -222,8 +222,8 @@ public class OrderMapperTests
             NotificationChannel = NotificationChannel.Sms,
             Recipients = new List<Recipient>()
             {
-                        new Recipient() { AddressInfo = new List<IAddressPoint>() { new SmsAddressPoint("+4740000001") } },
-                        new Recipient() { AddressInfo = new List<IAddressPoint>() { new SmsAddressPoint("+4740000002") } }
+                new Recipient() { AddressInfo = new List<IAddressPoint>() { new SmsAddressPoint("+4740000001") } },
+                new Recipient() { AddressInfo = new List<IAddressPoint>() { new SmsAddressPoint("+4740000002") } }
             }
         };
 
@@ -289,7 +289,12 @@ public class OrderMapperTests
             {
                 Body = "sms-body",
             },
-            Recipients = new List<RecipientExt>() { new RecipientExt() { EmailAddress = "recipient1@domain.com" }, new RecipientExt() { NationalIdentityNumber = "123456" } },
+            Recipients = new List<RecipientExt>()
+            {
+                new RecipientExt() { EmailAddress = "recipient1@domain.com" },
+                new RecipientExt() { NationalIdentityNumber = "123456" },
+                new RecipientExt() { MobileNumber = "+4712345678" }
+            },
             SendersReference = "senders-reference",
             RequestedSendTime = sendTime,
             ConditionEndpoint = new Uri("https://vg.no"),
@@ -315,8 +320,9 @@ public class OrderMapperTests
             RequestedSendTime = sendTime,
             Recipients = new List<Recipient>()
             {
-                        new Recipient() { AddressInfo = new List<IAddressPoint>() { new EmailAddressPoint("recipient1@domain.com") } },
-                        new Recipient() { NationalIdentityNumber = "123456" }
+                new Recipient() { AddressInfo = new List<IAddressPoint>() { new EmailAddressPoint("recipient1@domain.com") } },
+                new Recipient() { NationalIdentityNumber = "123456" },
+                new Recipient() { AddressInfo = new List<IAddressPoint>() { new SmsAddressPoint("+4712345678") } }
             },
             ConditionEndpoint = new Uri("https://vg.no"),
             IgnoreReservation = true,


### PR DESCRIPTION
## Description
This bugfix corrects the handling of recipients when ordering notifications for only mobile phone numbers.

Now, SmsAddressPoints are created and added for recipients when mapping `NotificationOrderRequestExt `-> `NotificationOrderRequest `in _src\Altinn.Notifications\Mappers\OrderMapper.cs_.

One of the tests in `OrderMapperTests` have been extended with a "mobile no. only" recipient. This gives test coverage of the scenario where this mapping previously has failed.

## Related Issue(s)
- #608 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
