### PR TITLE
Do not update the SMS order based on the gateway reference.

### DIFF
--- a/src/Altinn.Notifications.Core/Altinn.Notifications.Core.csproj
+++ b/src/Altinn.Notifications.Core/Altinn.Notifications.Core.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="libphonenumber-csharp" Version="8.13.54" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Altinn.Notifications.Core/Enums/SmsNotificationResultType.cs
+++ b/src/Altinn.Notifications.Core/Enums/SmsNotificationResultType.cs
@@ -6,67 +6,67 @@
 public enum SmsNotificationResultType
 {
     /// <summary>
-    /// The default result for new notifications.
+    /// Indicates a new SMS notification.
     /// </summary>
     New,
 
     /// <summary>
-    /// The SMS notification is currently being sent.
+    /// Indicates that the SMS is currently being sent.
     /// </summary>
     Sending,
 
     /// <summary>
-    /// The SMS notification has been sent to the service provider.
+    /// Indicates that the SMS has been sent to the service provider.
     /// </summary>
     Accepted,
 
     /// <summary>
-    /// The SMS notification was successfully delivered to the recipient.
+    /// Indicates that the SMS was successfully delivered to the recipient.
     /// </summary>
     Delivered,
 
     /// <summary>
-    /// The SMS notification send operation failed.
+    /// Indicates that the SMS send operation failed.
     /// </summary>
     Failed,
 
     /// <summary>
-    /// The SMS notification send operation failed due to an invalid recipient.
+    /// Indicates that the SMS send operation failed due to an invalid recipient.
     /// </summary>
     Failed_InvalidRecipient,
 
     /// <summary>
-    /// The SMS notification send operation failed because the recipient is reserved in KRR.
+    /// Indicates that the SMS send operation failed because the recipient is reserved due to the contact and reservation register (KRR).
     /// </summary>
     Failed_RecipientReserved,
 
     /// <summary>
-    /// The SMS notification send operation failed because the recipient's number is barred, blocked, or not in use.
+    /// Indicates that the SMS send operation failed because the recipient's number is barred, blocked, or not in use.
     /// </summary>
     Failed_BarredReceiver,
 
     /// <summary>
-    /// The SMS notification send operation failed because the message has been deleted.
+    /// Indicates that the SMS send operation failed because the message has been deleted.
     /// </summary>
     Failed_Deleted,
 
     /// <summary>
-    /// The SMS notification send operation failed because the message validity period has expired.
+    /// Indicates that the SMS send operation failed because the message validity period has expired.
     /// </summary>
     Failed_Expired,
 
     /// <summary>
-    /// The SMS notification send operation failed because the SMS was undeliverable.
+    /// Indicates that the SMS send operation failed because the SMS was undeliverable.
     /// </summary>
     Failed_Undelivered,
 
     /// <summary>
-    /// The SMS notification send operation failed because the recipient's mobile number was not identified.
+    /// Indicates that the SMS send operation failed because the recipient's mobile number was not identified.
     /// </summary>
     Failed_RecipientNotIdentified,
 
     /// <summary>
-    /// The SMS notification send operation failed because the message was rejected.
+    /// Indicates that the SMS send operation failed because the message was rejected.
     /// </summary>
     Failed_Rejected
 }

--- a/src/Altinn.Notifications.Core/Enums/SmsNotificationResultType.cs
+++ b/src/Altinn.Notifications.Core/Enums/SmsNotificationResultType.cs
@@ -1,72 +1,72 @@
 ﻿namespace Altinn.Notifications.Core.Enums;
 
 /// <summary>
-/// Enum describing sms notification result types
+/// Enum representing the result types for SMS notifications.
 /// </summary>
 public enum SmsNotificationResultType
 {
     /// <summary>
-    /// Default result for new notifications
+    /// The default result for new notifications.
     /// </summary>
     New,
 
     /// <summary>
-    /// Sms notification being sent
+    /// The SMS notification is currently being sent.
     /// </summary>
     Sending,
 
     /// <summary>
-    /// Sms notification sent to service provider
+    /// The SMS notification has been sent to the service provider.
     /// </summary>
     Accepted,
 
     /// <summary>
-    /// Sms notification was successfully delivered to destination.
+    /// The SMS notification was successfully delivered to the recipient.
     /// </summary>
     Delivered,
 
     /// <summary>
-    /// Sms notification send operation failed
+    /// The SMS notification send operation failed.
     /// </summary>
     Failed,
 
     /// <summary>
-    /// Sms notification send operation failed due to invalid recipient
+    /// The SMS notification send operation failed due to an invalid recipient.
     /// </summary>
     Failed_InvalidRecipient,
 
     /// <summary>
-    /// Failed, recipient is reserved in KRR
+    /// The SMS notification send operation failed because the recipient is reserved in KRR.
     /// </summary>
     Failed_RecipientReserved,
 
     /// <summary>
-    /// Sms notification send operation failed because the receiver number is barred/blocked/not in use. 
+    /// The SMS notification send operation failed because the recipient's number is barred, blocked, or not in use.
     /// </summary>
     Failed_BarredReceiver,
 
     /// <summary>
-    /// Sms notification send operation failed because the message has been deleted.
+    /// The SMS notification send operation failed because the message has been deleted.
     /// </summary>
     Failed_Deleted,
 
     /// <summary>
-    /// Sms notification send operation failed because the message validity period has expired.
+    /// The SMS notification send operation failed because the message validity period has expired.
     /// </summary>
     Failed_Expired,
 
     /// <summary>
-    /// Sms notification send operation failed due to the SMS being undeliverable.
+    /// The SMS notification send operation failed because the SMS was undeliverable.
     /// </summary>
     Failed_Undelivered,
 
     /// <summary>
-    /// Recipient mobile number was not identified
+    /// The SMS notification send operation failed because the recipient's mobile number was not identified.
     /// </summary>
     Failed_RecipientNotIdentified,
 
     /// <summary>
-    /// Message was rejected.
+    /// The SMS notification send operation failed because the message was rejected.
     /// </summary>
     Failed_Rejected
 }

--- a/src/Altinn.Notifications.Core/Models/Notification/INotification.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/INotification.cs
@@ -1,13 +1,11 @@
-﻿using System;
-
-using Altinn.Notifications.Core.Enums;
+﻿using Altinn.Notifications.Core.Enums;
 
 namespace Altinn.Notifications.Core.Models.Notification;
 
 /// <summary>
 /// Defines the contract for a base notification.
 /// </summary>
