### PR TITLE
Improved handling of invalid mobile numbers

### DIFF
--- a/src/Altinn.Notifications.Core/Helpers/MobileNumberHelper.cs
+++ b/src/Altinn.Notifications.Core/Helpers/MobileNumberHelper.cs
@@ -54,8 +54,8 @@ namespace Altinn.Notifications.Core.Helpers
             
             try
             {
-            PhoneNumber phoneNumber = phoneNumberUtil.Parse(mobileNumber, null);
-            isValidNumber = phoneNumberUtil.IsValidNumber(phoneNumber);
+                PhoneNumber phoneNumber = phoneNumberUtil.Parse(mobileNumber, null);
+                isValidNumber = phoneNumberUtil.IsValidNumber(phoneNumber);
             }
             catch (NumberParseException)
             {

--- a/src/Altinn.Notifications.Core/Helpers/MobileNumberHelper.cs
+++ b/src/Altinn.Notifications.Core/Helpers/MobileNumberHelper.cs
@@ -49,8 +49,20 @@ namespace Altinn.Notifications.Core.Helpers
             }
 
             PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.GetInstance();
+
+            bool isValidNumber;
+            
+            try
+            {
             PhoneNumber phoneNumber = phoneNumberUtil.Parse(mobileNumber, null);
-            return phoneNumberUtil.IsValidNumber(phoneNumber);
+            isValidNumber = phoneNumberUtil.IsValidNumber(phoneNumber);
+            }
+            catch (NumberParseException)
+            {
+                isValidNumber = false;
+            }
+
+            return isValidNumber;
         }
     }
 }

--- a/src/Altinn.Notifications/Validators/Rules/RecipientRules.cs
+++ b/src/Altinn.Notifications/Validators/Rules/RecipientRules.cs
@@ -234,7 +234,7 @@ public static class RecipientRules
             return false;
         }
 
-        string emailRegexPattern = @"((&quot;[^&quot;]+&quot;)|(([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9������]([a-zA-Z0-9\-������]{0,61})[a-zA-Z0-9������]\.)|[a-zA-Z0-9������]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))";
+        string emailRegexPattern = @"((&quot;[^&quot;]+&quot;)|(([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))";
 
         Regex regex = new(emailRegexPattern, RegexOptions.None, TimeSpan.FromSeconds(1));
 

--- a/src/Altinn.Notifications/Validators/Rules/RecipientRules.cs
+++ b/src/Altinn.Notifications/Validators/Rules/RecipientRules.cs
@@ -170,10 +170,10 @@ public static class RecipientRules
             mobileNumber.RuleFor(mobileNumber => mobileNumber)
                 .Must(mobileNumber => MobileNumberHelper.IsValidMobileNumber(mobileNumber))
                 .When(mobileNumber => !string.IsNullOrEmpty(mobileNumber))
-                .WithMessage("Invalid mobile number format.");
+                .WithMessage("Mobile number can contain only '+' and numeric characters, and it must adhere to the E.164 standard.");
         });
     }
-
+    
     private static IRuleBuilderOptions<T, string?> MustBeValidNationalIdentityNumber<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
@@ -234,7 +234,7 @@ public static class RecipientRules
             return false;
         }
 
-        string emailRegexPattern = @"((&quot;[^&quot;]+&quot;)|(([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\.)|[a-zA-Z0-9æøåÆØÅ]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))";
+        string emailRegexPattern = @"((&quot;[^&quot;]+&quot;)|(([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+(\.([a-zA-Z0-9!#$%&amp;'*+\-=?\^_`{|}~])+)*))@((((([a-zA-Z0-9ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½]([a-zA-Z0-9\-ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½]{0,61})[a-zA-Z0-9ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½]\.)|[a-zA-Z0-9ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½]\.){1,9})([a-zA-Z]{2,14}))|((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})))";
 
         Regex regex = new(emailRegexPattern, RegexOptions.None, TimeSpan.FromSeconds(1));
 

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using Altinn.Notifications.Models;
 using Altinn.Notifications.Validators;
