### PR TITLE
Replace newline characters with a single whitespace

### DIFF
--- a/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
+++ b/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Enums;
+﻿using System.Text.RegularExpressions;
+
+using Altinn.Notifications.Core.Enums;
 using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.Orders;
 using Altinn.Notifications.Core.Models.Recipients;
@@ -12,7 +14,7 @@ namespace Altinn.Notifications.Mappers;
 /// <summary>
 /// Provides mapping functionality between external API models and internal domain models.
 /// </summary>
-public static class NotificationOrderChainMapper
+public static partial class NotificationOrderChainMapper
 {
     private const string SingleWhiteSpace = " ";
 
@@ -81,8 +83,8 @@ public static class NotificationOrderChainMapper
             Body = emailSendingOptionsExt.Body,
             ContentType = (EmailContentType)emailSendingOptionsExt.ContentType,
             SenderEmailAddress = emailSendingOptionsExt.SenderEmailAddress?.Trim(),
-            Subject = emailSendingOptionsExt.Subject.Replace("\n", SingleWhiteSpace),
-            SendingTimePolicy = (SendingTimePolicy)emailSendingOptionsExt.SendingTimePolicy
+            SendingTimePolicy = (SendingTimePolicy)emailSendingOptionsExt.SendingTimePolicy,
+            Subject = NormalizeLineEndingsRegex().Replace(emailSendingOptionsExt.Subject, SingleWhiteSpace)
         };
     }
 
@@ -182,4 +184,10 @@ public static class NotificationOrderChainMapper
             SendingTimePolicy = (SendingTimePolicy)smsSendingOptionsExt.SendingTimePolicy
         };
     }
+
+    /// <summary>
+    /// Regular expression to detect newline characters.
+    /// </summary>
+    [GeneratedRegex(@"\r\n|\r|\n")]
+    private static partial Regex NormalizeLineEndingsRegex();
 }

--- a/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
+++ b/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
@@ -14,6 +14,8 @@ namespace Altinn.Notifications.Mappers;
 /// </summary>
 public static class NotificationOrderChainMapper
 {
+    private const string SingleWhiteSpace = " ";
+
     /// <summary>
     /// Maps a <see cref="NotificationOrderChainRequestExt"/> to a <see cref="NotificationOrderChainRequest"/>.
     /// </summary>
@@ -77,9 +79,9 @@ public static class NotificationOrderChainMapper
         return new EmailSendingOptions
         {
             Body = emailSendingOptionsExt.Body,
-            Subject = emailSendingOptionsExt.Subject,
             ContentType = (EmailContentType)emailSendingOptionsExt.ContentType,
             SenderEmailAddress = emailSendingOptionsExt.SenderEmailAddress?.Trim(),
+            Subject = emailSendingOptionsExt.Subject.Replace("\n", SingleWhiteSpace),
             SendingTimePolicy = (SendingTimePolicy)emailSendingOptionsExt.SendingTimePolicy
         };
     }