-/// <typeparam name="TEnum">The type of the enumeration used for the notification result.</typeparam>
+/// <typeparam name="TEnum">The type of the enumeration used to represent the notification status.</typeparam>
 public interface INotification<TEnum>
     where TEnum : struct, Enum
 {
@@ -27,7 +25,7 @@ public interface INotification<TEnum>
     DateTime RequestedSendTime { get; }
 
     /// <summary>
-    /// Gets the channel through which the notification will be sent.
+    /// Gets the communication channel through which the notification will be sent.
     /// </summary>
     NotificationChannel NotificationChannel { get; }
 

--- a/src/Altinn.Notifications.Core/Models/Notification/INotification.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/INotification.cs
@@ -5,33 +5,34 @@ using Altinn.Notifications.Core.Enums;
 namespace Altinn.Notifications.Core.Models.Notification;
 
 /// <summary>
-/// Interface describing a base notification.
+/// Defines the contract for a base notification.
 /// </summary>
+/// <typeparam name="TEnum">The type of the enumeration used for the notification result.</typeparam>
 public interface INotification<TEnum>
     where TEnum : struct, Enum
 {
     /// <summary>
-    /// Gets the id of the notification.
+    /// Gets the unique identifier of the notification.
     /// </summary>
-    public Guid Id { get; }
+    Guid Id { get; }
 
     /// <summary>
-    /// Gets the order id of the notification.
+    /// Gets the unique identifier of the order associated with the notification.
     /// </summary>
-    public Guid OrderId { get; }
+    Guid OrderId { get; }
 
     /// <summary>
-    /// Gets the requested send time of the notification.
+    /// Gets the date and time when the notification is requested to be sent.
     /// </summary>
-    public DateTime RequestedSendTime { get; }
+    DateTime RequestedSendTime { get; }
 
     /// <summary>
-    /// Gets the notifiction channel for the notification.
+    /// Gets the channel through which the notification will be sent.
     /// </summary>
-    public NotificationChannel NotificationChannel { get; }
+    NotificationChannel NotificationChannel { get; }
 
     /// <summary>
-    /// Gets the send result of the notification.
+    /// Gets the result of the notification send operation.
     /// </summary>
-    public NotificationResult<TEnum> SendResult { get; }
+    NotificationResult<TEnum> SendResult { get; }
 }

--- a/src/Altinn.Notifications.Core/Models/Notification/INotification.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/INotification.cs
@@ -15,7 +15,7 @@ public interface INotification<TEnum>
     Guid Id { get; }
 
     /// <summary>
-    /// Gets the unique identifier of the order associated with the notification.
+    /// Gets the unique identifier of the order associated with this notification.
     /// </summary>
     Guid OrderId { get; }
 

--- a/src/Altinn.Notifications.Core/Models/Notification/NotificationResult.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/NotificationResult.cs
@@ -1,40 +1,44 @@
 ﻿namespace Altinn.Notifications.Core.Models.Notification;
 
 /// <summary>
-/// A class represednting a notification result
+/// Represents the result of the notification send operation.
 /// </summary>
+/// <typeparam name="TEnum">The type of the enumeration used to represent the notification send status.</typeparam>
 public class NotificationResult<TEnum>
     where TEnum : struct, Enum
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="NotificationResult{TEnum}"/> class.
     /// </summary>
+    /// <param name="result">The result of the notification send operation.</param>
+    /// <param name="resultTime">The date and time when the result was set.</param>
     public NotificationResult(TEnum result, DateTime resultTime)
     {
-        ResultTime = resultTime;
         Result = result;
+        ResultTime = resultTime;
     }
 
     /// <summary>
-    /// Sets the result description
-    /// </summary>
-    public void SetResultDescription(string? description)
-    {
-        ResultDescription = description;
-    }
-
-    /// <summary>
-    /// Gets the date and time for when the last result was set.
+    /// Gets the date and time when the result was set.
     /// </summary>
     public DateTime ResultTime { get; }
 
     /// <summary>
-    /// Gets the send result of the notification
+    /// Gets the result of the notification send operation.
     /// </summary>
     public TEnum Result { get; }
 
     /// <summary>
-    /// Gets the description of the send result
+    /// Gets the description of the send result.
     /// </summary>
     public string? ResultDescription { get; private set; }
+
+    /// <summary>
+    /// Sets the description of the send result.
+    /// </summary>
+    /// <param name="description">The description of the send result.</param>
+    public void SetResultDescription(string? description)
+    {
+        ResultDescription = description;
+    }
 }

--- a/src/Altinn.Notifications.Core/Models/Notification/SmsNotification.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/SmsNotification.cs
@@ -4,32 +4,33 @@ using Altinn.Notifications.Core.Models.Recipients;
 namespace Altinn.Notifications.Core.Models.Notification;
 
 /// <summary>