@@ -27,20 +27,6 @@ public class EmailNotificationOrderRequestValidatorTests
         {
             Subject = "This is an email subject",
             Recipients = [new RecipientExt() { EmailAddress = "recipient2@domain.com" }],
-            Body = "This is an email body"
-        };
-
-        var actual = _validator.Validate(order);
-        Assert.True(actual.IsValid);
-    }
-
-    [Fact]
-    public void Validate_RecipientWithNorwegianChars_ReturnsTrue()
-    {
-        var order = new EmailNotificationOrderRequestExt()
-        {
-            Subject = "This is an email subject",
-            Recipients = [new RecipientExt() { EmailAddress = "æge_sjøåsen@domain.com" }],
             Body = "This is an email body"
         };
 
@@ -226,6 +212,7 @@ public class EmailNotificationOrderRequestValidatorTests
     }
 
     [Theory]
+    [InlineData("æge_sjøåsen@domain.com", true)]
     [InlineData("stephanie@kul.no", true)]
     [InlineData("bakken_kundeservice@sykkelverksted.com", true)]
     [InlineData("john.doe@sub.domain.example", true)]

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
@@ -34,6 +34,20 @@ public class EmailNotificationOrderRequestValidatorTests
         Assert.True(actual.IsValid);
     }
 
+    [Fact]
+    public void Validate_RecipientWithNorwegianChars_ReturnsTrue()
+    {
+        var order = new EmailNotificationOrderRequestExt()
+        {
+            Subject = "This is an email subject",
+            Recipients = [new RecipientExt() { EmailAddress = "æge_sjøåsen@domain.com" }],
+            Body = "This is an email body"
+        };
+
+        var actual = _validator.Validate(order);
+        Assert.True(actual.IsValid);
+    }
+
     [Theory]
     [InlineData("123456789", true)]
     [InlineData("12345678", false)]

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationOrderRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationOrderRequestValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 using Altinn.Notifications.Models;
 using Altinn.Notifications.Validators;
@@ -14,7 +14,6 @@ namespace Altinn.Notifications.Tests.Notifications.TestingValidators
     {
         private readonly NotificationOrderRequestValidator _validator;
         private readonly NotificationOrderRequestExt _validEmailOrder;
-        private readonly NotificationOrderRequestExt _validEmailWithNorwegianLettersOrder;
         private readonly NotificationOrderRequestExt _validSmsOrder;
         private readonly NotificationOrderRequestExt _validEmailPreferredOrder;
         private readonly NotificationOrderRequestExt _validSmsPreferredOrder;
@@ -29,13 +28,6 @@ namespace Altinn.Notifications.Tests.Notifications.TestingValidators
                 NotificationChannel = NotificationChannelExt.Email,
                 EmailTemplate = new EmailTemplateExt { Subject = "Test", Body = "Test Body" },
                 Recipients = [new RecipientExt { EmailAddress = "test@test.com" }]
-            };
-            
-            _validEmailWithNorwegianLettersOrder = new()
-            {
-                NotificationChannel = NotificationChannelExt.Email,
-                EmailTemplate = new EmailTemplateExt { Subject = "Test", Body = "Test Body" },
-                Recipients = [new RecipientExt { EmailAddress = "æge@sjøåsen.com" }]
             };
 
             _validSmsOrder = new()
