### PR TITLE
Split a data update query into two separate queries

### DIFF
--- a/src/Altinn.Notifications.Core/Models/Sms.cs
+++ b/src/Altinn.Notifications.Core/Models/Sms.cs
@@ -10,7 +10,7 @@ public class Sms
     /// <summary>
     /// Gets or sets the unique identifier of the SMS.
     /// </summary>
-    public Guid Id { get; set; }
+    public Guid NotificationId { get; set; }
 
     /// <summary>
     /// Gets or sets the sender.
@@ -23,7 +23,7 @@ public class Sms
     /// <summary>
     /// Gets or sets the recipient phone number.
     /// </summary>
-    public string RecipientNumber { get; set; }
+    public string Recipient { get; set; }
 
     /// <summary>
     /// Gets or sets the content of the SMS message.
@@ -33,16 +33,16 @@ public class Sms
     /// <summary>
     /// Initializes a new instance of the <see cref="Sms"/> class with the specified parameters.
     /// </summary>
-    /// <param name="id">The unique identifier of the SMS.</param>
+    /// <param name="notificationId">The unique identifier of the SMS.</param>
     /// <param name="sender">The sender of the SMS message.</param>
-    /// <param name="recipientNumber">The recipient of the SMS message.</param>
+    /// <param name="recipient">The recipient of the SMS message.</param>
     /// <param name="message">The content of the SMS message.</param>
-    public Sms(Guid id, string sender, string recipientNumber, string message)
+    public Sms(Guid notificationId, string sender, string recipient, string message)
     {
-        Id = id;
         Sender = sender;
         Message = message;
-        RecipientNumber = recipientNumber;
+        Recipient = recipient;
+        NotificationId = notificationId;
     }
 
     /// <summary>

--- a/src/Altinn.Notifications.Core/Persistence/ISmsNotificationRepository.cs
+++ b/src/Altinn.Notifications.Core/Persistence/ISmsNotificationRepository.cs
@@ -20,7 +20,7 @@ public interface ISmsNotificationRepository
     Task AddNotification(SmsNotification notification, DateTime expiry, int count);
 
     /// <summary>
-    /// Retrieves all SMS notifications with a status 'New'.
+    /// Retrieves all SMS notifications that have the status 'New'.
     /// </summary>
     /// <returns>A task that represents the asynchronous operation. The task result contains a list of new SMS notifications.</returns>
     Task<List<Sms>> GetNewNotifications();

--- a/src/Altinn.Notifications.Core/Services/SmsNotificationService.cs
+++ b/src/Altinn.Notifications.Core/Services/SmsNotificationService.cs
@@ -71,7 +71,7 @@ public class SmsNotificationService : ISmsNotificationService
             bool success = await _producer.ProduceAsync(_smsQueueTopicName, sms.Serialize());
             if (!success)
             {
-                await _repository.UpdateSendStatus(sms.Id, SmsNotificationResultType.New);
+                await _repository.UpdateSendStatus(sms.NotificationId, SmsNotificationResultType.New);
             }
         }
     }

--- a/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
@@ -149,7 +149,7 @@ public class SmsNotificationRepository : ISmsNotificationRepository
     /// <param name="gatewayReference">The gateway reference (optional). If provided, it will be updated in the database.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     /// <exception cref="ArgumentException">Thrown when the provided SMS identifier is invalid.</exception>