-/// Represents an SMS notification and implements the <see cref="INotification{SmsNotificationResultType}"/> interface.
+/// Represents an SMS notification that implements the <see cref="INotification{SmsNotificationResultType}"/> interface.
 /// </summary>
 public class SmsNotification : INotification<SmsNotificationResultType>
 {
     /// <summary>
-    /// Gets the unique identifier of the notification.
+    /// Gets the unique identifier of the SMS notification.
     /// </summary>
     public Guid Id { get; internal set; }
 
     /// <summary>
-    /// Gets the unique identifier of the order associated with the notification.
+    /// Gets the unique identifier of the order associated with this SMS notification.
     /// </summary>
     public Guid OrderId { get; internal set; }
 
     /// <summary>
-    /// Gets the date and time when the notification is requested to be sent.
+    /// Gets the date and time when the SMS notification is requested to be sent.
     /// </summary>
     public DateTime RequestedSendTime { get; internal set; }
 
     /// <summary>
-    /// Gets the channel through which the notification will be sent, which is always <see cref="NotificationChannel.Sms"/> for this class.
+    /// Gets the communication channel through which the SMS notification will be sent.
+    /// This is always <see cref="NotificationChannel.Sms"/>.
     /// </summary>
     public NotificationChannel NotificationChannel { get; } = NotificationChannel.Sms;
 
     /// <summary>
-    /// Gets the recipient of the SMS notification.
+    /// Gets the recipient information for the SMS notification.
     /// </summary>
     public SmsRecipient Recipient { get; internal set; } = new();
 

--- a/src/Altinn.Notifications.Core/Models/Notification/SmsNotification.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/SmsNotification.cs
@@ -4,27 +4,37 @@ using Altinn.Notifications.Core.Models.Recipients;
 namespace Altinn.Notifications.Core.Models.Notification;
 
 /// <summary>
-/// Class describing an sns notification and extends the <see cref="INotification{SmsNotificationResultType}"/>
+/// Represents an SMS notification and implements the <see cref="INotification{SmsNotificationResultType}"/> interface.
 /// </summary>
 public class SmsNotification : INotification<SmsNotificationResultType>
 {
-    /// <inheritdoc/>
+    /// <summary>
+    /// Gets the unique identifier of the notification.
+    /// </summary>
     public Guid Id { get; internal set; }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Gets the unique identifier of the order associated with the notification.
+    /// </summary>
     public Guid OrderId { get; internal set; }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Gets the date and time when the notification is requested to be sent.
+    /// </summary>
     public DateTime RequestedSendTime { get; internal set; }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Gets the channel through which the notification will be sent, which is always <see cref="NotificationChannel.Sms"/> for this class.
+    /// </summary>
     public NotificationChannel NotificationChannel { get; } = NotificationChannel.Sms;
 
     /// <summary>
-    /// Get the recipient of the notification
+    /// Gets the recipient of the SMS notification.
     /// </summary>
     public SmsRecipient Recipient { get; internal set; } = new();
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Gets the result of the SMS notification send operation.
+    /// </summary>
     public NotificationResult<SmsNotificationResultType> SendResult { get; internal set; } = new(SmsNotificationResultType.New, DateTime.UtcNow);
 }

--- a/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System.Text.Json;
+﻿using System.Text.Json;
 
 using Altinn.Notifications.Core.Enums;
 

--- a/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
@@ -5,48 +5,52 @@ using Altinn.Notifications.Core.Enums;
 namespace Altinn.Notifications.Core.Models.Notification;
 
 /// <summary>
-/// A class representing a sms send operation update object
-/// </summary>    
+/// Represents the result of an SMS send operation.
+/// </summary>
 public class SmsSendOperationResult
 {
     /// <summary>
-    /// The notification id
+    /// Gets or sets the unique identifier of the SMS notification.
     /// </summary>
-    public Guid NotificationId { get; set; }
+    public Guid Id { get; set; }
 
     /// <summary>
-    /// The reference to the delivery in sms gateway
+    /// Gets or sets the reference to the delivery in the SMS gateway.
     /// </summary>
     public string GatewayReference { get; set; } = string.Empty;
 
     /// <summary>
-    /// The sms send result
+    /// Gets or sets the result of the SMS send operation.
     /// </summary>
     public SmsNotificationResultType SendResult { get; set; }
 
     /// <summary>
-    /// Json serializes the <see cref="SmsSendOperationResult"/>
+    /// Serializes the <see cref="SmsSendOperationResult"/> object to a JSON string.
     /// </summary>
+    /// <returns>A JSON string representation of the <see cref="SmsSendOperationResult"/> object.</returns>
     public string Serialize()
     {
         return JsonSerializer.Serialize(this, JsonSerializerOptionsProvider.Options);
     }
 
     /// <summary>
-    /// Deserialize a json string into the <see cref="SmsSendOperationResult"/>
+    /// Deserializes a JSON string into an <see cref="SmsSendOperationResult"/> object.
     /// </summary>
+    /// <param name="serializedString">The JSON string to deserialize.</param>
+    /// <returns>An <see cref="SmsSendOperationResult"/> object.</returns>
     public static SmsSendOperationResult? Deserialize(string serializedString)
     {
-        return JsonSerializer.Deserialize<SmsSendOperationResult>(
-            serializedString, JsonSerializerOptionsProvider.Options);
+        return JsonSerializer.Deserialize<SmsSendOperationResult>(serializedString, JsonSerializerOptionsProvider.Options);
     }
 
     /// <summary>
-    /// Try to parse a json string into a<see cref="SmsSendOperationResult"/>
+    /// Tries to parse a JSON string into an <see cref="SmsSendOperationResult"/> object.
     /// </summary>
+    /// <param name="input">The JSON string to parse.</param>
+    /// <param name="value">When this method returns, contains the parsed <see cref="SmsSendOperationResult"/> object, if the parsing succeeded, or a new instance of <see cref="SmsSendOperationResult"/> if the parsing failed.</param>
+    /// <returns><c>true</c> if the JSON string was parsed successfully; otherwise, <c>false</c>.</returns>
     public static bool TryParse(string input, out SmsSendOperationResult value)
     {
-        SmsSendOperationResult? parsedOutput;
         value = new SmsSendOperationResult();
 
         if (string.IsNullOrEmpty(input))
@@ -56,14 +60,16 @@ public class SmsSendOperationResult
 
         try
         {
-            parsedOutput = Deserialize(input!);
-
-            value = parsedOutput!;
-            return value.NotificationId != Guid.Empty || value.GatewayReference != string.Empty;
+            var parsedOutput = Deserialize(input);
+            if (parsedOutput != null)
+            {
+                value = parsedOutput;
+                return value.Id != Guid.Empty || !string.IsNullOrEmpty(value.GatewayReference);
+            }
         }
         catch
         {
-            // try parse, we simply return false if fails
+            // Ignore exceptions and return false
         }
 
         return false;

--- a/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
@@ -12,7 +12,7 @@ public class SmsSendOperationResult
     /// <summary>
     /// The notification id
     /// </summary>
-    public Guid? NotificationId { get; set; }
+    public Guid NotificationId { get; set; }
 
     /// <summary>
     /// The reference to the delivery in sms gateway

--- a/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 
 using Altinn.Notifications.Core.Enums;
+using Microsoft.Extensions.Logging;
 
 namespace Altinn.Notifications.Core.Models.Notification;
 
@@ -47,24 +48,26 @@ public class SmsSendOperationResult
     /// Tries to parse a JSON string into an <see cref="SmsSendOperationResult"/> object.
     /// </summary>
     /// <param name="jsonString">The JSON string to parse.</param>
-    /// <param name="result">When this method returns, contains the parsed <see cref="SmsSendOperationResult"/> object, if the parsing succeeded, or a new instance of <see cref="SmsSendOperationResult"/> if the parsing failed.</param>
+    /// <param name="result">
+    /// When this method returns, contains the parsed <see cref="SmsSendOperationResult"/> object if the parsing succeeded; 
+    /// otherwise, a new instance of <see cref="SmsSendOperationResult"/>.
+    /// </param>
     /// <returns><c>true</c> if the JSON string was parsed successfully; otherwise, <c>false</c>.</returns>
     public static bool TryParse(string jsonString, out SmsSendOperationResult result)
     {
         result = new SmsSendOperationResult();
 
-        if (string.IsNullOrEmpty(jsonString))
+        if (string.IsNullOrWhiteSpace(jsonString))
         {
             return false;
         }
 
         try
         {
-            var parsedOutput = Deserialize(jsonString);
-            if (parsedOutput != null)
+            var parsedResult = Deserialize(jsonString);
+            if (parsedResult != null)
             {
-                result = parsedOutput;
-                return result.Id != Guid.Empty || !string.IsNullOrEmpty(result.GatewayReference);
+                result = parsedResult;
             }
         }
         catch
@@ -72,6 +75,6 @@ public class SmsSendOperationResult
             // Ignore exceptions and return false
         }
 
-        return false;
+        return result.Id != Guid.Empty;
     }
 }

--- a/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json;
 
 using Altinn.Notifications.Core.Enums;
-using Microsoft.Extensions.Logging;
 
 namespace Altinn.Notifications.Core.Models.Notification;
 

--- a/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
+++ b/src/Altinn.Notifications.Core/Models/Notification/SmsSendOperationResult.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+﻿#nullable enable
+
+using System.Text.Json;
 
 using Altinn.Notifications.Core.Enums;
 
@@ -17,7 +19,7 @@ public class SmsSendOperationResult
     /// <summary>
     /// Gets or sets the reference to the delivery in the SMS gateway.
     /// </summary>
-    public string GatewayReference { get; set; } = string.Empty;
+    public string? GatewayReference { get; set; } = null;
 
     /// <summary>
     /// Gets or sets the result of the SMS send operation.
@@ -46,25 +48,25 @@ public class SmsSendOperationResult
     /// <summary>
     /// Tries to parse a JSON string into an <see cref="SmsSendOperationResult"/> object.
     /// </summary>
-    /// <param name="input">The JSON string to parse.</param>
-    /// <param name="value">When this method returns, contains the parsed <see cref="SmsSendOperationResult"/> object, if the parsing succeeded, or a new instance of <see cref="SmsSendOperationResult"/> if the parsing failed.</param>
+    /// <param name="jsonString">The JSON string to parse.</param>
+    /// <param name="result">When this method returns, contains the parsed <see cref="SmsSendOperationResult"/> object, if the parsing succeeded, or a new instance of <see cref="SmsSendOperationResult"/> if the parsing failed.</param>
     /// <returns><c>true</c> if the JSON string was parsed successfully; otherwise, <c>false</c>.</returns>
-    public static bool TryParse(string input, out SmsSendOperationResult value)
+    public static bool TryParse(string jsonString, out SmsSendOperationResult result)
     {
-        value = new SmsSendOperationResult();
+        result = new SmsSendOperationResult();
 
-        if (string.IsNullOrEmpty(input))
+        if (string.IsNullOrEmpty(jsonString))
         {
             return false;
         }
 
         try
         {
-            var parsedOutput = Deserialize(input);
+            var parsedOutput = Deserialize(jsonString);
             if (parsedOutput != null)
             {
-                value = parsedOutput;
-                return value.Id != Guid.Empty || !string.IsNullOrEmpty(value.GatewayReference);
+                result = parsedOutput;
+                return result.Id != Guid.Empty || !string.IsNullOrEmpty(result.GatewayReference);
             }
         }
         catch

--- a/src/Altinn.Notifications.Core/Models/Recipients/SmsRecipient.cs
+++ b/src/Altinn.Notifications.Core/Models/Recipients/SmsRecipient.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Altinn.Notifications.Core.Models.Recipients;
 
 /// <summary>

--- a/src/Altinn.Notifications.Core/Models/Recipients/SmsRecipient.cs
+++ b/src/Altinn.Notifications.Core/Models/Recipients/SmsRecipient.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Altinn.Notifications.Core.Models.Recipients;
 
 /// <summary>

--- a/src/Altinn.Notifications.Core/Models/Sms.cs
+++ b/src/Altinn.Notifications.Core/Models/Sms.cs
@@ -3,7 +3,7 @@
 namespace Altinn.Notifications.Core.Models;
 
 /// <summary>
-/// Represents an SMS notification.
+/// Represents an SMS.
 /// </summary>
 public class Sms
 {
@@ -13,7 +13,7 @@ public class Sms
     public Guid Id { get; set; }
 
     /// <summary>
-    /// Gets or sets the sender of the SMS message.
+    /// Gets or sets the sender.
     /// </summary>
     /// <remarks>
     /// The sender can be a literal string or a phone number.
@@ -21,9 +21,9 @@ public class Sms
     public string Sender { get; set; }
 
     /// <summary>
-    /// Gets or sets the recipient of the SMS message.
+    /// Gets or sets the recipient phone number.
     /// </summary>
-    public string Recipient { get; set; }
+    public string RecipientNumber { get; set; }
 
     /// <summary>
     /// Gets or sets the content of the SMS message.
@@ -35,14 +35,14 @@ public class Sms
     /// </summary>
     /// <param name="id">The unique identifier of the SMS.</param>
     /// <param name="sender">The sender of the SMS message.</param>
-    /// <param name="recipient">The recipient of the SMS message.</param>
+    /// <param name="recipientNumber">The recipient of the SMS message.</param>
     /// <param name="message">The content of the SMS message.</param>
-    public Sms(Guid id, string sender, string recipient, string message)
+    public Sms(Guid id, string sender, string recipientNumber, string message)
     {
         Id = id;
         Sender = sender;
         Message = message;
-        Recipient = recipient;
+        RecipientNumber = recipientNumber;
     }
 
     /// <summary>

--- a/src/Altinn.Notifications.Core/Models/Sms.cs
+++ b/src/Altinn.Notifications.Core/Models/Sms.cs
@@ -3,20 +3,20 @@
 namespace Altinn.Notifications.Core.Models;
 
 /// <summary>
-/// Represents an SMS message.
+/// Represents an SMS notification.
 /// </summary>
 public class Sms
 {
     /// <summary>
-    /// Gets or sets the ID of the SMS.
+    /// Gets or sets the unique identifier of the SMS.
     /// </summary>
-    public Guid NotificationId { get; set; }
+    public Guid Id { get; set; }
 
     /// <summary>
     /// Gets or sets the sender of the SMS message.
     /// </summary>
     /// <remarks>
-    /// Can be a literal string or a phone number.
+    /// The sender can be a literal string or a phone number.
     /// </remarks>
     public string Sender { get; set; }
 
@@ -26,23 +26,23 @@ public class Sms
     public string Recipient { get; set; }
 
     /// <summary>
-    /// Gets or sets the contents of the SMS message.
+    /// Gets or sets the content of the SMS message.
     /// </summary>
     public string Message { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Sms"/> class with the specified parameters.
     /// </summary>
-    /// <param name="notificationId">The ID of the SMS.</param>
+    /// <param name="id">The unique identifier of the SMS.</param>
     /// <param name="sender">The sender of the SMS message.</param>
     /// <param name="recipient">The recipient of the SMS message.</param>
-    /// <param name="message">The contents of the SMS message.</param>
-    public Sms(Guid notificationId, string sender, string recipient, string message)
+    /// <param name="message">The content of the SMS message.</param>
+    public Sms(Guid id, string sender, string recipient, string message)
     {
-        NotificationId = notificationId;
-        Recipient = recipient;
+        Id = id;
         Sender = sender;
         Message = message;
+        Recipient = recipient;
     }
 
     /// <summary>

--- a/src/Altinn.Notifications.Core/Persistence/ISmsNotificationRepository.cs
+++ b/src/Altinn.Notifications.Core/Persistence/ISmsNotificationRepository.cs
@@ -15,9 +15,9 @@ public interface ISmsNotificationRepository
     /// </summary>
     /// <param name="notification">The SMS notification to be added.</param>
     /// <param name="expiry">The expiration date and time of the notification.</param>
-    /// <param name="smsCount">The number of SMS messages.</param>
+    /// <param name="count">The number of SMS messages.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    Task AddNotification(SmsNotification notification, DateTime expiry, int smsCount);
+    Task AddNotification(SmsNotification notification, DateTime expiry, int count);
 
     /// <summary>
     /// Retrieves all SMS notifications with a status 'New'.

--- a/src/Altinn.Notifications.Core/Persistence/ISmsNotificationRepository.cs
+++ b/src/Altinn.Notifications.Core/Persistence/ISmsNotificationRepository.cs
@@ -6,29 +6,38 @@ using Altinn.Notifications.Core.Models.Recipients;
 namespace Altinn.Notifications.Core.Persistence;
 
 /// <summary>
-/// Interface describing all repository operations related to an sms notification
+/// Defines the repository operations related to SMS notifications.
 /// </summary>
 public interface ISmsNotificationRepository
 {
     /// <summary>
-    /// Adds a new sms notification to the database
+    /// Adds a new SMS notification to the database.
     /// </summary>
-    public Task AddNotification(SmsNotification notification, DateTime expiry, int smsCount);
+    /// <param name="notification">The SMS notification to be added.</param>
+    /// <param name="expiry">The expiration date and time of the notification.</param>
+    /// <param name="smsCount">The number of SMS messages.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task AddNotification(SmsNotification notification, DateTime expiry, int smsCount);
 
     /// <summary>
-    /// Retrieves all sms notifications with status 'New'
+    /// Retrieves all SMS notifications with a status 'New'.
     /// </summary>
-    /// <returns>A list of sms</returns>
-    public Task<List<Sms>> GetNewNotifications();
+    /// <returns>A task that represents the asynchronous operation. The task result contains a list of new SMS notifications.</returns>
+    Task<List<Sms>> GetNewNotifications();
 
     /// <summary>
-    /// Retrieves all processed sms recipients for an order
+    /// Retrieves all processed SMS recipients for a specified order.
     /// </summary>
-    /// <returns>A list of sms recipients</returns>
-    public Task<List<SmsRecipient>> GetRecipients(Guid orderId);
+    /// <param name="orderId">The unique identifier of the order.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains a list of SMS recipients.</returns>
+    Task<List<SmsRecipient>> GetRecipients(Guid orderId);
 
     /// <summary>
-    /// Sets result status of an sms notification and update operation id
+    /// Updates the send status of an SMS notification and sets the operation identifier.
     /// </summary>
-    public Task UpdateSendStatus(Guid? notificationId, SmsNotificationResultType result, string? gatewayReference = null);
+    /// <param name="id">The unique identifier of the SMS notification.</param>
+    /// <param name="result">The result status of the SMS notification.</param>
+    /// <param name="gatewayReference">The gateway reference (optional).</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task UpdateSendStatus(Guid id, SmsNotificationResultType result, string? gatewayReference = null);
 }

--- a/src/Altinn.Notifications.Core/Services/Interfaces/ISmsNotificationService.cs
+++ b/src/Altinn.Notifications.Core/Services/Interfaces/ISmsNotificationService.cs
@@ -5,22 +5,32 @@ using Altinn.Notifications.Core.Models.Recipients;
 namespace Altinn.Notifications.Core.Services.Interfaces;
 
 /// <summary>
-/// Interface for SMS notification service
+/// Defines the contract for the SMS notification service.
 /// </summary>
 public interface ISmsNotificationService
 {
     /// <summary>
-    /// Creates a new SMS notification based on the provided orderId and recipient
+    /// Creates a new SMS notification based on the provided order identifier, requested send time, address points, and recipient details.
     /// </summary>
-    public Task CreateNotification(Guid orderId, DateTime requestedSendTime, List<SmsAddressPoint> smsAddresses, SmsRecipient smsRecipient, int smsCount, bool ignoreReservation = false);
+    /// <param name="orderId">The unique identifier of the order associated with the notification.</param>
+    /// <param name="requestedSendTime">The date and time when the notification is requested to be sent.</param>
+    /// <param name="addressPoints">A list of SMS address points containing the recipient's mobile numbers.</param>
+    /// <param name="recipient">The recipient details of the SMS notification.</param>
+    /// <param name="count">The number of SMS messages to be sent.</param>
+    /// <param name="ignoreReservation">A flag indicating whether to ignore the recipient's reservation status.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task CreateNotification(Guid orderId, DateTime requestedSendTime, List<SmsAddressPoint> addressPoints, SmsRecipient recipient, int count, bool ignoreReservation = false);
 
     /// <summary>
-    /// Starts the process of sending all ready SMS notifications
+    /// Initiates the process of sending all ready-to-send SMS notifications.
     /// </summary>
-    public Task SendNotifications();
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task SendNotifications();
 
     /// <summary>
-    /// Update send status for an SMS notification
+    /// Updates the send status of an SMS notification based on the provided send operation result.
     /// </summary>
-    public Task UpdateSendStatus(SmsSendOperationResult sendOperationResult);
+    /// <param name="sendOperationResult">The result of the SMS send operation, including the notification identifier and send result status.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task UpdateSendStatus(SmsSendOperationResult sendOperationResult);
 }

--- a/src/Altinn.Notifications.Persistence/Altinn.Notifications.Persistence.csproj
+++ b/src/Altinn.Notifications.Persistence/Altinn.Notifications.Persistence.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.2" />
     <PackageReference Include="Npgsql" Version="9.0.2" />
     <PackageReference Include="Npgsql.DependencyInjection" Version="9.0.2" />
     <PackageReference Include="Yuniql.AspNetCore" Version="1.2.25" />

--- a/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
@@ -117,6 +117,7 @@ public class SmsNotificationRepository : ISmsNotificationRepository
     }
 
     /// <inheritdoc/>
+    /// <exception cref="ArgumentException">Throws if the provided SMS identifier is empty.</exception>
     public async Task UpdateSendStatus(Guid id, SmsNotificationResultType result, string? gatewayReference = null)
     {
         if (id == Guid.Empty)

--- a/src/Altinn.Notifications/Altinn.Notifications.csproj
+++ b/src/Altinn.Notifications/Altinn.Notifications.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.Common.AccessToken" Version="4.5.5" />
+    <PackageReference Include="Altinn.Common.AccessToken" Version="5.0.0" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="JWTCookieAuthentication" Version="4.0.1" />
-    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
+    <PackageReference Include="JWTCookieAuthentication" Version="4.0.4" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.2" />

--- a/test/Altinn.Notifications.IntegrationTests/Altinn.Notifications.IntegrationTests.csproj
+++ b/test/Altinn.Notifications.IntegrationTests/Altinn.Notifications.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 	  <PackageReference Include="coverlet.collector" Version="6.0.4">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Integrations/TestingConsumers/SmsStatusConsumerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Integrations/TestingConsumers/SmsStatusConsumerTests.cs
@@ -31,7 +31,7 @@ public class SmsStatusConsumerTests : IAsyncLifetime
 
         SmsSendOperationResult sendOperationResult = new()
         {
-            NotificationId = notification.Id,
+            Id = notification.Id,
             SendResult = SmsNotificationResultType.Accepted,
             GatewayReference = Guid.NewGuid().ToString()
         };

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
@@ -188,4 +188,24 @@ public class SmsNotificationRepositoryTests : IAsyncLifetime
             }
         }
     }
+
+    [Fact]
+    public async Task UpdateSendStatus_WithEmptyGuid_ThrowsArgumentException()
+    {
+        // Arrange
+        SmsNotificationRepository repo = (SmsNotificationRepository)ServiceUtil
+            .GetServices([typeof(ISmsNotificationRepository)])
+            .First(i => i.GetType() == typeof(SmsNotificationRepository));
+
+        Guid emptyGuid = Guid.Empty;
+        SmsNotificationResultType resultType = SmsNotificationResultType.Failed;
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(async () =>
+        {
+            await repo.UpdateSendStatus(emptyGuid, resultType);
+        });
+
+        Assert.Equal("The provided SMS identifier is invalid.", exception.Message);
+    }
 }

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
@@ -138,40 +138,6 @@ public class SmsNotificationRepositoryTests : IAsyncLifetime
         Assert.Equal(1, actualCount);
     }
 