@@ -102,19 +94,6 @@ namespace Altinn.Notifications.Tests.Notifications.TestingValidators
         {
             // Arrange
             var model = _validEmailOrder;
-
-            // Act
-            var result = _validator.Validate(model);
-
-            // Assert
-            Assert.True(result.IsValid);
-        }
-        
-        [Fact]
-        public void Validate_Email_AllRequiredPropsAndNorwegianLetters_IsValid()
-        {
-            // Arrange
-            var model = _validEmailWithNorwegianLettersOrder;
 
             // Act
             var result = _validator.Validate(model);

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationOrderRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationOrderRequestValidatorTests.cs
@@ -14,7 +14,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingValidators
     {
         private readonly NotificationOrderRequestValidator _validator;
         private readonly NotificationOrderRequestExt _validEmailOrder;
-
+        private readonly NotificationOrderRequestExt _validEmailWithNorwegianLettersOrder;
         private readonly NotificationOrderRequestExt _validSmsOrder;
         private readonly NotificationOrderRequestExt _validEmailPreferredOrder;
         private readonly NotificationOrderRequestExt _validSmsPreferredOrder;
@@ -29,6 +29,13 @@ namespace Altinn.Notifications.Tests.Notifications.TestingValidators
                 NotificationChannel = NotificationChannelExt.Email,
                 EmailTemplate = new EmailTemplateExt { Subject = "Test", Body = "Test Body" },
                 Recipients = [new RecipientExt { EmailAddress = "test@test.com" }]
+            };
+            
+            _validEmailWithNorwegianLettersOrder = new()
+            {
+                NotificationChannel = NotificationChannelExt.Email,
+                EmailTemplate = new EmailTemplateExt { Subject = "Test", Body = "Test Body" },
+                Recipients = [new RecipientExt { EmailAddress = "æge@sjøåsen.com" }]
             };
 
             _validSmsOrder = new()
@@ -95,6 +102,19 @@ namespace Altinn.Notifications.Tests.Notifications.TestingValidators
         {
             // Arrange
             var model = _validEmailOrder;
+
+            // Act
+            var result = _validator.Validate(model);
+
+            // Assert
+            Assert.True(result.IsValid);
+        }
+        
+        [Fact]
+        public void Validate_Email_AllRequiredPropsAndNorwegianLetters_IsValid()
+        {
+            // Arrange
+            var model = _validEmailWithNorwegianLettersOrder;
 
             // Act
             var result = _validator.Validate(model);

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationOrderRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationOrderRequestValidatorTests.cs
@@ -18,6 +18,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingValidators
         private readonly NotificationOrderRequestExt _validSmsOrder;
         private readonly NotificationOrderRequestExt _validEmailPreferredOrder;
         private readonly NotificationOrderRequestExt _validSmsPreferredOrder;
+        private readonly NotificationOrderRequestExt _invalidSmsPreferredOrder;
 
         public NotificationOrderRequestValidatorTests()
         {
@@ -51,6 +52,14 @@ namespace Altinn.Notifications.Tests.Notifications.TestingValidators
                 EmailTemplate = new EmailTemplateExt { Subject = "Test", Body = "Test Body" },
                 SmsTemplate = new SmsTemplateExt { Body = "Test Body" },
                 Recipients = [new RecipientExt { OrganizationNumber = "123456789" }]
+            };
+
+            _invalidSmsPreferredOrder = new()
+            {
+                NotificationChannel = NotificationChannelExt.SmsPreferred,
+                EmailTemplate = new EmailTemplateExt { Subject = "Test", Body = "Test Body" },
+                SmsTemplate = new SmsTemplateExt { Body = "Test Body" },
+                Recipients = [new RecipientExt { MobileNumber = "+47invalidChar" }]
             };
         }
 
@@ -148,6 +157,20 @@ namespace Altinn.Notifications.Tests.Notifications.TestingValidators
             // Assert
             Assert.False(result.IsValid);
             Assert.Contains(result.Errors, a => a.ErrorMessage.Equals("Organization number cannot be combined with email address, mobile number, or national identity number."));
+        }
+
+        [Fact]
+        public void Validate_SmsPreferred_LettersInMobileNumber_IsNotValid()
+        {
+            // Arrange
+            var model = _invalidSmsPreferredOrder;
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.Contains(result.Errors, a => a.ErrorMessage.Equals("Mobile number can contain only '+' and numeric characters, and it must adhere to the E.164 standard."));
         }
     }
 }

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/SmsNotificationOrderRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/SmsNotificationOrderRequestValidatorTests.cs
@@ -80,7 +80,7 @@ public class SmsNotificationOrderRequestValidatorTests
         var actual = _validator.Validate(order);
 
         Assert.False(actual.IsValid);
-        Assert.Contains(actual.Errors, a => a.ErrorMessage.Equals("Invalid mobile number format."));
+        Assert.Contains(actual.Errors, a => a.ErrorMessage.Equals("Mobile number can contain only '+' and numeric characters, and it must adhere to the E.164 standard."));
     }
 
     [Fact]


### PR DESCRIPTION
## Description

When placing notification orders where SMS is involved, mobile numbers that include invalid characters (like letters) now produces response code 400 instead of 500. Additionally, the general response for such invalid numbers is changed:
- Before: "_Invalid mobile number format_".
- Now: "_Mobile number can contain only '+' and numeric characters, and it must adhere to the E.164 standard._"

Affected endpoints:
- POST /notifications/api/v1/orders/sms
- POST /notifications/api/v1/orders

The `MobileNumberHelper` class, used by Validators to perform number validation, now has a try/catch for when PhoneNumberUtil throws NumberParseException. These exceptions now result in the method `IsValidMobileNumber` returning `false`.

## Related Issue(s)
- #619 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
