### PR TITLE
Ignore the first response event in tracing

### DIFF
--- a/src/Altinn.Notifications.Persistence/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.Notifications.Persistence/Extensions/ServiceCollectionExtensions.cs
@@ -39,7 +39,8 @@ public static class ServiceCollectionExtensions
                    .ConfigureTracing(o => o
                        .ConfigureCommandSpanNameProvider(cmd => cmd.CommandText)
                        .ConfigureCommandFilter(cmd => true)
-                       .ConfigureCommandEnrichmentCallback(DbEnricher.Enrich)));
+                       .ConfigureCommandEnrichmentCallback(DbEnricher.Enrich)
+                       .EnableFirstResponseEvent(false)));
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
Filters out the Npgsql-spawned 'received-first-response' records in the trace log

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