-    //[Fact]
-    //public async Task UpdateSendStatus_WithoutNotificationId_WithGatewayRef()
-    //{
-    //    // Arrange
-    //    (NotificationOrder order, SmsNotification smsNotification) = await PostgreUtil.PopulateDBWithOrderAndSmsNotification();
-    //    _orderIdsToDelete.Add(order.Id);
-
-    //    SmsNotificationRepository repo = (SmsNotificationRepository)ServiceUtil
-    //      .GetServices(new List<Type>() { typeof(ISmsNotificationRepository) })
-    //      .First(i => i.GetType() == typeof(SmsNotificationRepository));
-
-    //    string gatewayReference = Guid.NewGuid().ToString();
-
-    //    string setGateqwaySql = $@"Update notifications.smsnotifications 
-    //            SET gatewayreference = '{gatewayReference}'
-    //            WHERE alternateid = '{smsNotification.Id}'";
-
-    //    await PostgreUtil.RunSql(setGateqwaySql);
-
-    //    // Act
-    //    await repo.UpdateSendStatus(null, SmsNotificationResultType.Accepted, gatewayReference);
-
-    //    // Assert
-    //    string sql = $@"SELECT count(1) 
-    //          FROM notifications.smsnotifications sms
-    //          WHERE sms.alternateid = '{smsNotification.Id}'
-    //          AND sms.result = '{SmsNotificationResultType.Accepted}'
-    //          AND sms.gatewayreference = '{gatewayReference}'";
-
-    //    int actualCount = await PostgreUtil.RunSqlReturnOutput<int>(sql);
-
-    //    Assert.Equal(1, actualCount);
-    //}
-
     [Fact]
     public async Task UpdateSendStatus_WithNotificationId_WithoutGatewayRef()
     {

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
@@ -27,6 +27,11 @@ public class SmsNotificationRepositoryTests : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
+        if (_orderIdsToDelete.Count == 0)
+        {
+            return;
+        }
+
         string deleteSql = $@"DELETE from notifications.orders o where o.alternateid in ('{string.Join("','", _orderIdsToDelete)}')";
         await PostgreUtil.RunSql(deleteSql);
     }

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
@@ -83,7 +83,7 @@ public class SmsNotificationRepositoryTests : IAsyncLifetime
         List<Sms> smsToBeSent = await repo.GetNewNotifications();
 
         // Assert
