### PR TITLE
Ensure `ORDERID` field in the `ORDERSCHAIN` table uniquely identifies the order chain

### DIFF
--- a/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderChainRequest.cs
+++ b/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderChainRequest.cs
@@ -52,6 +52,14 @@ public class NotificationOrderChainRequest
     public Guid OrderId { get; private set; }
 
     /// <summary>
+    /// Gets the unique identifier for the entire notification order chain.
+    /// </summary>
+    /// <value>
+    /// A <see cref="Guid"/> representing the unique identifier of the notification order chain.
+    /// </value>
+    public Guid OrderChainId { get; private set; }
+
+    /// <summary>
     /// Gets the recipient information for this notification.
     /// </summary>
     /// <remarks>
@@ -93,6 +101,7 @@ public class NotificationOrderChainRequest
     public class NotificationOrderChainRequestBuilder
     {
         private Guid _orderId;
+        private Guid _orderChainId;
         private Uri? _conditionEndpoint;
         private string? _sendersReference;
         private Creator _creator = new(string.Empty);
@@ -103,11 +112,20 @@ public class NotificationOrderChainRequest
         private DialogportenIdentifiers? _dialogportenAssociation;
 
         /// <summary>
-        /// Sets the order ID for the notification request.
+        /// Sets the order identifier for the notification request.
         /// </summary>
         public NotificationOrderChainRequestBuilder SetOrderId(Guid orderId)
         {
             _orderId = orderId;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the order chain identifier for the notification request.
+        /// </summary>
+        public NotificationOrderChainRequestBuilder SetOrderChainId(Guid orderChainId)
+        {
+            _orderChainId = orderChainId;
             return this;
         }
 
@@ -193,6 +211,11 @@ public class NotificationOrderChainRequest
                 throw new InvalidOperationException("OrderId must be set.");
             }
 
+            if (_orderChainId == Guid.Empty)
+            {
+                throw new InvalidOperationException("OrderChainId must be set.");
+            }
+
             if (string.IsNullOrEmpty(_idempotencyId))
             {
                 throw new InvalidOperationException("IdempotencyId must be set.");
@@ -209,6 +232,7 @@ public class NotificationOrderChainRequest
                 Creator = _creator,
                 Reminders = _reminders,
                 Recipient = _recipient,
+                OrderChainId = _orderChainId,
                 IdempotencyId = _idempotencyId,
                 SendersReference = _sendersReference,
                 RequestedSendTime = _requestedSendTime,

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -98,7 +98,7 @@ public class OrderRequestService : IOrderRequestService
 
         if (savedOrders == null || savedOrders.Count == 0)
         {
-            throw new InvalidOperationException("Failed to create notification order chain.");
+            throw new InvalidOperationException("Failed to create the notification order chain.");
         }
 
         // Get the main order (first in the list)
@@ -222,6 +222,7 @@ public class OrderRequestService : IOrderRequestService
                 creator,
                 currentTime,
                 reminder.ConditionEndpoint);
+
             reminderOrders.Add(reminderOrder);
         }
 

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -107,7 +107,7 @@ public class OrderRequestService : IOrderRequestService
         // Create and return the response
         return new NotificationOrderChainResponse
         {
-            Id = savedMainOrder.Id,
+            Id = orderRequest.OrderChainId,
             CreationResult = new NotificationOrderChainReceipt
             {
                 ShipmentId = savedMainOrder.Id,

--- a/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
@@ -115,7 +115,7 @@ public class OrderRepository : IOrderRepository
         await using var transaction = await connection.BeginTransactionAsync();
         try
         {
-            await InsertOrderChain(orderRequest, mainNotificationOrder.Created, connection, transaction);
+            await InsertOrderChainAsync(orderRequest, mainNotificationOrder.Created, connection, transaction);
 
             long mainOrderId = await InsertOrder(mainNotificationOrder, connection, transaction);
 
@@ -311,15 +311,15 @@ public class OrderRepository : IOrderRepository
         }
     }
 
-    private static async Task InsertOrderChain(NotificationOrderChainRequest order, DateTime creationDateTime, NpgsqlConnection connection, NpgsqlTransaction transaction)
+    private static async Task InsertOrderChainAsync(NotificationOrderChainRequest orderchain, DateTime creationDateTime, NpgsqlConnection connection, NpgsqlTransaction transaction)
     {
-        await using NpgsqlCommand pgcom = new NpgsqlCommand(_insertorderchainSql, connection, transaction);
+        await using NpgsqlCommand pgcom = new(_insertorderchainSql, connection, transaction);
 
-        pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, order.OrderId);
-        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, order.IdempotencyId);
-        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, order.Creator.ShortName);
+        pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, orderchain.OrderChainId);
+        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, orderchain.IdempotencyId);
+        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, orderchain.Creator.ShortName);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.TimestampTz, creationDateTime);
-        pgcom.Parameters.AddWithValue(NpgsqlDbType.Jsonb, order);
+        pgcom.Parameters.AddWithValue(NpgsqlDbType.Jsonb, orderchain);
 
         await pgcom.ExecuteNonQueryAsync();
     }

