### PR TITLE
Persist recipient orgNo for sms notifications

### DIFF
--- a/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
@@ -51,7 +51,7 @@ public class SmsNotificationRepository : ISmsNotificationRepository
 
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notification.OrderId);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notification.Id);
-        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, (object)DBNull.Value); // recipientorgno
+        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.Recipient.OrganizationNumber ?? (object)DBNull.Value);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.Recipient.NationalIdentityNumber ?? (object)DBNull.Value);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.Recipient.MobileNumber);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, notification.Recipient.CustomizedBody ?? (object)DBNull.Value);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix for recipient organization number not being persisted for generated Sms notifications

## Description
<!--- Describe your changes in detail -->
Similar to https://github.com/Altinn/altinn-notifications/pull/515


## Related Issue(s)
- #705 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