-        Assert.Contains(smsToBeSent, s => s.NotificationId == smsNotification.Id);
+        Assert.Contains(smsToBeSent, s => s.Id == smsNotification.Id);
     }
 
     [Fact]

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
@@ -138,39 +138,39 @@ public class SmsNotificationRepositoryTests : IAsyncLifetime
         Assert.Equal(1, actualCount);
     }
 
-    [Fact]
-    public async Task UpdateSendStatus_WithoutNotificationId_WithGatewayRef()
-    {
-        // Arrange
-        (NotificationOrder order, SmsNotification smsNotification) = await PostgreUtil.PopulateDBWithOrderAndSmsNotification();
-        _orderIdsToDelete.Add(order.Id);
+    //[Fact]
+    //public async Task UpdateSendStatus_WithoutNotificationId_WithGatewayRef()
+    //{
+    //    // Arrange
+    //    (NotificationOrder order, SmsNotification smsNotification) = await PostgreUtil.PopulateDBWithOrderAndSmsNotification();
+    //    _orderIdsToDelete.Add(order.Id);
 
-        SmsNotificationRepository repo = (SmsNotificationRepository)ServiceUtil
-          .GetServices(new List<Type>() { typeof(ISmsNotificationRepository) })
-          .First(i => i.GetType() == typeof(SmsNotificationRepository));
+    //    SmsNotificationRepository repo = (SmsNotificationRepository)ServiceUtil
+    //      .GetServices(new List<Type>() { typeof(ISmsNotificationRepository) })
+    //      .First(i => i.GetType() == typeof(SmsNotificationRepository));
 
-        string gatewayReference = Guid.NewGuid().ToString();
+    //    string gatewayReference = Guid.NewGuid().ToString();
 
-        string setGateqwaySql = $@"Update notifications.smsnotifications 
-                SET gatewayreference = '{gatewayReference}'
-                WHERE alternateid = '{smsNotification.Id}'";
+    //    string setGateqwaySql = $@"Update notifications.smsnotifications 
+    //            SET gatewayreference = '{gatewayReference}'
+    //            WHERE alternateid = '{smsNotification.Id}'";
 
-        await PostgreUtil.RunSql(setGateqwaySql);
+    //    await PostgreUtil.RunSql(setGateqwaySql);
 
-        // Act
-        await repo.UpdateSendStatus(null, SmsNotificationResultType.Accepted, gatewayReference);
+    //    // Act
+    //    await repo.UpdateSendStatus(null, SmsNotificationResultType.Accepted, gatewayReference);
 
-        // Assert
-        string sql = $@"SELECT count(1) 
-              FROM notifications.smsnotifications sms
-              WHERE sms.alternateid = '{smsNotification.Id}'
-              AND sms.result = '{SmsNotificationResultType.Accepted}'
-              AND sms.gatewayreference = '{gatewayReference}'";
+    //    // Assert
+    //    string sql = $@"SELECT count(1) 
+    //          FROM notifications.smsnotifications sms
+    //          WHERE sms.alternateid = '{smsNotification.Id}'
+    //          AND sms.result = '{SmsNotificationResultType.Accepted}'
+    //          AND sms.gatewayreference = '{gatewayReference}'";
 
-        int actualCount = await PostgreUtil.RunSqlReturnOutput<int>(sql);
+    //    int actualCount = await PostgreUtil.RunSqlReturnOutput<int>(sql);
 
-        Assert.Equal(1, actualCount);
-    }
+    //    Assert.Equal(1, actualCount);
+    //}
 
     [Fact]
     public async Task UpdateSendStatus_WithNotificationId_WithoutGatewayRef()