--- a/src/Altinn.Notifications/Mappers/OrderMapper.cs
+++ b/src/Altinn.Notifications/Mappers/OrderMapper.cs
@@ -15,6 +15,8 @@ namespace Altinn.Notifications.Mappers;
 /// </summary>
 public static class OrderMapper
 {
+    private const string SingleWhiteSpace = " ";
+
     /// <summary>
     /// Maps a <see cref="NotificationOrderRequestExt"/> to a <see cref="NotificationOrderRequest"/>
     /// </summary>
@@ -46,7 +48,7 @@ public static class OrderMapper
         {
             var emailTemplate = new EmailTemplate(
                 null,
-                extRequest.EmailTemplate.Subject,
+                extRequest.EmailTemplate.Subject.Replace("\n", SingleWhiteSpace),
                 extRequest.EmailTemplate.Body,
                 (EmailContentType)extRequest.EmailTemplate.ContentType);
 
@@ -79,7 +81,7 @@ public static class OrderMapper
     {
         var emailTemplate = new EmailTemplate(
             null,
-            extRequest.Subject,
+            extRequest.Subject.Replace("\n", SingleWhiteSpace),
             extRequest.Body,
             (EmailContentType?)extRequest.ContentType ?? EmailContentType.Plain);
 

--- a/src/Altinn.Notifications/Mappers/OrderMapper.cs
+++ b/src/Altinn.Notifications/Mappers/OrderMapper.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Enums;
+﻿using System.Text.RegularExpressions;
+
+using Altinn.Notifications.Core.Enums;
 using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.Address;
 using Altinn.Notifications.Core.Models.NotificationTemplate;
@@ -13,7 +15,7 @@ namespace Altinn.Notifications.Mappers;
 /// <summary>
 /// Provides mapping functionality between external API models and internal domain models.
 /// </summary>
-public static class OrderMapper
+public static partial class OrderMapper
 {
     private const string SingleWhiteSpace = " ";
 
@@ -48,7 +50,7 @@ public static class OrderMapper
         {
             var emailTemplate = new EmailTemplate(
                 null,
-                extRequest.EmailTemplate.Subject.Replace("\n", SingleWhiteSpace),
+                NormalizeLineEndingsRegex().Replace(extRequest.EmailTemplate.Subject, SingleWhiteSpace),
                 extRequest.EmailTemplate.Body,
                 (EmailContentType)extRequest.EmailTemplate.ContentType);
 
@@ -81,7 +83,7 @@ public static class OrderMapper
     {
         var emailTemplate = new EmailTemplate(
             null,
-            extRequest.Subject.Replace("\n", SingleWhiteSpace),
+            NormalizeLineEndingsRegex().Replace(extRequest.Subject, SingleWhiteSpace),
             extRequest.Body,
             (EmailContentType?)extRequest.ContentType ?? EmailContentType.Plain);
 
@@ -337,4 +339,10 @@ public static class OrderMapper
 
         return smsAddressPoint?.MobileNumber;
     }
+
+    /// <summary>
+    /// Regular expression to detect newline characters.
+    /// </summary>
+    [GeneratedRegex(@"\r\n|\r|\n")]
+    private static partial Regex NormalizeLineEndingsRegex();
 }

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/NotificationOrderChainMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/NotificationOrderChainMapperTests.cs
@@ -334,7 +334,7 @@ public class NotificationOrderChainMapperTests
                     {
                         Body = "This is a test email body",
                         SenderEmailAddress = "sender@example.com",
-                        Subject = "This\nis\na\ntest\nemail\nsubject"
+                        Subject = "This\nis\r\na\rtest\r\nemail\nsubject"
                     }
                 }
             }

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/NotificationOrderChainMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/NotificationOrderChainMapperTests.cs
@@ -318,6 +318,43 @@ public class NotificationOrderChainMapperTests
     }
 
     [Fact]
+    public void MapToNotificationOrderChainRequest_WithEmailRecipientContainingNewlinesInSubject_ReplacesNewlinesWithSingleWhiteSpace()
+    {
+        // Arrange
+        var creatorName = "ttd";
+        var requestExt = new NotificationOrderChainRequestExt
+        {
+            IdempotencyId = "63404F51-2079-4598-BD23-8F4467590FB4",
+            Recipient = new NotificationRecipientExt
+            {
+                RecipientEmail = new RecipientEmailExt
+                {
+                    EmailAddress = "recipient@example.com",
+                    Settings = new EmailSendingOptionsExt
+                    {
+                        Body = "This is a test email body",
+                        SenderEmailAddress = "sender@example.com",
+                        Subject = "This\nis\na\ntest\nemail\nsubject"
+                    }
+                }
+            }
+        };
+
+        // Act
+        var result = requestExt.MapToNotificationOrderChainRequest(creatorName);
+
+        // Assert
+        Assert.NotNull(result);
+
+        Assert.NotNull(result.Recipient);
+        Assert.NotNull(result.Recipient.RecipientEmail);
+        Assert.Equal("recipient@example.com", result.Recipient.RecipientEmail.EmailAddress);
+        Assert.Equal("This is a test email body", result.Recipient.RecipientEmail.Settings.Body);
+        Assert.Equal("This is a test email subject", result.Recipient.RecipientEmail!.Settings.Subject);
+        Assert.Equal("sender@example.com", result.Recipient.RecipientEmail.Settings.SenderEmailAddress);
+    }
+
+    [Fact]
     public void MapToNotificationOrderChainRequest_WithOrganizationRecipientEmailChannel_MapsCorrectly()
     {
         // Arrange

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -456,9 +456,9 @@ public class OrderMapperTests
         // Arrange
         EmailNotificationOrderRequestExt emailRequestExt = new()
         {
-            Subject = "This is a\nsubject with\nnewlines",
             Body = "email-body",
-            ContentType = EmailContentTypeExt.Html
+            ContentType = EmailContentTypeExt.Html,
+            Subject = "This is a\nsubject with\nnewlines\r\nand CRLF\rand CR"
         };
 
         NotificationOrderRequestExt notificationRequestExt = new()
@@ -466,9 +466,9 @@ public class OrderMapperTests
             NotificationChannel = NotificationChannelExt.Email,
             EmailTemplate = new()
             {
-                Subject = "Another\nsubject with\nnewlines",
                 Body = "email-body",
-                ContentType = EmailContentTypeExt.Html
+                ContentType = EmailContentTypeExt.Html,
+                Subject = "Another\nsubject with\r\nmixed\rnewline types"
             }
         };
 
@@ -481,7 +481,7 @@ public class OrderMapperTests
         var notificationEmailTemplate = actualNotificationRequest.Templates[0] as EmailTemplate;
 
         // Assert
-        Assert.Equal("This is a subject with newlines", emailTemplate!.Subject);
-        Assert.Equal("Another subject with newlines", notificationEmailTemplate!.Subject);
+        Assert.Equal("This is a subject with newlines and CRLF and CR", emailTemplate!.Subject);
+        Assert.Equal("Another subject with mixed newline types", notificationEmailTemplate!.Subject);
     }
 }

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -449,4 +449,39 @@ public class OrderMapperTests
         // Assert
         Assert.Equivalent(expected, actual, true);
     }
