### PR TITLE
Return status code 201 upon successful creation

### DIFF
--- a/src/Altinn.Notifications/Controllers/FutureOrdersController.cs
+++ b/src/Altinn.Notifications/Controllers/FutureOrdersController.cs
@@ -81,7 +81,7 @@ public class FutureOrdersController : ControllerBase
             var notificationOrderChainRequest = notificationOrderRequest.MapToNotificationOrderChainRequest(creator);
             var registeredNotificationOrderChain = await _orderRequestService.RegisterNotificationOrderChain(notificationOrderChainRequest, cancellationToken);
 
-            return Accepted(registeredNotificationOrderChain.OrderChainId.GetSelfLinkFromOrderChainId(), registeredNotificationOrderChain.MapToNotificationOrderChainResponseExt());
+            return Created(registeredNotificationOrderChain.OrderChainId.GetSelfLinkFromOrderChainId(), registeredNotificationOrderChain.MapToNotificationOrderChainResponseExt());
         }
         catch (OperationCanceledException)
         {

--- a/src/Altinn.Notifications/Controllers/FutureOrdersController.cs
+++ b/src/Altinn.Notifications/Controllers/FutureOrdersController.cs
@@ -54,7 +54,6 @@ public class FutureOrdersController : ControllerBase
     [SwaggerResponse(400, "The notification order is invalid", typeof(ValidationProblemDetails))]
     [SwaggerResponse(422, "The notification order is invalid", typeof(ValidationProblemDetails))]
     [SwaggerResponse(499, "Request terminated - The client disconnected or cancelled the request before the server could complete processing")]
-    [SwaggerResponse(500, "An unexpected error occurred")]
     public async Task<ActionResult<NotificationOrderChainResponseExt>> Post(NotificationOrderChainRequestExt notificationOrderRequest, CancellationToken cancellationToken = default)
     {
         try
@@ -86,10 +85,6 @@ public class FutureOrdersController : ControllerBase
         catch (OperationCanceledException)
         {
             return StatusCode(499, "Request terminated - The client disconnected or cancelled the request before the server could complete processing");
-        }
-        catch (Exception)
-        {
-            return StatusCode(500, $"An unexpected error occurred");
         }
     }
 }

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/FutureOrdersController/FutureOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/FutureOrdersController/FutureOrdersControllerTests.cs
@@ -185,7 +185,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     }
 
     [Fact]
-    public async Task Post_OrganizationTokenWithCorrectScope_ReturnsAcceptedWithOrderDetails()
+    public async Task Post_OrganizationTokenWithCorrectScope_ReturnsCreateddWithOrderDetails()
     {
         // Arrange
         var requestExt = CreateValidRequest();
@@ -218,7 +218,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
         var responseObject = await DeserializeResponse(response);
 
         // Assert
-        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.NotNull(responseObject);
         Assert.Null(responseObject.OrderChainReceipt.Reminders);
         Assert.Equal(expectedResponse.OrderChainId, responseObject.OrderChainId);
@@ -228,7 +228,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     }
 
     [Fact]
-    public async Task Post_PlatformAccessTokenAuthentication_ReturnsAcceptedWithOrderDetails()
+    public async Task Post_PlatformAccessTokenAuthentication_ReturnsCreatedWithOrderDetails()
     {
         // Arrange
         var requestExt = CreateValidRequest();
@@ -264,7 +264,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
         var responseObject = await DeserializeResponse(response);
 
         // Assert
-        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.NotNull(responseObject);
         Assert.Null(responseObject.OrderChainReceipt.Reminders);
         Assert.Equal(expectedResponse.OrderChainId, responseObject.OrderChainId);
@@ -274,7 +274,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     }
 
     [Fact]
-    public async Task Post_ValidRequest_WithReminders_ReturnsAcceptedResponseWithReminderDetails()
+    public async Task Post_ValidRequest_WithReminders_ReturnsCreatedResponseWithReminderDetails()
     {
         // Arrange
         var requestExt = new NotificationOrderChainRequestExt
@@ -327,7 +327,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
         var responseObject = await DeserializeResponse(response);
 
         // Assert
-        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.NotNull(responseObject);
         Assert.Equal(expectedResponse.OrderChainId, responseObject.OrderChainId);
         Assert.NotNull(responseObject.OrderChainReceipt);
@@ -340,7 +340,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     }
 
     [Fact]
-    public async Task Post_ValidRequestUsingRecipientEmail_WithoutReminders_ReturnsAccepted()
+    public async Task Post_ValidRequestUsingRecipientEmail_WithoutReminders_ReturnsCreated()
     {
         // Arrange
         var requestExt = CreateValidRequest();
@@ -355,7 +355,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
         var responseObject = await DeserializeResponse(response);
 
         // Assert
-        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.NotNull(responseObject);
         Assert.Equal(expectedResponse.OrderChainId, responseObject.OrderChainId);
         Assert.NotNull(responseObject.OrderChainReceipt);
@@ -365,7 +365,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     }
 
     [Fact]
