### PR TITLE
Restrict data retrieval from the Register API

### DIFF
--- a/src/Altinn.Notifications.Core/Services/EmailOrderProcessingService.cs
+++ b/src/Altinn.Notifications.Core/Services/EmailOrderProcessingService.cs
@@ -142,8 +142,8 @@ public class EmailOrderProcessingService : IEmailOrderProcessingService
             IsReserved = recipient.IsReserved,
             OrganizationNumber = recipient.OrganizationNumber,
             NationalIdentityNumber = recipient.NationalIdentityNumber,
-            CustomizedBody = RequiresCustomization(emailTemplate?.Body) ? emailTemplate?.Body : null,
-            CustomizedSubject = RequiresCustomization(emailTemplate?.Subject) ? emailTemplate?.Subject : null,
+            CustomizedBody = RequiresCustomization(emailTemplate?.Body) ? emailTemplate!.Body : null,
+            CustomizedSubject = RequiresCustomization(emailTemplate?.Subject) ? emailTemplate!.Subject : null,
         }).ToList();
 
         return await _keywordsService.ReplaceKeywordsAsync(emailRecipients);

--- a/src/Altinn.Notifications.Core/Services/KeywordsService.cs
+++ b/src/Altinn.Notifications.Core/Services/KeywordsService.cs
@@ -38,13 +38,15 @@ public class KeywordsService : IKeywordsService
         ArgumentNullException.ThrowIfNull(smsRecipients);
 
         var organizationNumbers = smsRecipients
-            .Where(r => !string.IsNullOrWhiteSpace(r.OrganizationNumber))
-            .Select(r => r.OrganizationNumber!)
+            .Where(e => !string.IsNullOrWhiteSpace(e.CustomizedBody))
+            .Where(e => !string.IsNullOrWhiteSpace(e.OrganizationNumber))
+            .Select(e => e.OrganizationNumber!)
             .ToList();
 
         var nationalIdentityNumbers = smsRecipients
-            .Where(r => !string.IsNullOrWhiteSpace(r.NationalIdentityNumber))
-            .Select(r => r.NationalIdentityNumber!)
+            .Where(e => !string.IsNullOrWhiteSpace(e.CustomizedBody))
+            .Where(e => !string.IsNullOrWhiteSpace(e.NationalIdentityNumber))
+            .Select(e => e.NationalIdentityNumber!)
             .ToList();
 
         var (personDetails, organizationDetails) = await FetchPartyDetailsAsync(organizationNumbers, nationalIdentityNumbers);
@@ -64,13 +66,15 @@ public class KeywordsService : IKeywordsService
         ArgumentNullException.ThrowIfNull(emailRecipients);
 
         var organizationNumbers = emailRecipients
-            .Where(r => !string.IsNullOrWhiteSpace(r.OrganizationNumber))
-            .Select(r => r.OrganizationNumber!)
+            .Where(e => !string.IsNullOrWhiteSpace(e.OrganizationNumber))
+            .Where(e => !string.IsNullOrWhiteSpace(e.CustomizedBody) || !string.IsNullOrWhiteSpace(e.CustomizedSubject))
+            .Select(e => e.OrganizationNumber!)
             .ToList();
 
         var nationalIdentityNumbers = emailRecipients
-            .Where(r => !string.IsNullOrWhiteSpace(r.NationalIdentityNumber))
-            .Select(r => r.NationalIdentityNumber!)
+            .Where(e => !string.IsNullOrWhiteSpace(e.NationalIdentityNumber))
+            .Where(e => !string.IsNullOrWhiteSpace(e.CustomizedBody) || !string.IsNullOrWhiteSpace(e.CustomizedSubject))
+            .Select(e => e.NationalIdentityNumber!)
             .ToList();
 
         var (personDetails, organizationDetails) = await FetchPartyDetailsAsync(organizationNumbers, nationalIdentityNumbers);

--- a/src/Altinn.Notifications.Core/Services/SmsOrderProcessingService.cs
+++ b/src/Altinn.Notifications.Core/Services/SmsOrderProcessingService.cs
@@ -77,7 +77,7 @@ public class SmsOrderProcessingService : ISmsOrderProcessingService
             {
                 continue;
             }
-            
+
             var matchedSmsRecipient = FindSmsRecipient(allSmsRecipients, recipient);
             var smsRecipient = matchedSmsRecipient ?? new SmsRecipient { IsReserved = recipient.IsReserved };
 
@@ -135,10 +135,20 @@ public class SmsOrderProcessingService : ISmsOrderProcessingService
             IsReserved = recipient.IsReserved,
             OrganizationNumber = recipient.OrganizationNumber,
             NationalIdentityNumber = recipient.NationalIdentityNumber,
-            CustomizedBody = (_keywordsService.ContainsRecipientNumberPlaceholder(smsTemplate?.Body) || _keywordsService.ContainsRecipientNamePlaceholder(smsTemplate?.Body)) ? smsTemplate?.Body : null,
+            CustomizedBody = RequiresCustomization(smsTemplate?.Body) ? smsTemplate!.Body : null
         }).ToList();
 
         return await _keywordsService.ReplaceKeywordsAsync(smsRecipients);
+    }
+
+    /// <summary>
+    /// Determines whether the specified template part requires customization by checking for placeholder keywords.
+    /// </summary>
+    /// <param name="templatePart">The part of the SMS template (The SMS body) to evaluate.</param>
+    /// <returns><c>true</c> if the template part contains placeholders for recipient-specific customization; otherwise, <c>false</c>.</returns>
+    private bool RequiresCustomization(string? templatePart)
+    {
+        return _keywordsService.ContainsRecipientNumberPlaceholder(templatePart) || _keywordsService.ContainsRecipientNamePlaceholder(templatePart);
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
After merging the changes for #545, some regression tests failed because the Notification API was trying to retrieve data from the Register API unnecessarily. This PR fixes the issue by ensuring the Register API only retrieves data for entries that have at least one keyword and either a valid national identity number or organization number.

## Related Issue(s)
- #545 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