--- a/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
+++ b/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
@@ -32,10 +32,8 @@ public static class NotificationOrderChainMapper
         var reminders = notificationOrderChainRequestExt.Reminders?
             .Select(reminder =>
             {
-                // Calculate the send time for each reminder.
                 var requestedSendTime = notificationOrderChainRequestExt.RequestedSendTime.AddDays(reminder.DelayDays).ToUniversalTime();
 
-                // Map the reminder with the calculated send time.
                 return reminder.MapToNotificationReminder(requestedSendTime);
             })
             .ToList();
@@ -44,6 +42,7 @@ public static class NotificationOrderChainMapper
 
         return new NotificationOrderChainRequest.NotificationOrderChainRequestBuilder()
             .SetOrderId(Guid.NewGuid())
+            .SetOrderChainId(Guid.NewGuid())
             .SetCreator(new Creator(creatorName))
             .SetIdempotencyId(notificationOrderChainRequestExt.IdempotencyId)
             .SetRecipient(recipient)
@@ -86,7 +85,7 @@ public static class NotificationOrderChainMapper
     /// <summary>
     /// Maps a <see cref="NotificationReminderExt"/> to a <see cref="NotificationReminder"/>.
     /// </summary>
-    /// <param name="notificationReminderExt">The extended notification reminder object to map from.</param>
+    /// <param name="notificationReminderExt">The external notification reminder object to map from.</param>
     /// <param name="requestedSendTime">The requested send time for the reminder.</param>
     /// <returns>A <see cref="NotificationReminder"/> object mapped from the provided notification reminder.</returns>
     private static NotificationReminder MapToNotificationReminder(this NotificationReminderExt notificationReminderExt, DateTime requestedSendTime)

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/NotificationOrderChainMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/NotificationOrderChainMapperTests.cs
@@ -54,7 +54,9 @@ public class NotificationOrderChainMapperTests
 
         // Verify NotificationOrderChainRequest properties
         Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal(creatorName, result.Creator.ShortName);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal("ref-AB12CD34", result.SendersReference);
         Assert.Equal("63404F51-2079-4598-BD23-8F4467590FB4", result.IdempotencyId);
         Assert.Equal(requestExt.RequestedSendTime.ToUniversalTime(), result.RequestedSendTime);
@@ -170,7 +172,9 @@ public class NotificationOrderChainMapperTests
 
         // Verify NotificationOrderChainRequest properties
         Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal(creatorName, result.Creator.ShortName);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal("ref-D1E4B80C", result.SendersReference);
         Assert.Equal(requestExt.ConditionEndpoint, result.ConditionEndpoint);
         Assert.Equal("16E1A61B-F544-420B-BB6E-B40D8815C59C", result.IdempotencyId);
@@ -198,6 +202,7 @@ public class NotificationOrderChainMapperTests
         Assert.Equal(3, firstReminder.DelayDays);
         Assert.NotEqual(Guid.Empty, firstReminder.OrderId);
         Assert.NotEqual(result.OrderId, firstReminder.OrderId);
