### PR TITLE
Hold the sending time policy used in the SMS settings

### DIFF
--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -429,7 +429,7 @@ public class OrderRequestService : IOrderRequestService
     /// <item><description>Channel - The determined notification channel based on recipient type</description></item>
     /// <item><description>IgnoreReservation - Flag indicating whether to bypass KRR reservations</description></item>
     /// <item><description>ResourceId - Optional resource ID for authorization and tracking</description></item>
-    /// <item><description>SendingTimePolicyForSms - The sendingTimePolicy associated with the selected SMS's configuration</description></item>
+    /// <item><description>SmsSendingTimePolicy - The sendingTimePolicy associated with the selected SMS's configuration</description></item>
     /// </list>
     /// </returns>
     /// <remarks>
@@ -437,7 +437,7 @@ public class OrderRequestService : IOrderRequestService
     /// the appropriate templates and addressing information based on the recipient's configuration.
     /// The default channel is SMS if the recipient type cannot be determined.
     /// </remarks>
-    private static (List<Recipient> Recipients, List<INotificationTemplate> Templates, NotificationChannel Channel, bool? IgnoreReservation, string? ResourceId, SendingTimePolicy? SendingTimePolicyForSms) ExtractDeliveryComponents(NotificationRecipient recipient)
+    private static (List<Recipient> Recipients, List<INotificationTemplate> Templates, NotificationChannel Channel, bool? IgnoreReservation, string? ResourceId, SendingTimePolicy? SmsSendingTimePolicy) ExtractDeliveryComponents(NotificationRecipient recipient)
     {
         bool? ignoreReservation = null;
         string? resourceIdentifier = null;
@@ -445,15 +445,14 @@ public class OrderRequestService : IOrderRequestService
         var recipients = new List<Recipient>();
         var templates = new List<INotificationTemplate>();
 
+        SendingTimePolicy? smsSendingTimePolicy = null;
         NotificationChannel notificationChannel = NotificationChannel.Sms;
-
-        SendingTimePolicy? sendingTimePolicyForSms = null;
 
         if (recipient.RecipientSms?.Settings != null)
         {
             notificationChannel = NotificationChannel.Sms;
 
-            sendingTimePolicyForSms = recipient.RecipientSms.Settings.SendingTimePolicy;
+            smsSendingTimePolicy = recipient.RecipientSms.Settings.SendingTimePolicy;
 
             templates.Add(CreateSmsTemplate(recipient.RecipientSms.Settings));
 
@@ -476,7 +475,7 @@ public class OrderRequestService : IOrderRequestService
             if (recipient.RecipientPerson.SmsSettings != null)
             {
                 templates.Add(CreateSmsTemplate(recipient.RecipientPerson.SmsSettings));
-                sendingTimePolicyForSms = recipient.RecipientPerson.SmsSettings.SendingTimePolicy;
+                smsSendingTimePolicy = recipient.RecipientPerson.SmsSettings.SendingTimePolicy;
             }
 
             if (recipient.RecipientPerson.EmailSettings != null)
@@ -494,7 +493,7 @@ public class OrderRequestService : IOrderRequestService
             if (recipient.RecipientOrganization.SmsSettings != null)
             {
                 templates.Add(CreateSmsTemplate(recipient.RecipientOrganization.SmsSettings));
-                sendingTimePolicyForSms = recipient.RecipientOrganization.SmsSettings.SendingTimePolicy;
+                smsSendingTimePolicy = recipient.RecipientOrganization.SmsSettings.SendingTimePolicy;
             }
 
             if (recipient.RecipientOrganization.EmailSettings != null)
@@ -505,6 +504,6 @@ public class OrderRequestService : IOrderRequestService
             recipients.Add(new Recipient([], organizationNumber: recipient.RecipientOrganization.OrgNumber));
         }
 
-        return (recipients, templates, notificationChannel, ignoreReservation, resourceIdentifier, sendingTimePolicyForSms);
+        return (recipients, templates, notificationChannel, ignoreReservation, resourceIdentifier, smsSendingTimePolicy);
     }
 }

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -172,7 +172,7 @@ public class OrderRequestService : IOrderRequestService
     /// </remarks>
     private async Task<NotificationOrder> CreateNotificationOrder(NotificationRecipient recipient, Guid orderId, string? sendersReference, DateTime requestedSendTime, Creator creator, DateTime currentTime, Uri? conditionEndpoint)
     {
-        var (recipients, templates, channel, ignoreReservation, resourceId, sendingTimePolicy) = ExtractDeliveryComponents(recipient);
+        var (recipients, templates, channel, ignoreReservation, resourceId, sendingTimePolicyForSms) = ExtractDeliveryComponents(recipient);
 
         var lookupResult = await GetRecipientLookupResult(recipients, channel, resourceId);
         if (lookupResult?.MissingContact?.Count > 0)
@@ -195,7 +195,7 @@ public class OrderRequestService : IOrderRequestService
             IgnoreReservation = ignoreReservation,
             ResourceId = resourceId,
             ConditionEndpoint = conditionEndpoint,
-            SendingTimePolicy = sendingTimePolicy
+            SendingTimePolicy = sendingTimePolicyForSms
         };
     }
 