-    public async Task UpdateSendStatusById(Guid id, SmsNotificationResultType result, string? gatewayReference = null)
+    private async Task UpdateSendStatusById(Guid id, SmsNotificationResultType result, string? gatewayReference = null)
     {
         if (id == Guid.Empty)
         {
@@ -173,7 +173,7 @@ public class SmsNotificationRepository : ISmsNotificationRepository
     /// <param name="result">The result status of sending the SMS notification.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     /// <exception cref="ArgumentException">Thrown when the provided gateway reference is invalid.</exception>
-    public async Task UpdateSendStatusByGatewayReference(string gatewayReference, SmsNotificationResultType result)
+    private async Task UpdateSendStatusByGatewayReference(string gatewayReference, SmsNotificationResultType result)
     {
         if (string.IsNullOrWhiteSpace(gatewayReference))
         {

--- a/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/SmsNotificationRepository.cs
@@ -21,15 +21,21 @@ public class SmsNotificationRepository : ISmsNotificationRepository
     private readonly NpgsqlDataSource _dataSource;
     private readonly TelemetryClient? _telemetryClient;
 
-    private const string _insertSmsNotificationSql = "call notifications.insertsmsnotification($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"; // (__orderid, _alternateid, _recipientorgno, _recipientnin, _mobilenumber, _customizedbody, _result, _smscount, _resulttime, _expirytime)
-    private const string _getSmsNotificationsSql = "select * from notifications.getsms_statusnew_updatestatus()";
-    private const string _getSmsRecipients = "select * from notifications.getsmsrecipients_v2($1)"; // (_orderid)
+    private const string _getNewSmsNotificationsSql = "select * from notifications.getsms_statusnew_updatestatus()";
+    private const string _getSmsNotificationRecipientsSql = "select * from notifications.getsmsrecipients_v2($1)"; // (_orderid)
+    private const string _insertNewSmsNotificationSql = "call notifications.insertsmsnotification($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"; // (__orderid, _alternateid, _recipientorgno, _recipientnin, _mobilenumber, _customizedbody, _result, _smscount, _resulttime, _expirytime)
 
-    private const string _updateSmsNotificationStatus =
+    private const string _updateSmsNotificationBasedOnGatewayReferenceSql =
+        @"UPDATE notifications.smsnotifications 
+            SET result = $1::smsnotificationresulttype, 
+                resulttime = now() 
+            WHERE gatewayreference = $2"; // (_result, _gatewayreference)
+
+    private const string _updateSmsNotificationBasedOnIdentifierSql =
         @"UPDATE notifications.smsnotifications 
             SET result = $1::smsnotificationresulttype, 
                 resulttime = now(), 
-                gatewayreference = $2
+                gatewayreference = $2 
             WHERE alternateid = $3"; // (_result, _gatewayreference, _alternateid)
 
     /// <summary>
@@ -46,7 +52,7 @@ public class SmsNotificationRepository : ISmsNotificationRepository
     /// <inheritdoc/>
     public async Task AddNotification(SmsNotification notification, DateTime expiry, int count)
     {
-        await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_insertSmsNotificationSql);
+        await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_insertNewSmsNotificationSql);
         using TelemetryTracker tracker = new(_telemetryClient, pgcom);
 
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notification.OrderId);
@@ -69,11 +75,11 @@ public class SmsNotificationRepository : ISmsNotificationRepository
     {
         List<SmsRecipient> recipients = [];
 
-        await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_getSmsRecipients);
+        await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_getSmsNotificationRecipientsSql);
         using TelemetryTracker tracker = new(_telemetryClient, pgcom);
 
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, orderId);
-        
+
         await using (NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync())
         {
             while (await reader.ReadAsync())
@@ -95,7 +101,7 @@ public class SmsNotificationRepository : ISmsNotificationRepository
     public async Task<List<Sms>> GetNewNotifications()
     {
         List<Sms> readyToSendSMS = [];
-        await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_getSmsNotificationsSql);
+        await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_getNewSmsNotificationsSql);
         using TelemetryTracker tracker = new(_telemetryClient, pgcom);
 
         await using (NpgsqlDataReader reader = await pgcom.ExecuteReaderAsync())