+        Assert.NotEqual(result.OrderChainId, firstReminder.OrderId);
         Assert.Equal("12236E1A-C7D9-4334-8CEE-873DAA64467F", firstReminder.SendersReference);
         Assert.Equal(requestExt.Reminders[0].ConditionEndpoint, firstReminder.ConditionEndpoint);
 
@@ -221,10 +226,11 @@ public class NotificationOrderChainMapperTests
         // Verify NotificationReminder properties for second reminder
         var secondReminder = result.Reminders[1];
         Assert.Equal(5, secondReminder.DelayDays);
-        Assert.Equal("7B1A786D-4767-4113-8401-836D1D176BC2", secondReminder.SendersReference);
-        Assert.Equal(requestExt.Reminders[1].ConditionEndpoint, secondReminder.ConditionEndpoint);
         Assert.NotEqual(Guid.Empty, secondReminder.OrderId);
         Assert.NotEqual(result.OrderId, secondReminder.OrderId);
+        Assert.NotEqual(result.OrderChainId, secondReminder.OrderId);
+        Assert.Equal("7B1A786D-4767-4113-8401-836D1D176BC2", secondReminder.SendersReference);
+        Assert.Equal(requestExt.Reminders[1].ConditionEndpoint, secondReminder.ConditionEndpoint);
 
         // Verify DateTime properties for second reminder
         var expectedSecondReminderDeliveryTime = baseTime.AddDays(5).ToUniversalTime();
@@ -259,6 +265,7 @@ public class NotificationOrderChainMapperTests
             SendersReference = "ref-D1E4B80C",
             ConditionEndpoint = new Uri("https://vg.no/condition"),
             IdempotencyId = "EBEF8B94-3F8C-444E-BF94-6F6B1FA0417C",