+
+    [Fact]
+    public void MapToOrderRequest_SubjectWithNewLines_ReplacesWithSingleSpace()
+    {
+        // Arrange
+        EmailNotificationOrderRequestExt emailRequestExt = new()
+        {
+            Subject = "This is a\nsubject with\nnewlines",
+            Body = "email-body",
+            ContentType = EmailContentTypeExt.Html
+        };
+
+        NotificationOrderRequestExt notificationRequestExt = new()
+        {
+            NotificationChannel = NotificationChannelExt.Email,
+            EmailTemplate = new()
+            {
+                Subject = "Another\nsubject with\nnewlines",
+                Body = "email-body",
+                ContentType = EmailContentTypeExt.Html
+            }
+        };
+
+        // Act
+        var actualEmailRequest = emailRequestExt.MapToOrderRequest("ttd");
+        var actualNotificationRequest = notificationRequestExt.MapToOrderRequest("ttd");
+
+        // Get email template from both requests
+        var emailTemplate = actualEmailRequest.Templates[0] as EmailTemplate;
+        var notificationEmailTemplate = actualNotificationRequest.Templates[0] as EmailTemplate;
+
+        // Assert
+        Assert.Equal("This is a subject with newlines", emailTemplate!.Subject);
+        Assert.Equal("Another subject with newlines", notificationEmailTemplate!.Subject);
+    }
 }

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -476,7 +476,6 @@ public class OrderMapperTests
         var actualEmailRequest = emailRequestExt.MapToOrderRequest("ttd");
         var actualNotificationRequest = notificationRequestExt.MapToOrderRequest("ttd");
 
-        // Get email template from both requests
         var emailTemplate = actualEmailRequest.Templates[0] as EmailTemplate;
         var notificationEmailTemplate = actualNotificationRequest.Templates[0] as EmailTemplate;
 

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -458,7 +458,7 @@ public class OrderMapperTests
         {
             Body = "email-body",
             ContentType = EmailContentTypeExt.Html,
-            Subject = "This is a\nsubject with\nnewlines\r\nand CRLF\rand CR"
+            Subject = "This is a\nsubject with\r\nnewlines and\rcarriage returns"
         };
 
         NotificationOrderRequestExt notificationRequestExt = new()
@@ -468,7 +468,7 @@ public class OrderMapperTests
             {
                 Body = "email-body",
                 ContentType = EmailContentTypeExt.Html,
-                Subject = "Another\nsubject with\r\nmixed\rnewline types"
+                Subject = "Another\nsubject with\r\nnewlines and\rcarriage returns",
             }
         };
 
@@ -481,7 +481,7 @@ public class OrderMapperTests
         var notificationEmailTemplate = actualNotificationRequest.Templates[0] as EmailTemplate;
 
         // Assert
-        Assert.Equal("This is a subject with newlines and CRLF and CR", emailTemplate!.Subject);
-        Assert.Equal("Another subject with mixed newline types", notificationEmailTemplate!.Subject);
+        Assert.Equal("This is a subject with newlines and carriage returns", emailTemplate!.Subject);
+        Assert.Equal("Another subject with newlines and carriage returns", notificationEmailTemplate!.Subject);
     }
 }


### PR DESCRIPTION
## Description
This pull request has the necessary changes to replace newline characters used in the Email subject with a single whitespace.

## Related Issue(s)
- #745 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Email subjects now automatically replace newline characters with spaces to ensure proper formatting.
- **Tests**
	- Added tests to verify that newline characters in email subjects are correctly replaced with spaces during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->