--- a/test/Altinn.Notifications.Tests/Altinn.Notifications.Tests.csproj
+++ b/test/Altinn.Notifications.Tests/Altinn.Notifications.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="RandomString4Net" Version="1.9.0" />
-    <PackageReference Include="FluentAssertions" Version="7.1.0" />
+    <PackageReference Include="FluentAssertions" Version="8.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
@@ -13,7 +13,7 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
         public void TryParse_ValidInput_ReturnsTrue()
         {
             // Arrange
-            string input = "{\"Id\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\",\"GatewayReference\":\"123456789\",\"SendResult\":3}";
+            string input = "{\"id\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\",\"gatewayReference\":\"123456789\",\"sendResult\":3}";
 
             // Act
             bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
@@ -30,7 +30,7 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
         public void TryParse_InvalidInput_ReturnsFalse()
         {
             // Arrange
-            string input = "{\"InvalidJson\":\"value\"}";
+            string input = "{\"invalidJson\":\"value\"}";
 
             // Act
             bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
@@ -64,7 +64,7 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
         public void TryParse_NullIdAndEmptyGatewayReference_ReturnsFalse()
         {
             // Arrange
-            string input = "{\"Id\":\"00000000-0000-0000-0000-000000000000\",\"GatewayReference\":\"\",\"SendResult\":3}";
+            string input = "{\"id\":\"00000000-0000-0000-0000-000000000000\",\"gatewayReference\":\"\",\"sendResult\":3}";
 
             // Act
             bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
@@ -101,7 +101,7 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
         public void Deserialize_ValidJsonString_ReturnsObject()
         {
             // Arrange
-            string jsonString = "{\"Id\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\",\"GatewayReference\":\"123456789\",\"SendResult\":2}";
+            string jsonString = "{\"id\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\",\"gatewayReference\":\"123456789\",\"sendResult\":2}";
 
             // Act
             var result = SmsSendOperationResult.Deserialize(jsonString);

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
@@ -61,10 +61,10 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
         }
 
         [Fact]
-        public void TryParse_NullIdAndEmptyGatewayReference_ReturnsFalse()
+        public void TryParse_NullIdWithGatewayReference_ReturnsFalse()
         {
             // Arrange
-            string input = "{\"id\":\"00000000-0000-0000-0000-000000000000\",\"gatewayReference\":\"\",\"sendResult\":3}";
+            string input = "{\"id\":\"00000000-0000-0000-0000-000000000000\",\"gatewayReference\":\"123456789\",\"sendResult\":3}";
 
             // Act
             bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
@@ -73,7 +73,7 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
             Assert.False(result);
             Assert.NotNull(parsedResult);
             Assert.Equal(Guid.Empty, parsedResult.Id);
-            Assert.Equal(string.Empty, parsedResult.GatewayReference);
+            Assert.Equal("123456789", parsedResult.GatewayReference);
             Assert.Equal(SmsNotificationResultType.Delivered, parsedResult.SendResult);
         }
 

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
@@ -27,22 +27,6 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
         }
 
         [Fact]
-        public void TryParse_ValidInput_NoNotificationId_ReturnsTrue()
-        {
-            // Arrange
-            string input = "{\"GatewayReference\":\"123456789\",\"SendResult\":3}";
-
-            // Act
-            bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
-
-            // Assert
-            Assert.True(result);
-            Assert.NotNull(parsedResult);
-            Assert.Equal("123456789", parsedResult.GatewayReference);
-            Assert.Equal(SmsNotificationResultType.Delivered, parsedResult.SendResult);
-        }
-
-        [Fact]
         public void TryParse_InvalidInput_ReturnsFalse()
         {
             // Arrange
@@ -74,6 +58,23 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
             Assert.Equal(Guid.Empty, parsedResult.Id);
             Assert.Null(parsedResult.GatewayReference);
             Assert.Equal(SmsNotificationResultType.New, parsedResult.SendResult);
+        }
+
+        [Fact]
+        public void TryParse_NullIdAndEmptyGatewayReference_ReturnsFalse()
+        {
+            // Arrange
+            string input = "{\"Id\":\"00000000-0000-0000-0000-000000000000\",\"GatewayReference\":\"\",\"SendResult\":3}";
+
+            // Act
+            bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(parsedResult);
+            Assert.Equal(Guid.Empty, parsedResult.Id);
+            Assert.Equal(string.Empty, parsedResult.GatewayReference);
+            Assert.Equal(SmsNotificationResultType.Delivered, parsedResult.SendResult);
         }
 
         [Fact]

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
@@ -5,112 +5,110 @@ using Altinn.Notifications.Core.Models.Notification;
 
 using Xunit;
 
-namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
+namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels;
+
+public class SmsSendOperationResultTests
 {
-    public class SmsSendOperationResultTests
+    [Fact]
+    public void TryParse_EmptyInput_ReturnsFalse()
     {
-        [Fact]
-        public void TryParse_ValidInput_ReturnsTrue()
-        {
-            // Arrange
-            string input = "{\"id\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\",\"gatewayReference\":\"123456789\",\"sendResult\":3}";
+        // Arrange
+        string input = string.Empty;
 
-            // Act
-            bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
+        // Act
+        bool parseResult = SmsSendOperationResult.TryParse(input, out SmsSendOperationResult result);
 
-            // Assert
-            Assert.True(result);
-            Assert.NotNull(parsedResult);
-            Assert.Equal("123456789", parsedResult.GatewayReference);
-            Assert.Equal(SmsNotificationResultType.Delivered, parsedResult.SendResult);
-            Assert.Equal(Guid.Parse("d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b"), parsedResult.Id);
-        }
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(parseResult);
+        Assert.Equal(Guid.Empty, result.Id);
+        Assert.Null(result.GatewayReference);
+        Assert.Equal(SmsNotificationResultType.New, result.SendResult);
+    }
 
-        [Fact]
-        public void TryParse_InvalidInput_ReturnsFalse()
-        {
-            // Arrange
-            string input = "{\"invalidJson\":\"value\"}";
+    [Fact]
+    public void TryParse_WhitespaceInput_ReturnsFalse()
+    {
+        // Arrange
+        string input = " ";
 
-            // Act
-            bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
+        // Act
+        bool parseResult = SmsSendOperationResult.TryParse(input, out SmsSendOperationResult result);
 
-            // Assert
-            Assert.False(result);
-            Assert.NotNull(parsedResult);
-            Assert.Equal(Guid.Empty, parsedResult.Id);
-            Assert.Null(parsedResult.GatewayReference);
-            Assert.Equal(SmsNotificationResultType.New, parsedResult.SendResult);
-        }
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(parseResult);
+        Assert.Equal(Guid.Empty, result.Id);
+        Assert.Null(result.GatewayReference);
+        Assert.Equal(SmsNotificationResultType.New, result.SendResult);
+    }
 
-        [Fact]
-        public void TryParse_EmptyInput_ReturnsFalse()
-        {
-            // Arrange
-            string input = string.Empty;
+    [Fact]
+    public void TryParse_ValidInput_ReturnsTrue()
+    {
+        // Arrange
+        string input = "{\"id\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\",\"gatewayReference\":\"123456789\",\"sendResult\":3}";
 
-            // Act
-            bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
+        // Act
+        bool parseResult = SmsSendOperationResult.TryParse(input, out SmsSendOperationResult result);
 
-            // Assert
-            Assert.False(result);
-            Assert.NotNull(parsedResult);
-            Assert.Equal(Guid.Empty, parsedResult.Id);
-            Assert.Null(parsedResult.GatewayReference);
-            Assert.Equal(SmsNotificationResultType.New, parsedResult.SendResult);
-        }
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(parseResult);
+        Assert.Equal("123456789", result.GatewayReference);
+        Assert.Equal(SmsNotificationResultType.Delivered, result.SendResult);
+        Assert.Equal(Guid.Parse("d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b"), result.Id);
+    }
 
-        [Fact]
-        public void TryParse_NullIdWithGatewayReference_ReturnsFalse()
-        {
-            // Arrange
-            string input = "{\"id\":\"00000000-0000-0000-0000-000000000000\",\"gatewayReference\":\"123456789\",\"sendResult\":3}";
+    [Fact]
+    public void TryParse_InvalidJson_ReturnsFalse()
+    {
+        // Arrange
+        string input = "{\"invalidJson\":\"value\"}";
 
-            // Act
-            bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
+        // Act
+        bool parseResult = SmsSendOperationResult.TryParse(input, out SmsSendOperationResult result);
 
-            // Assert
-            Assert.False(result);
-            Assert.NotNull(parsedResult);
-            Assert.Equal(Guid.Empty, parsedResult.Id);
-            Assert.Equal("123456789", parsedResult.GatewayReference);
-            Assert.Equal(SmsNotificationResultType.Delivered, parsedResult.SendResult);
-        }
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(parseResult);
+        Assert.Equal(Guid.Empty, result.Id);
+        Assert.Null(result.GatewayReference);
+        Assert.Equal(SmsNotificationResultType.New, result.SendResult);
+    }
 
-        [Fact]
-        public void Serialize_ReturnsValidJsonString()
-        {
-            // Arrange
-            var smsSendOperationResult = new SmsSendOperationResult
-            {
-                GatewayReference = "123456789",
-                SendResult = SmsNotificationResultType.Delivered,
-                Id = Guid.Parse("d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b")
-            };
+    [Fact]
+    public void TryParse_NullIdWithGatewayReference_ReturnsFalse()
+    {
+        // Arrange
+        string input = "{\"id\":\"00000000-0000-0000-0000-000000000000\",\"gatewayReference\":\"123456789\",\"sendResult\":3}";
 
-            // Act
-            string jsonString = smsSendOperationResult.Serialize();
+        // Act
+        bool parseResult = SmsSendOperationResult.TryParse(input, out SmsSendOperationResult result);
 
-            // Assert
-            Assert.Contains("\"sendResult\":\"Delivered\"", jsonString);
-            Assert.Contains("\"gatewayReference\":\"123456789\"", jsonString);
-            Assert.Contains("\"id\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\"", jsonString);
-        }
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(parseResult);
+        Assert.Equal(Guid.Empty, result.Id);
+        Assert.Equal("123456789", result.GatewayReference);
+        Assert.Equal(SmsNotificationResultType.Delivered, result.SendResult);
+    }
 
-        [Fact]
-        public void Deserialize_ValidJsonString_ReturnsObject()
-        {
-            // Arrange
-            string jsonString = "{\"id\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\",\"gatewayReference\":\"123456789\",\"sendResult\":2}";
+    [Fact]
+    public void TryParse_MalformedJson_ReturnsFalse()
+    {
+        // Arrange
+        string input = "{";
 
-            // Act
-            var result = SmsSendOperationResult.Deserialize(jsonString);
+        // Act
+        bool parseResult = SmsSendOperationResult.TryParse(input, out SmsSendOperationResult result);
 
-            // Assert
-            Assert.NotNull(result);
-            Assert.Equal("123456789", result.GatewayReference);
-            Assert.Equal(SmsNotificationResultType.Accepted, result.SendResult);
-            Assert.Equal(Guid.Parse("d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b"), result.Id);
-        }
+        // Assert
+        // Exception is caught, so TryParse returns false and result is a new instance with default values.
+        Assert.NotNull(result);
+        Assert.False(parseResult);
+        Assert.Equal(Guid.Empty, result.Id);
+        Assert.Null(result.GatewayReference);
+        Assert.Equal(SmsNotificationResultType.New, result.SendResult);
     }
 }

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
@@ -111,4 +111,40 @@ public class SmsSendOperationResultTests
         Assert.Null(result.GatewayReference);
         Assert.Equal(SmsNotificationResultType.New, result.SendResult);
     }
+
+    [Fact]
+    public void Serialize_ReturnsValidJsonString()
+    {
+        // Arrange
+        var smsSendOperationResult = new SmsSendOperationResult
+        {
+            GatewayReference = "123456789",
+            SendResult = SmsNotificationResultType.Delivered,
+            Id = Guid.Parse("d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b")
+        };
+
+        // Act
+        string jsonString = smsSendOperationResult.Serialize();
+
+        // Assert
+        Assert.Contains("\"sendResult\":\"Delivered\"", jsonString);
+        Assert.Contains("\"gatewayReference\":\"123456789\"", jsonString);
+        Assert.Contains("\"id\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\"", jsonString);
+    }
+
+    [Fact]
+    public void Deserialize_ValidJsonString_ReturnsObject()
+    {
+        // Arrange
+        string jsonString = "{\"id\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\",\"gatewayReference\":\"123456789\",\"sendResult\":2}";
+
+        // Act
+        var result = SmsSendOperationResult.Deserialize(jsonString);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("123456789", result.GatewayReference);
+        Assert.Equal(SmsNotificationResultType.Accepted, result.SendResult);
+        Assert.Equal(Guid.Parse("d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b"), result.Id);
+    }
 }

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingModels/SmsSendOperationResultTests.cs
@@ -1,4 +1,7 @@
-﻿using Altinn.Notifications.Core.Models.Notification;
+﻿using System;
+
+using Altinn.Notifications.Core.Enums;
+using Altinn.Notifications.Core.Models.Notification;
 
 using Xunit;
 