+
             Recipient = new NotificationRecipientExt
             {
                 RecipientEmail = new RecipientEmailExt
@@ -285,7 +292,9 @@ public class NotificationOrderChainMapperTests
 
         // Verify NotificationOrderChainRequest properties
         Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal(creatorName, result.Creator.ShortName);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal("ref-D1E4B80C", result.SendersReference);
         Assert.Equal(requestTime.ToUniversalTime(), result.RequestedSendTime);
         Assert.Equal(new Uri("https://vg.no/condition"), result.ConditionEndpoint);
@@ -326,6 +335,7 @@ public class NotificationOrderChainMapperTests
             ConditionEndpoint = new Uri("https://vg.no/condition"),
             IdempotencyId = "2F3A4B5C-6D7E-8F9A-0B1C-2D3E4F5A6B7C",
             SendersReference = "CF537A1B-43E0-4917-9D61-83F28C8667C8",
+
             Recipient = new NotificationRecipientExt
             {
                 RecipientOrganization = new RecipientOrganizationExt
@@ -333,6 +343,7 @@ public class NotificationOrderChainMapperTests
                     OrgNumber = "910150804",
                     ResourceId = "urn:altinn:resource:7890",
                     ChannelSchema = NotificationChannelExt.Email,
+
                     EmailSettings = new EmailSendingOptionsExt
                     {
                         Body = "Organization email body",
@@ -352,7 +363,9 @@ public class NotificationOrderChainMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal(creatorName, result.Creator.ShortName);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal(requestExt.ConditionEndpoint, result.ConditionEndpoint);
         Assert.Equal("2F3A4B5C-6D7E-8F9A-0B1C-2D3E4F5A6B7C", result.IdempotencyId);
         Assert.Equal("CF537A1B-43E0-4917-9D61-83F28C8667C8", result.SendersReference);
@@ -398,6 +411,7 @@ public class NotificationOrderChainMapperTests
             SendersReference = "ref-4617F6FFBE7D",
             IdempotencyId = "G1H2I3J4-K5L6-M7N8-O9P0-Q1R2S3T4U5V6",
             ConditionEndpoint = new Uri("https://vg.no/condition"),
+
             Recipient = new NotificationRecipientExt
             {
                 RecipientOrganization = new RecipientOrganizationExt
@@ -415,6 +429,7 @@ public class NotificationOrderChainMapperTests
                         ContentType = EmailContentTypeExt.Plain,
                         SendingTimePolicy = SendingTimePolicyExt.Anytime
                     },
+
                     SmsSettings = new SmsSendingOptionsExt
                     {
                         Body = "Organization SMS body",
@@ -431,7 +446,9 @@ public class NotificationOrderChainMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal(creatorName, result.Creator.ShortName);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal("ref-4617F6FFBE7D", result.SendersReference);
         Assert.Equal(requestExt.ConditionEndpoint, result.ConditionEndpoint);
         Assert.Equal(requestTime.ToUniversalTime(), result.RequestedSendTime);
@@ -479,6 +496,7 @@ public class NotificationOrderChainMapperTests
             RequestedSendTime = baseTime,
             IdempotencyId = "7A8B9C0D-1E2F-3A4B-5C6D-7E8F9A0B1C2D",
             SendersReference = "4567890A-BCDE-F123-4567-89ABCDEF1234",
+
             Recipient = new NotificationRecipientExt
             {
                 RecipientOrganization = new RecipientOrganizationExt
@@ -569,6 +587,9 @@ public class NotificationOrderChainMapperTests
         Assert.NotNull(result);
 
         // Main order verification
+        Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal(baseTime.ToUniversalTime(), result.RequestedSendTime);
         Assert.Equal("4567890A-BCDE-F123-4567-89ABCDEF1234", result.SendersReference);
 
@@ -631,6 +652,7 @@ public class NotificationOrderChainMapperTests
         // Verify first reminder has a unique OrderId
         Assert.NotEqual(Guid.Empty, firstReminder.OrderId);
         Assert.NotEqual(result.OrderId, firstReminder.OrderId);
+        Assert.NotEqual(result.OrderChainId, firstReminder.OrderId);
 
         // Second reminder verification
         var secondReminder = result.Reminders[1];
@@ -663,6 +685,7 @@ public class NotificationOrderChainMapperTests
         // Verify reminder has a unique OrderId
         Assert.NotEqual(Guid.Empty, secondReminder.OrderId);
         Assert.NotEqual(result.OrderId, secondReminder.OrderId);
+        Assert.NotEqual(result.OrderChainId, secondReminder.OrderId);
 
         // Verify reminders have unique OrderIds
         Assert.NotEqual(firstReminder.OrderId, secondReminder.OrderId);
@@ -713,7 +736,9 @@ public class NotificationOrderChainMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal(creatorName, result.Creator.ShortName);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal("ref-4617F6FFBE7D", result.SendersReference);
         Assert.Equal(requestExt.ConditionEndpoint, result.ConditionEndpoint);
         Assert.Equal(requestTime.ToUniversalTime(), result.RequestedSendTime);
@@ -756,6 +781,7 @@ public class NotificationOrderChainMapperTests
         // Arrange
         var creatorName = "ttd";
         var baseTime = DateTime.UtcNow;
+
         var requestExt = new NotificationOrderChainRequestExt
         {
             RequestedSendTime = baseTime,
@@ -848,6 +874,8 @@ public class NotificationOrderChainMapperTests
 
         // Assert
         Assert.NotNull(result);
+        Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal("ref-F1E2D3C4B5A6", result.SendersReference);
         Assert.Equal(baseTime.ToUniversalTime(), result.RequestedSendTime);
 
@@ -925,8 +953,11 @@ public class NotificationOrderChainMapperTests
         Assert.Null(secondReminder.Recipient.RecipientOrganization.EmailSettings);
 
         // Verify OrderId uniqueness
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.NotEqual(result.OrderId, firstReminder.OrderId);
         Assert.NotEqual(result.OrderId, secondReminder.OrderId);
+        Assert.NotEqual(result.OrderChainId, firstReminder.OrderId);
+        Assert.NotEqual(result.OrderChainId, secondReminder.OrderId);
         Assert.NotEqual(firstReminder.OrderId, secondReminder.OrderId);
     }
 
@@ -965,7 +996,9 @@ public class NotificationOrderChainMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal(creatorName, result.Creator.ShortName);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal("ref-9B8D303243B6", result.SendersReference);
         Assert.Equal(requestExt.ConditionEndpoint, result.ConditionEndpoint);
         Assert.Equal("C1D2E3F4-G5H6-I7J8-K9L0-M1N2O3P4Q5R6", result.IdempotencyId);
@@ -1075,7 +1108,9 @@ public class NotificationOrderChainMapperTests
 
         // Verify NotificationOrderChainRequest properties
         Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal(creatorName, result.Creator.ShortName);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal("ref-D3C9BA54", result.SendersReference);
         Assert.Equal(baseTime.ToUniversalTime(), result.RequestedSendTime);
         Assert.Equal("F1E2D3C4-B5A6-9876-5432-1098ABCDEF01", result.IdempotencyId);
@@ -1100,6 +1135,7 @@ public class NotificationOrderChainMapperTests
         Assert.Equal(3, firstReminder.DelayDays);
         Assert.NotEqual(Guid.Empty, firstReminder.OrderId);
         Assert.NotEqual(result.OrderId, firstReminder.OrderId);
+        Assert.NotEqual(result.OrderChainId, firstReminder.OrderId);
         Assert.Equal("ref-reminder-A3BCFE4284D6", firstReminder.SendersReference);
         Assert.Equal(requestExt.Reminders[0].ConditionEndpoint, firstReminder.ConditionEndpoint);
 
@@ -1123,6 +1159,7 @@ public class NotificationOrderChainMapperTests
         Assert.Equal(7, secondReminder.DelayDays);
         Assert.NotEqual(Guid.Empty, secondReminder.OrderId);
         Assert.NotEqual(result.OrderId, secondReminder.OrderId);
+        Assert.NotEqual(result.OrderChainId, secondReminder.OrderId);
         Assert.Equal("ref-reminder-F2491E785C2D", secondReminder.SendersReference);
         Assert.Equal(requestExt.Reminders[1].ConditionEndpoint, secondReminder.ConditionEndpoint);
 
@@ -1180,7 +1217,9 @@ public class NotificationOrderChainMapperTests
 
         // Verify NotificationOrderChainRequest properties
         Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal(creatorName, result.Creator.ShortName);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal("ref-4617F6FFBE7D", result.SendersReference);
         Assert.Equal(requestExt.ConditionEndpoint, result.ConditionEndpoint);
         Assert.Equal(requestTime.ToUniversalTime(), result.RequestedSendTime);
@@ -1244,7 +1283,9 @@ public class NotificationOrderChainMapperTests
 
         // Verify other properties are correctly mapped
         Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal(creatorName, result.Creator.ShortName);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal("BC47D9EA-3CD5-48A6-B5B7-CF5B95D53F9B", result.IdempotencyId);
 
         // Verify Email recipient properties
@@ -1294,7 +1335,9 @@ public class NotificationOrderChainMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal(creatorName, result.Creator.ShortName);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal(requestExt.ConditionEndpoint, result.ConditionEndpoint);
         Assert.Equal("2F3A4B5C-6D7E-8F9A-0B1C-2D3E4F5A6B7C", result.IdempotencyId);
         Assert.Equal("CF537A1B-43E0-4917-9D61-83F28C8667C8", result.SendersReference);
@@ -1337,9 +1380,10 @@ public class NotificationOrderChainMapperTests
         var requestExt = new NotificationOrderChainRequestExt
         {
             RequestedSendTime = DateTime.UtcNow,
+            SendersReference = "ref-9B8D303243B6",
             ConditionEndpoint = new Uri("https://vg.no/condition"),
             IdempotencyId = "C1D2E3F4-G5H6-I7J8-K9L0-M1N2O3P4Q5R6",
-            SendersReference = "ref-9B8D303243B6",
+
             Recipient = new NotificationRecipientExt
             {
                 RecipientPerson = new RecipientPersonExt
@@ -1364,7 +1408,9 @@ public class NotificationOrderChainMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal(creatorName, result.Creator.ShortName);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal("ref-9B8D303243B6", result.SendersReference);
         Assert.Equal(requestExt.ConditionEndpoint, result.ConditionEndpoint);
         Assert.Equal("C1D2E3F4-G5H6-I7J8-K9L0-M1N2O3P4Q5R6", result.IdempotencyId);
@@ -1442,7 +1488,9 @@ public class NotificationOrderChainMapperTests
         // Assert
         Assert.NotNull(result);
         Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
         Assert.Equal(creatorName, result.Creator.ShortName);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal("ref-4617F6FFBE7D", result.SendersReference);
         Assert.Equal(requestExt.ConditionEndpoint, result.ConditionEndpoint);
         Assert.Equal(requestTime.ToUniversalTime(), result.RequestedSendTime);
@@ -1496,10 +1544,10 @@ public class NotificationOrderChainMapperTests
             {
                 RecipientPerson = new RecipientPersonExt
                 {
+                    IgnoreReservation = true,
                     NationalIdentityNumber = "18874198354",
                     ResourceId = "urn:altinn:resource:4321",
                     ChannelSchema = NotificationChannelExt.EmailPreferred,
-                    IgnoreReservation = true,
 
                     EmailSettings = new EmailSendingOptionsExt
                     {
@@ -1521,61 +1569,63 @@ public class NotificationOrderChainMapperTests
             Reminders =
             [
                 new NotificationReminderExt
-            {
-                DelayDays = 3,
-                Recipient = new NotificationRecipientExt
                 {
-                    RecipientPerson = new RecipientPersonExt
+                    DelayDays = 3,
+                    Recipient = new NotificationRecipientExt
                     {
-                        NationalIdentityNumber = "18874198354",
-                        ResourceId = "urn:altinn:resource:4321",
-                        ChannelSchema = NotificationChannelExt.EmailPreferred,
-                        IgnoreReservation = true,
-                        EmailSettings = new EmailSendingOptionsExt
+                        RecipientPerson = new RecipientPersonExt
                         {
-                            Body = "Reminder 1 person email body",
-                            Subject = "Reminder 1 person email subject",
-                            SenderName = "Reminder 1 person email sender",
-                            SenderEmailAddress = "reminder-person-sender@example.com",
-                            ContentType = EmailContentTypeExt.Html,
-                            SendingTimePolicy = SendingTimePolicyExt.Anytime
-                        },
-                        SmsSettings = new SmsSendingOptionsExt
-                        {
-                            Body = "Reminder 1 person SMS body",
-                            Sender = "Reminder 1 person SMS sender",
-                            SendingTimePolicy = SendingTimePolicyExt.Daytime
+                            IgnoreReservation = true,
+                            NationalIdentityNumber = "18874198354",
+                            ResourceId = "urn:altinn:resource:4321",
+                            ChannelSchema = NotificationChannelExt.EmailPreferred,
+
+                            EmailSettings = new EmailSendingOptionsExt
+                            {
+                                Body = "Reminder 1 person email body",
+                                Subject = "Reminder 1 person email subject",
+                                SenderName = "Reminder 1 person email sender",
+                                SenderEmailAddress = "reminder-person-sender@example.com",
+                                ContentType = EmailContentTypeExt.Html,
+                                SendingTimePolicy = SendingTimePolicyExt.Anytime
+                            },
+                            SmsSettings = new SmsSendingOptionsExt
+                            {
+                                Body = "Reminder 1 person SMS body",
+                                Sender = "Reminder 1 person SMS sender",
+                                SendingTimePolicy = SendingTimePolicyExt.Daytime
+                            }
                         }
-                    }
+                    },
+                    SendersReference = "ref-A1B2C3D4E5F6",
+                    ConditionEndpoint = new Uri("https://vg.no/first-reminder-condition")
                 },
-                SendersReference = "ref-A1B2C3D4E5F6",
-                ConditionEndpoint = new Uri("https://vg.no/first-reminder-condition")
-            },
-            new NotificationReminderExt
-            {
-                DelayDays = 7,
-                Recipient = new NotificationRecipientExt
+                new NotificationReminderExt
                 {
-                    RecipientPerson = new RecipientPersonExt
+                    DelayDays = 7,
+                    Recipient = new NotificationRecipientExt
                     {
-                        NationalIdentityNumber = "18874198354",
-                        ResourceId = "urn:altinn:resource:4321",
-                        ChannelSchema = NotificationChannelExt.Email,
-                        IgnoreReservation = false,
-                        EmailSettings = new EmailSendingOptionsExt
+                        RecipientPerson = new RecipientPersonExt
                         {
-                            Body = "Reminder 2 person email body",
-                            Subject = "Reminder 2 person email subject",
-                            SenderName = "Reminder 2 person email sender",
-                            SenderEmailAddress = "reminder2-person-sender@example.com",
-                            ContentType = EmailContentTypeExt.Plain,
-                            SendingTimePolicy = SendingTimePolicyExt.Anytime
+                            IgnoreReservation = false,
+                            NationalIdentityNumber = "18874198354",
+                            ResourceId = "urn:altinn:resource:4321",
+                            ChannelSchema = NotificationChannelExt.Email,
+
+                            EmailSettings = new EmailSendingOptionsExt
+                            {
+                                Body = "Reminder 2 person email body",
+                                Subject = "Reminder 2 person email subject",
+                                SenderName = "Reminder 2 person email sender",
+                                SenderEmailAddress = "reminder2-person-sender@example.com",
+                                ContentType = EmailContentTypeExt.Plain,
+                                SendingTimePolicy = SendingTimePolicyExt.Anytime
+                            }
                         }
-                    }
-                },
-                SendersReference = "ref-G1H2I3J4K5L6",
-                ConditionEndpoint = new Uri("https://vg.no/second-reminder-condition")
-            }
+                    },
+                    SendersReference = "ref-G1H2I3J4K5L6",
+                    ConditionEndpoint = new Uri("https://vg.no/second-reminder-condition")
+                }
             ]
         };
 
@@ -1584,15 +1634,18 @@ public class NotificationOrderChainMapperTests
 
         // Assert
         Assert.NotNull(result);
+        Assert.NotEqual(Guid.Empty, result.OrderId);
+        Assert.NotEqual(Guid.Empty, result.OrderChainId);
+        Assert.NotEqual(result.OrderId, result.OrderChainId);
         Assert.Equal("ref-F1E2D3C4B5A6", result.SendersReference);
         Assert.Equal(baseTime.ToUniversalTime(), result.RequestedSendTime);
 
         // Person recipient validation
         Assert.NotNull(result.Recipient.RecipientPerson);
+        Assert.True(result.Recipient.RecipientPerson.IgnoreReservation);
         Assert.Equal("18874198354", result.Recipient.RecipientPerson.NationalIdentityNumber);
         Assert.Equal("urn:altinn:resource:4321", result.Recipient.RecipientPerson.ResourceId);
         Assert.Equal(NotificationChannel.EmailPreferred, result.Recipient.RecipientPerson.ChannelSchema);
-        Assert.True(result.Recipient.RecipientPerson.IgnoreReservation);
 
         // Email settings validation for main notification
         Assert.NotNull(result.Recipient.RecipientPerson.EmailSettings);
@@ -1669,6 +1722,8 @@ public class NotificationOrderChainMapperTests
         // Verify OrderId uniqueness
         Assert.NotEqual(result.OrderId, firstReminder.OrderId);
         Assert.NotEqual(result.OrderId, secondReminder.OrderId);
+        Assert.NotEqual(result.OrderChainId, firstReminder.OrderId);
+        Assert.NotEqual(result.OrderChainId, secondReminder.OrderId);
         Assert.NotEqual(firstReminder.OrderId, secondReminder.OrderId);
     }
 
@@ -1727,6 +1782,7 @@ public class NotificationOrderChainMapperTests
         builder.SetRequestedSendTime(null);
         builder.SetOrderId(Guid.NewGuid());
         builder.SetCreator(new Creator("ttd"));
+        builder.SetOrderChainId(Guid.NewGuid());
         builder.SetIdempotencyId("E4DD3079FCAC");
 
         // Act
@@ -1742,13 +1798,58 @@ public class NotificationOrderChainMapperTests
     }
 
     [Fact]
-    public void Build_WithEmptyOrderId_ThrowsInvalidOperationException()
+    public void Build_WithEmptyOrderId_ThrowsArgumentException()
     {
         // Arrange
         var builder = new NotificationOrderChainRequest.NotificationOrderChainRequestBuilder()
-            .SetIdempotencyId("63404F51-2079-4598-BD23-8F4467590FB4")
+            .SetOrderId(Guid.Empty)
             .SetCreator(new Creator("ttd"))
-            .SetRecipient(new NotificationRecipient());
+            .SetOrderChainId(Guid.NewGuid())
+            .SetRecipient(new NotificationRecipient())
+            .SetIdempotencyId("63404F51-2079-4598-BD23-8F4467590FB4");
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+    }
+
+    [Fact]
+    public void Build_WithEmptyOrderChainId_ThrowsArgumentException()
+    {
+        // Arrange
+        var builder = new NotificationOrderChainRequest.NotificationOrderChainRequestBuilder()
+            .SetOrderId(Guid.NewGuid())
+            .SetOrderChainId(Guid.Empty)
+            .SetCreator(new Creator("ttd"))
+            .SetRecipient(new NotificationRecipient())
+            .SetIdempotencyId("63404F51-2079-4598-BD23-8F4467590FB4");
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+    }
+
+    [Fact]
+    public void Build_WithoutOrderId_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var builder = new NotificationOrderChainRequest.NotificationOrderChainRequestBuilder()
+            .SetCreator(new Creator("ttd"))
+            .SetOrderChainId(Guid.NewGuid())
+            .SetRecipient(new NotificationRecipient())
+            .SetIdempotencyId("63404F51-2079-4598-BD23-8F4467590FB4");
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+    }
+
+    [Fact]
+    public void Build_WithEmptyOrderChainId_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var builder = new NotificationOrderChainRequest.NotificationOrderChainRequestBuilder()
+            .SetOrderId(Guid.NewGuid())
+            .SetCreator(new Creator("ttd"))
+            .SetRecipient(new NotificationRecipient())
+            .SetIdempotencyId("63404F51-2079-4598-BD23-8F4467590FB4");
 
         // Act & Assert
         Assert.Throws<InvalidOperationException>(() => builder.Build());
@@ -1761,6 +1862,7 @@ public class NotificationOrderChainMapperTests
         var builder = new NotificationOrderChainRequest.NotificationOrderChainRequestBuilder()
             .SetOrderId(Guid.NewGuid())
             .SetCreator(new Creator("ttd"))
+            .SetOrderChainId(Guid.NewGuid())
             .SetRecipient(new NotificationRecipient());
 
         // Act & Assert
@@ -1773,8 +1875,9 @@ public class NotificationOrderChainMapperTests
         // Arrange
         var builder = new NotificationOrderChainRequest.NotificationOrderChainRequestBuilder()
             .SetOrderId(Guid.NewGuid())
-            .SetIdempotencyId("63404F51-2079-4598-BD23-8F4467590FB4")
-            .SetRecipient(new NotificationRecipient());
+            .SetOrderChainId(Guid.NewGuid())
+            .SetRecipient(new NotificationRecipient())
+            .SetIdempotencyId("63404F51-2079-4598-BD23-8F4467590FB4");
 
         // Act & Assert
         Assert.Throws<InvalidOperationException>(() => builder.Build());
@@ -1786,9 +1889,10 @@ public class NotificationOrderChainMapperTests
         // Arrange
         var builder = new NotificationOrderChainRequest.NotificationOrderChainRequestBuilder()
             .SetOrderId(Guid.NewGuid())
-            .SetIdempotencyId("63404F51-2079-4598-BD23-8F4467590FB4")
+            .SetOrderChainId(Guid.NewGuid())
             .SetCreator(new Creator(string.Empty))
-            .SetRecipient(new NotificationRecipient());
+            .SetRecipient(new NotificationRecipient())
+            .SetIdempotencyId("63404F51-2079-4598-BD23-8F4467590FB4");
 
         // Act & Assert
         Assert.Throws<InvalidOperationException>(() => builder.Build());


### PR DESCRIPTION
## Description
The `ORDERID` field in the `ORDERSCHAIN` table is currently pointing to the main notification row in the `ORDERS` table. This causes `notificationOrderId` and `shipmentId` in the API response to have the same value for the main notification, potentially leading to confusion.

## Related Issue(s)
- #768 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
