### PR TITLE
Restore the Required attribute

### DIFF
--- a/src/Altinn.Notifications/Models/NotificationOrderRequestBaseExt.cs
+++ b/src/Altinn.Notifications/Models/NotificationOrderRequestBaseExt.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 
@@ -10,6 +11,7 @@ public class NotificationOrderRequestBaseExt : NotificationOrderBaseExt
     /// <summary>
     /// Gets or sets the list of recipients.
     /// </summary>
+    [Required]
     [JsonPropertyName("recipients")]
     public List<RecipientExt> Recipients { get; set; } = [];
 


### PR DESCRIPTION
## Description
Add the `[Required]` attribute for `Recipients` property in `NotificationOrderRequestExt`.

## Related Issue(s)
- #764 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