@@ -120,16 +126,54 @@ public class SmsNotificationRepository : ISmsNotificationRepository
     /// <exception cref="ArgumentException">Throws if the provided SMS identifier is empty.</exception>
     public async Task UpdateSendStatus(Guid id, SmsNotificationResultType result, string? gatewayReference = null)
     {
-        if (id == Guid.Empty)
+        if (id == Guid.Empty && string.IsNullOrWhiteSpace(gatewayReference))
         {
             throw new ArgumentException("The provided SMS identifier is invalid.");
         }
 
-        await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_updateSmsNotificationStatus);
+        if (id != Guid.Empty && !string.IsNullOrWhiteSpace(gatewayReference))
+        {
+            await UpdateSendStatusById(id, result, gatewayReference);
+        }
+        else if (id == Guid.Empty && !string.IsNullOrWhiteSpace(gatewayReference))
+        {
+            await UpdateSendStatusByGatewayReference(gatewayReference, result);
+        }
+    }
+
+    /// <summary>
+    /// Updates the send status of an SMS notification based on its identifier and sets the operation identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the SMS notification.</param>
+    /// <param name="result">The result status of the SMS notification.</param>
+    /// <param name="gatewayReference">The gateway reference (optional).</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <exception cref="ArgumentException">Throws if the provided SMS identifier is empty.</exception>
+    public async Task UpdateSendStatusById(Guid id, SmsNotificationResultType result, string? gatewayReference = null)
+    {
+        await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_updateSmsNotificationBasedOnIdentifierSql);
         using TelemetryTracker tracker = new(_telemetryClient, pgcom);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, result.ToString());
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, string.IsNullOrWhiteSpace(gatewayReference) ? DBNull.Value : gatewayReference);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, id);
+
+        await pgcom.ExecuteNonQueryAsync();
+        tracker.Track();
+    }
+
+    /// <summary>
+    /// Updates the send status of an SMS notification based on its gateway reference.
+    /// </summary>
+    /// <param name="gatewayReference">The gateway reference of the SMS notification.</param>
+    /// <param name="result">The result status of the SMS notification.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <exception cref="ArgumentException">Throws if the provided gateway reference is empty.</exception>
+    public async Task UpdateSendStatusByGatewayReference(string gatewayReference, SmsNotificationResultType result)
+    {
+        await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_updateSmsNotificationBasedOnGatewayReferenceSql);
+        using TelemetryTracker tracker = new(_telemetryClient, pgcom);
+        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, result.ToString());
+        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, gatewayReference);
 
         await pgcom.ExecuteNonQueryAsync();
         tracker.Track();

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
@@ -88,7 +88,7 @@ public class SmsNotificationRepositoryTests : IAsyncLifetime
         List<Sms> smsToBeSent = await repo.GetNewNotifications();
 
         // Assert
-        Assert.Contains(smsToBeSent, s => s.Id == smsNotification.Id);
+        Assert.Contains(smsToBeSent, s => s.NotificationId == smsNotification.Id);
     }
 
     [Fact]

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/SmsNotificationRepositoryTests.cs
@@ -213,4 +213,38 @@ public class SmsNotificationRepositoryTests : IAsyncLifetime
 
         Assert.Equal("The provided SMS identifier is invalid.", exception.Message);
     }
+
+    [Fact]
+    public async Task UpdateSendStatus_WithoutNotificationId_WithGatewayRef()
+    {
+        // Arrange
+        (NotificationOrder order, SmsNotification smsNotification) = await PostgreUtil.PopulateDBWithOrderAndSmsNotification();
+        _orderIdsToDelete.Add(order.Id);
+
+        SmsNotificationRepository repo = (SmsNotificationRepository)ServiceUtil
+          .GetServices(new List<Type>() { typeof(ISmsNotificationRepository) })
+          .First(i => i.GetType() == typeof(SmsNotificationRepository));
+
+        string gatewayReference = Guid.NewGuid().ToString();
+
+        string setGateqwaySql = $@"Update notifications.smsnotifications 
+                SET gatewayreference = '{gatewayReference}'
+                WHERE alternateid = '{smsNotification.Id}'";
+
+        await PostgreUtil.RunSql(setGateqwaySql);
+
+        // Act
+        await repo.UpdateSendStatus(Guid.Empty, SmsNotificationResultType.Accepted, gatewayReference);
+
+        // Assert
+        string sql = $@"SELECT count(1) 
+              FROM notifications.smsnotifications sms
+              WHERE sms.alternateid = '{smsNotification.Id}'
+              AND sms.result = '{SmsNotificationResultType.Accepted}'
+              AND sms.gatewayreference = '{gatewayReference}'";
+
+        int actualCount = await PostgreUtil.RunSqlReturnOutput<int>(sql);
+
+        Assert.Equal(1, actualCount);
+    }
 }


### PR DESCRIPTION
## Description
The previous Notifications API used an or operator to find out which row to update. This query is divide into two quires to make sure we update the data when we have valid identifier.

## Related Issue(s)
- #700 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