@@ -429,7 +429,7 @@ public class OrderRequestService : IOrderRequestService
     /// <item><description>Channel - The determined notification channel based on recipient type</description></item>
     /// <item><description>IgnoreReservation - Flag indicating whether to bypass KRR reservations</description></item>
     /// <item><description>ResourceId - Optional resource ID for authorization and tracking</description></item>
-    /// <item><description>SendingTimePolicy - The sendingTimePolicy associated with the selected recipient's configuration</description></item>
+    /// <item><description>SendingTimePolicyForSms - The sendingTimePolicy associated with the selected SMS's configuration</description></item>
     /// </list>
     /// </returns>
     /// <remarks>
@@ -437,7 +437,7 @@ public class OrderRequestService : IOrderRequestService
     /// the appropriate templates and addressing information based on the recipient's configuration.
     /// The default channel is SMS if the recipient type cannot be determined.
     /// </remarks>
-    private static (List<Recipient> Recipients, List<INotificationTemplate> Templates, NotificationChannel Channel, bool? IgnoreReservation, string? ResourceId, SendingTimePolicy? SendingTimePolicy) ExtractDeliveryComponents(NotificationRecipient recipient)
+    private static (List<Recipient> Recipients, List<INotificationTemplate> Templates, NotificationChannel Channel, bool? IgnoreReservation, string? ResourceId, SendingTimePolicy? SendingTimePolicyForSms) ExtractDeliveryComponents(NotificationRecipient recipient)
     {
         bool? ignoreReservation = null;
         string? resourceIdentifier = null;
@@ -447,13 +447,13 @@ public class OrderRequestService : IOrderRequestService
 
         NotificationChannel notificationChannel = NotificationChannel.Sms;
 
-        SendingTimePolicy? sendingTimePolicy = null;
+        SendingTimePolicy? sendingTimePolicyForSms = null;
 
         if (recipient.RecipientSms?.Settings != null)
         {
             notificationChannel = NotificationChannel.Sms;
 
-            sendingTimePolicy = recipient.RecipientSms.Settings.SendingTimePolicy;
+            sendingTimePolicyForSms = recipient.RecipientSms.Settings.SendingTimePolicy;
 
             templates.Add(CreateSmsTemplate(recipient.RecipientSms.Settings));
 
@@ -462,8 +462,6 @@ public class OrderRequestService : IOrderRequestService
         else if (recipient.RecipientEmail?.Settings != null)
         {
             notificationChannel = NotificationChannel.Email;
-
-            sendingTimePolicy = recipient.RecipientEmail.Settings.SendingTimePolicy;
 
             templates.Add(CreateEmailTemplate(recipient.RecipientEmail.Settings));
 
@@ -478,13 +476,12 @@ public class OrderRequestService : IOrderRequestService
             if (recipient.RecipientPerson.SmsSettings != null)
             {
                 templates.Add(CreateSmsTemplate(recipient.RecipientPerson.SmsSettings));
-                sendingTimePolicy = recipient.RecipientPerson.SmsSettings.SendingTimePolicy;
+                sendingTimePolicyForSms = recipient.RecipientPerson.SmsSettings.SendingTimePolicy;
             }
 
             if (recipient.RecipientPerson.EmailSettings != null)
             {
                 templates.Add(CreateEmailTemplate(recipient.RecipientPerson.EmailSettings));
-                sendingTimePolicy = recipient.RecipientPerson.EmailSettings.SendingTimePolicy;
             }
 
             recipients.Add(new Recipient([], nationalIdentityNumber: recipient.RecipientPerson.NationalIdentityNumber));
@@ -497,18 +494,17 @@ public class OrderRequestService : IOrderRequestService
             if (recipient.RecipientOrganization.SmsSettings != null)
             {
                 templates.Add(CreateSmsTemplate(recipient.RecipientOrganization.SmsSettings));
-                sendingTimePolicy = recipient.RecipientOrganization.SmsSettings.SendingTimePolicy;
+                sendingTimePolicyForSms = recipient.RecipientOrganization.SmsSettings.SendingTimePolicy;
             }
 
             if (recipient.RecipientOrganization.EmailSettings != null)
             {
                 templates.Add(CreateEmailTemplate(recipient.RecipientOrganization.EmailSettings));
-                sendingTimePolicy = recipient.RecipientOrganization.EmailSettings.SendingTimePolicy;
             }
 
             recipients.Add(new Recipient([], organizationNumber: recipient.RecipientOrganization.OrgNumber));
         }
 
-        return (recipients, templates, notificationChannel, ignoreReservation, resourceIdentifier, sendingTimePolicy);
+        return (recipients, templates, notificationChannel, ignoreReservation, resourceIdentifier, sendingTimePolicyForSms);
     }
 }

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -892,36 +892,46 @@ public class OrderRequestServiceTests
     }
 
     [Fact]