-    public async Task Post_ValidRequestUsingPersonRecipient_WithoutReminders_ReturnsAccepted()
+    public async Task Post_ValidRequestUsingPersonRecipient_WithoutReminders_ReturnsCreated()
     {
         // Arrange
         var requestExt = new NotificationOrderChainRequestExt
@@ -405,7 +405,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
         var responseObject = await DeserializeResponse(response);
 
         // Assert
-        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.NotNull(responseObject);
         Assert.Equal(expectedResponse.OrderChainId, responseObject.OrderChainId);
         Assert.NotNull(responseObject.OrderChainReceipt);
@@ -415,7 +415,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     }
 
     [Fact]
-    public async Task Post_ValidRequestUsingOrganizationRecipient_WithReminders_ReturnsAccepted()
+    public async Task Post_ValidRequestUsingOrganizationRecipient_WithReminders_ReturnsCreated()
     {
         // Arrange
         var requestExt = new NotificationOrderChainRequestExt
@@ -495,7 +495,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
         var responseObject = await DeserializeResponse(response);
 
         // Assert
-        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         Assert.NotNull(responseObject);
         Assert.Equal(expectedResponse.OrderChainId, responseObject.OrderChainId);
         Assert.NotNull(responseObject.OrderChainReceipt);
@@ -540,7 +540,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     }
 
     [Fact]
-    public async Task Post_ValidRequest_FirstTimeSubmission_ReturnsAcceptedWithSelfReferenceUrl()
+    public async Task Post_ValidRequest_FirstTimeSubmission_ReturnsCreatedWithSelfReferenceUrl()
     {
         // Arrange
         var request = CreateValidRequest();
@@ -567,9 +567,9 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
         var result = await controller.Post(request);
 
         // Assert
-        var acceptedResult = Assert.IsType<AcceptedResult>(result.Result);
-        Assert.Equal(expectedUrl, acceptedResult.Location);
-        var response = Assert.IsType<NotificationOrderChainResponseExt>(acceptedResult.Value);
+        var createdResult = Assert.IsType<CreatedResult>(result.Result);
+        Assert.Equal(expectedUrl, createdResult.Location);
+        var response = Assert.IsType<NotificationOrderChainResponseExt>(createdResult.Value);
         Assert.Equal(newResponse.OrderChainId, response.OrderChainId);
     }
 
@@ -603,35 +603,6 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     }
 
     [Fact]
-    public async Task Post_UnexpectedException_Returns500WithErrorMessage()
-    {
-        // Arrange
-        var request = CreateValidRequest();
-        var validatorMock = SetupValidValidator();
-        var orderServiceMock = new Mock<IOrderRequestService>();
-
-        orderServiceMock.Setup(s => s.RetrieveOrderChainTracking(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("Unexpected error"));
-
-        var httpContext = new DefaultHttpContext();
-        httpContext.Items["Org"] = "ttd";
-
-        var controller = new FutureOrdersController(orderServiceMock.Object, validatorMock.Object)
-        {
-            ControllerContext = new ControllerContext { HttpContext = httpContext }
-        };
-
-        // Act
-        var result = await controller.Post(request);
-
-        // Assert
-        var statusCodeResult = Assert.IsType<ObjectResult>(result.Result);
-        Assert.Equal(500, statusCodeResult.StatusCode);
-        Assert.NotNull(statusCodeResult.Value);
-        Assert.Contains("An unexpected error occurred", statusCodeResult.Value.ToString());
-    }
-
-    [Fact]
     public async Task Post_OperationCanceledDuringRegistration_Returns499Status()
     {
         // Arrange
@@ -661,35 +632,6 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
         Assert.Equal(499, statusCodeResult.StatusCode);
         Assert.NotNull(statusCodeResult.Value);
         Assert.Contains("Request terminated", statusCodeResult.Value.ToString());
-    }
-
-    [Fact]
-    public async Task Post_RetrieveThrowsException_Returns500Status()
-    {
-        // Arrange
-        var request = CreateValidRequest();
-        var validatorMock = SetupValidValidator();
-        var orderServiceMock = new Mock<IOrderRequestService>();
-
-        orderServiceMock.Setup(s => s.RetrieveOrderChainTracking(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("Database error"));
-
-        var httpContext = new DefaultHttpContext();
-        httpContext.Items["Org"] = "ttd";
-
-        var controller = new FutureOrdersController(orderServiceMock.Object, validatorMock.Object)
-        {
-            ControllerContext = new ControllerContext { HttpContext = httpContext }
-        };
-
-        // Act
-        var result = await controller.Post(request);
-
-        // Assert
-        var statusCodeResult = Assert.IsType<ObjectResult>(result.Result);
-        Assert.Equal(500, statusCodeResult.StatusCode);
-        Assert.NotNull(statusCodeResult.Value);
-        Assert.Contains("An unexpected error occurred", statusCodeResult.Value.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
## Description
The API should return a 201 status code upon successful creation and a 200 status code upon further attempts to create the same order.

## Related Issue(s)
- #777 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the notification order creation response to return a 201 Created status, ensuring a more accurate and consistent API behavior following successful operations. 
  - Removed general exception handling in the notification order creation process, which may affect how unexpected errors are reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->