### PR TITLE
Correct the path to startup project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Kafdrop is now available at http://localhost:9000.
 
 The Notifications components can be run locally when developing/debugging. Follow the install steps above if this has not already been done.
 
-- Navigate to _src/Notifications_, and build and run the code from there, or run the solution using you selected code editor
+- Navigate to _src/Altinn.Notifications_, and build and run the code from there, or run the solution using you selected code editor
 
   ```cmd
   cd src/Notifications


### PR DESCRIPTION
## Description
Updates the instruction for running Notifications locally, using the up-to-date path to the startup project

## Related Issue(s)
- N/A

## Verification
- [ ] ~~**Your** code builds clean without any errors or warnings~~
- [ ] ~~Manual testing done (required)~~ 
- [ ] ~~Relevant automated test added (if you find this hard, leave it and we'll help out)~~
- [ ] ~~All tests run green~~

## Documentation
- [ ] ~~User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)~~
