### PR TITLE
Revert "Update mcr.microsoft.com/dotnet/aspnet Docker tag to v9"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN dotnet build ./src/DbTools/DbTools.csproj -c Release -o /app_tools
 RUN dotnet publish -c Release -o out ./src/Altinn.Notifications/Altinn.Notifications.csproj
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:9.0.0-alpine3.20 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.11-alpine3.20 AS final
 WORKDIR /app
 EXPOSE 5090
 


### PR DESCRIPTION
Reverts Altinn/altinn-notifications#649

We will update the .Net framework separately.