### PR TITLE
Add security def and requirement to swaggergen-options

### DIFF
--- a/src/Altinn.Notifications/Controllers/OrdersController.cs
+++ b/src/Altinn.Notifications/Controllers/OrdersController.cs
@@ -24,7 +24,6 @@ namespace Altinn.Notifications.Controllers;
 /// </summary>
 [Route("notifications/api/v1/orders")]
 [ApiController]
-[Authorize(Policy = AuthorizationConstants.POLICY_CREATE_SCOPE_OR_PLATFORM_ACCESS)]
 [SwaggerResponse(401, "Caller is unauthorized")]
 [SwaggerResponse(403, "Caller is not authorized to access the requested resource")]
 public class OrdersController : ControllerBase

--- a/src/Altinn.Notifications/Controllers/OrdersController.cs
+++ b/src/Altinn.Notifications/Controllers/OrdersController.cs
@@ -24,6 +24,7 @@ namespace Altinn.Notifications.Controllers;
 /// </summary>
 [Route("notifications/api/v1/orders")]
 [ApiController]
+[Authorize(Policy = AuthorizationConstants.POLICY_CREATE_SCOPE_OR_PLATFORM_ACCESS)]
 [SwaggerResponse(401, "Caller is unauthorized")]
 [SwaggerResponse(403, "Caller is not authorized to access the requested resource")]
 public class OrdersController : ControllerBase

--- a/src/Altinn.Notifications/Controllers/SmsNotificationOrdersController.cs
+++ b/src/Altinn.Notifications/Controllers/SmsNotificationOrdersController.cs
@@ -43,7 +43,7 @@ public class SmsNotificationOrdersController : ControllerBase
     /// Add an SMS notification order.
     /// </summary>
     /// <remarks>
-    /// The API will accept the request after som basic validation of the request.
+    /// The API will accept the request after some basic validation of the request.
     /// The system will also attempt to verify that it will be possible to fulfill the order.
     /// </remarks>
     /// <returns>The notification order request response</returns>

--- a/src/Altinn.Notifications/Program.cs
+++ b/src/Altinn.Notifications/Program.cs
@@ -69,7 +69,7 @@ builder.Services.AddSwaggerGen(options =>
             {
                 Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "bearerAuth" }
             },
-            new string[] { }
+            Array.Empty<string>()
         }
     });
     IncludeXmlComments(options);

--- a/src/Altinn.Notifications/Program.cs
+++ b/src/Altinn.Notifications/Program.cs
@@ -91,7 +91,7 @@ app.MapHealthChecks("/health");
 
 app.UseOrgExtractor();
 
-app.Run();
+await app.RunAsync();
 
 void ConfigureWebHostCreationLogging()
 {

--- a/src/Altinn.Notifications/Program.cs
+++ b/src/Altinn.Notifications/Program.cs
@@ -28,6 +28,7 @@ using FluentValidation;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -52,11 +53,28 @@ ConfigureApplicationLogging(builder.Logging);
 ConfigureServices(builder.Services, builder.Configuration);
 
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(c =>
+builder.Services.AddSwaggerGen(options =>
 {
-    IncludeXmlComments(c);
-    c.EnableAnnotations();
-    c.OperationFilter<AddResponseHeadersFilter>();
+    options.AddSecurityDefinition("bearerAuth", new OpenApiSecurityScheme
+    {
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT",
+        Description = "JWT Authorization header using the Bearer scheme."
+    });
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "bearerAuth" }
+            },
+            new string[] { }
+        }
+    });
+    IncludeXmlComments(options);
+    options.EnableAnnotations();
+    options.OperationFilter<AddResponseHeadersFilter>();
 });
 
 var app = builder.Build();

--- a/src/Altinn.Notifications/Program.cs
+++ b/src/Altinn.Notifications/Program.cs
@@ -55,22 +55,15 @@ ConfigureServices(builder.Services, builder.Configuration);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {
-    options.AddSecurityDefinition("bearerAuth", new OpenApiSecurityScheme
+    bool includeUnauthorizedAndForbiddenResponses = true; 
+    string bearerSecuritySchemaName = "bearerAuth";
+    options.OperationFilter<SecurityRequirementsOperationFilter>(includeUnauthorizedAndForbiddenResponses, bearerSecuritySchemaName);
+    options.AddSecurityDefinition(bearerSecuritySchemaName, new OpenApiSecurityScheme
     {
         Type = SecuritySchemeType.Http,
         Scheme = "bearer",
         BearerFormat = "JWT",
         Description = "JWT Authorization header using the Bearer scheme."
-    });
-    options.AddSecurityRequirement(new OpenApiSecurityRequirement
-    {
-        {
-            new OpenApiSecurityScheme
-            {
-                Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "bearerAuth" }
-            },
-            Array.Empty<string>()
-        }
     });
     IncludeXmlComments(options);
     options.EnableAnnotations();


### PR DESCRIPTION
## Description
Adds a definition of the Bearer authentication `security` scheme to the OpenAPI document, and applies it on the operation level. That is, each endpoint (that has an `[Authorize(..)]` tag in action/controller) gets marked with a `security` attribute in the Swagger doc, indicating how that endpoint is protected.
This is implemented by extending the SwaggerGen options in application startup (Program.cs), through the addition of the (bearer) security definition and the `OperationFilter<SecurityRequirementsOperationFilter>`.


## Related Issue(s)
- [#168](https://github.com/orgs/Altinn/projects/20/views/11?pane=issue&itemId=98905829&issue=Altinn%7Cteam-core-private%7C168) (team-core-private)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