@@ -10,26 +13,103 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingModels
         public void TryParse_ValidInput_ReturnsTrue()
         {
             // Arrange
-            string input = "{\"notificationId\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\",\"gatewayReference\":\"123456789\",\"sendResult\":1}";
+            string input = "{\"Id\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\",\"GatewayReference\":\"123456789\",\"SendResult\":3}";
 
             // Act
-            bool result = SmsSendOperationResult.TryParse(input, out _);
+            bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
 
             // Assert
             Assert.True(result);
+            Assert.NotNull(parsedResult);
+            Assert.Equal("123456789", parsedResult.GatewayReference);
+            Assert.Equal(SmsNotificationResultType.Delivered, parsedResult.SendResult);
+            Assert.Equal(Guid.Parse("d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b"), parsedResult.Id);
         }
 
         [Fact]
         public void TryParse_ValidInput_NoNotificationId_ReturnsTrue()
         {
             // Arrange
-            string input = "{\"gatewayReference\":\"123456789\",\"sendResult\":1}";
+            string input = "{\"GatewayReference\":\"123456789\",\"SendResult\":3}";
 
             // Act
-            bool result = SmsSendOperationResult.TryParse(input, out _);
+            bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
 
             // Assert
             Assert.True(result);
+            Assert.NotNull(parsedResult);
+            Assert.Equal("123456789", parsedResult.GatewayReference);
+            Assert.Equal(SmsNotificationResultType.Delivered, parsedResult.SendResult);
+        }
+
+        [Fact]
+        public void TryParse_InvalidInput_ReturnsFalse()
+        {
+            // Arrange
+            string input = "{\"InvalidJson\":\"value\"}";
+
+            // Act
+            bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(parsedResult);
+            Assert.Equal(Guid.Empty, parsedResult.Id);
+            Assert.Null(parsedResult.GatewayReference);
+            Assert.Equal(SmsNotificationResultType.New, parsedResult.SendResult);
+        }
+
+        [Fact]
+        public void TryParse_EmptyInput_ReturnsFalse()
+        {
+            // Arrange
+            string input = string.Empty;
+
+            // Act
+            bool result = SmsSendOperationResult.TryParse(input, out var parsedResult);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(parsedResult);
+            Assert.Equal(Guid.Empty, parsedResult.Id);
+            Assert.Null(parsedResult.GatewayReference);
+            Assert.Equal(SmsNotificationResultType.New, parsedResult.SendResult);
+        }
+
+        [Fact]
+        public void Serialize_ReturnsValidJsonString()
+        {
+            // Arrange
+            var smsSendOperationResult = new SmsSendOperationResult
+            {
+                GatewayReference = "123456789",
+                SendResult = SmsNotificationResultType.Delivered,
+                Id = Guid.Parse("d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b")
+            };
+
+            // Act
+            string jsonString = smsSendOperationResult.Serialize();
+
+            // Assert
+            Assert.Contains("\"sendResult\":\"Delivered\"", jsonString);
+            Assert.Contains("\"gatewayReference\":\"123456789\"", jsonString);
+            Assert.Contains("\"id\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\"", jsonString);
+        }
+
+        [Fact]
+        public void Deserialize_ValidJsonString_ReturnsObject()
+        {
+            // Arrange
+            string jsonString = "{\"Id\":\"d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b\",\"GatewayReference\":\"123456789\",\"SendResult\":2}";
+
+            // Act
+            var result = SmsSendOperationResult.Deserialize(jsonString);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("123456789", result.GatewayReference);
+            Assert.Equal(SmsNotificationResultType.Accepted, result.SendResult);
+            Assert.Equal(Guid.Parse("d3b3f3e3-3e3b-3b3b-3b3b-3b3b3b3b3b3b"), result.Id);
         }
     }
 }

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsNotificationServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsNotificationServiceTests.cs
@@ -234,19 +234,19 @@ public class SmsNotificationServiceTests
     public async Task UpdateSendStatus_SendResultDefined_Succeeded()
     {
         // Arrange
-        Guid notificationid = Guid.NewGuid();
+        Guid id = Guid.NewGuid();
         string gatewayReference = Guid.NewGuid().ToString();
 
         SmsSendOperationResult sendOperationResult = new()
         {
-            NotificationId = notificationid,
+            Id = id,
             SendResult = SmsNotificationResultType.Accepted,
             GatewayReference = gatewayReference
         };
 
         var repoMock = new Mock<ISmsNotificationRepository>();
         repoMock.Setup(r => r.UpdateSendStatus(
-            It.Is<Guid>(n => n == notificationid),
+            It.Is<Guid>(n => n == id),
             It.Is<SmsNotificationResultType>(e => e == SmsNotificationResultType.Accepted),
             It.Is<string>(s => s.Equals(gatewayReference))));
 


### PR DESCRIPTION
## Description
Remove the `or` operator that was used to update the SMS order status based on the gateway reference.

## Related Issue(s)
- #700 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