-    public async Task RegisterNotificationOrderChain_RecipientOrganizationWithoutReminders_OrderChainCreated()
+    public async Task RegisterNotificationOrderChain_RecipientOrganizationWithEmailAndSms_SendingTimePolicyRespectsSmsOverEmail()
     {
         // Arrange
         Guid orderId = Guid.NewGuid();
         Guid orderChainId = Guid.NewGuid();
         DateTime currentTime = DateTime.UtcNow;
 
+        // Create a request with both email and SMS settings
+        // SMS has Daytime policy while Email has Anytime policy
         var orderChainRequest = new NotificationOrderChainRequest.NotificationOrderChainRequestBuilder()
             .SetOrderId(orderId)
             .SetOrderChainId(orderChainId)
             .SetCreator(new Creator("brg"))
-            .SetSendersReference("ANNUAL-REPORT-2025")
+            .SetSendersReference("REF-42DBDAB8281C")
             .SetRequestedSendTime(currentTime.AddHours(2))
-            .SetIdempotencyId("65698F3A-7B27-478C-9E76-A190C34A8099")
-            .SetConditionEndpoint(new Uri("https://api.brreg.no/conditions/annual-report"))
-            .SetDialogportenAssociation(new DialogportenIdentifiers { DialogId = "20E3D06D5546", TransmissionId = "F9D34BB1C65F" })
+            .SetIdempotencyId("A5B28914-7056-4E3B-9DAF-BEA23321D39C")
+            .SetConditionEndpoint(new Uri("https://api.brreg.no/conditions/notification"))
+            .SetDialogportenAssociation(new DialogportenIdentifiers { DialogId = "31E9F67A4B2D", TransmissionId = "C7D25A18E34F" })
             .SetRecipient(new NotificationRecipient
             {
                 RecipientOrganization = new RecipientOrganization
                 {
                     OrgNumber = "312508729",
-                    ChannelSchema = NotificationChannel.Email,
-                    ResourceId = "urn:altinn:resource:annual-report-2025",
+                    ChannelSchema = NotificationChannel.EmailAndSms,
+                    ResourceId = "urn:altinn:resource:email-sms-resouce-name",
+
+                    SmsSettings = new SmsSendingOptions
+                    {
+                        Sender = "Brønnøysund",
+                        Body = "Your organization's annual report is due by March 31, 2025. Log in to Altinn to complete it.",
+                        SendingTimePolicy = SendingTimePolicy.Daytime
+                    },
+
                     EmailSettings = new EmailSendingOptions
                     {
                         Subject = "Annual Report 2025",
                         ContentType = EmailContentType.Html,
                         SenderEmailAddress = "no-reply@brreg.no",
-                        Body = "<p>Your organization's annual report is due by March 31, 2025. Log in to Altinn to complete it.</p>",
-                        SendingTimePolicy = SendingTimePolicy.Anytime
+                        SendingTimePolicy = SendingTimePolicy.Anytime,
+                        Body = "<p>Your organization's annual report is due by March 31, 2025. Log in to Altinn to complete it.</p>"
                     }
                 }
             })
@@ -929,38 +939,38 @@ public class OrderRequestServiceTests
 
         var expectedOrder = new NotificationOrder(
             orderId,
-            "ANNUAL-REPORT-2025",
+            "REF-42DBDAB8281C",
             [
+                new SmsTemplate("Brønnøysund", "Your organization's annual report is due by March 31, 2025. Log in to Altinn to complete it."),
                 new EmailTemplate("no-reply@brreg.no", "Annual Report 2025", "<p>Your organization's annual report is due by March 31, 2025. Log in to Altinn to complete it.</p>", EmailContentType.Html)
             ],
             currentTime.AddHours(2),
-            NotificationChannel.Email,
+            NotificationChannel.EmailAndSms,
             new Creator("brg"),
             DateTime.UtcNow,
             [new([], organizationNumber: "312508729")],
             null,
-            "urn:altinn:resource:annual-report-2025",
-            new Uri("https://api.brreg.no/conditions/annual-report"));
+            "urn:altinn:resource:email-sms-resouce-name",
+            new Uri("https://api.brreg.no/conditions/notification"));
 
