### PR TITLE
Make the `sender` field optional

### DIFF
--- a/src/Altinn.Notifications.Core/Models/Recipients/SmsSendingOptions.cs
+++ b/src/Altinn.Notifications.Core/Models/Recipients/SmsSendingOptions.cs
@@ -13,7 +13,7 @@ public class SmsSendingOptions
     /// <remarks>
     /// Can be either a phone number or an alphanumeric sender identifier, subject to carrier and regional restrictions.
     /// </remarks>
-    public required string Sender { get; set; }
+    public string? Sender { get; set; }
 
     /// <summary>
     /// Gets or sets the text content of the SMS message.

--- a/src/Altinn.Notifications/Models/SmsSendingOptionsExt.cs
+++ b/src/Altinn.Notifications/Models/SmsSendingOptionsExt.cs
@@ -15,9 +15,8 @@ public class SmsSendingOptionsExt
     /// <remarks>
     /// Can be either a phone number or an alphanumeric sender identifier, subject to carrier and regional restrictions.
     /// </remarks>
-    [Required]
     [JsonPropertyName("sender")]
-    public required string Sender { get; set; }
+    public string? Sender { get; set; }
 
     /// <summary>
     /// Gets or sets the text content of the SMS message.


### PR DESCRIPTION
## Description
Make the `sender` field optional so that user can ignore setting the sender identifier displayed in the recipient's SMS message. 

## Related Issue(s)
- #790 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the SMS notification settings to make the sender field optional, enhancing configuration flexibility for SMS alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->