-        // Setup mock
         var orderRepositoryMock = new Mock<IOrderRepository>();
         orderRepositoryMock.Setup(r => r.Create(
-            It.Is<NotificationOrderChainRequest>(e => e.OrderChainId == orderChainId && e.SendersReference == "ANNUAL-REPORT-2025"),
-            It.Is<NotificationOrder>(o => o.NotificationChannel == NotificationChannel.Email && o.Recipients.Any(r => r.OrganizationNumber == "312508729")),
+            It.Is<NotificationOrderChainRequest>(e => e.OrderChainId == orderChainId && e.SendersReference == "REF-42DBDAB8281C"),
+            It.Is<NotificationOrder>(o => o.NotificationChannel == NotificationChannel.EmailAndSms && o.Recipients.Any(r => r.OrganizationNumber == "312508729")),
             It.Is<List<NotificationOrder>>(list => list.Count == 0),
-            It.IsAny<CancellationToken>()))
-            .ReturnsAsync([expectedOrder]);
+            It.IsAny<CancellationToken>())).ReturnsAsync([expectedOrder]);
 
         var contactPointServiceMock = new Mock<IContactPointService>();
         contactPointServiceMock
-            .Setup(contactService => contactService.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>()))
+            .Setup(contactService => contactService.AddEmailAndSmsContactPointsAsync(It.IsAny<List<Recipient>>(), It.IsAny<string?>()))
             .Callback<List<Recipient>, string?>((recipients, _) =>
             {
                 foreach (var recipient in recipients)
                 {
                     if (recipient.OrganizationNumber == "312508729")
                     {
-                        recipient.AddressInfo.Add(new EmailAddressPoint("recipient@example.com"));
+                        recipient.AddressInfo.Add(new SmsAddressPoint("+4799999999"));
+                        recipient.AddressInfo.Add(new EmailAddressPoint("organization@example.com"));
                     }
                 }
             });
@@ -973,32 +983,27 @@ public class OrderRequestServiceTests
         // Assert
         Assert.NotNull(response);
         Assert.Equal(orderChainId, response.OrderChainId);
-
-        Assert.NotNull(response.OrderChainReceipt);
         Assert.Equal(orderId, response.OrderChainReceipt.ShipmentId);
-        Assert.NotEqual(orderChainId, response.OrderChainReceipt.ShipmentId);
-        Assert.Equal("ANNUAL-REPORT-2025", response.OrderChainReceipt.SendersReference);
+        Assert.Equal("REF-42DBDAB8281C", response.OrderChainReceipt.SendersReference);
 
-        Assert.Null(response.OrderChainReceipt.Reminders);
-
-        // Verify repository interactions
         orderRepositoryMock.Verify(
             r => r.Create(
             It.Is<NotificationOrderChainRequest>(e => e.OrderChainId == orderChainId),
             It.Is<NotificationOrder>(o =>
                 o.Id == orderId &&
-                o.SendersReference == "ANNUAL-REPORT-2025" &&
-                o.NotificationChannel == NotificationChannel.Email &&
+                o.SendersReference == "REF-42DBDAB8281C" &&
+                o.SendingTimePolicy == SendingTimePolicy.Daytime &&
+                o.NotificationChannel == NotificationChannel.EmailAndSms &&
                 o.Recipients.Any(r => r.OrganizationNumber == "312508729")),
             It.Is<List<NotificationOrder>>(list => list.Count == 0),
             It.IsAny<CancellationToken>()),
             Times.Once);
 
-        // Verify contact point interactions
+        // Verify contact point service was called correctly
         contactPointServiceMock.Verify(
-            cp => cp.AddEmailContactPoints(
+            cp => cp.AddEmailAndSmsContactPointsAsync(
             It.Is<List<Recipient>>(r => r.Any(rec => rec.OrganizationNumber == "312508729")),
-            It.Is<string?>(s => s == "urn:altinn:resource:annual-report-2025")),
+            It.Is<string?>(s => s == "urn:altinn:resource:email-sms-resouce-name")),
             Times.Once);
     }
 


### PR DESCRIPTION
## Description
The sending time policy saved in the `orders` table must always reflect the sending time policy used for SMS, otherwise it must default to `null`.

## Related Issue(s)
- #824 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved clarity by renaming variables and documentation to specify that the sending time policy applies only to SMS notifications.
- **Tests**
  - Updated tests to verify that when both email and SMS channels are configured, the sending time policy prioritizes SMS settings over email.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->