### PR TITLE
Remove senders reference null-check

### DIFF
--- a/src/Altinn.Notifications.Persistence/Repository/NotificationDeliveryManifestRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/NotificationDeliveryManifestRepository.cs
@@ -250,16 +250,14 @@ public partial class NotificationDeliveryManifestRepository : INotificationDeliv
     private static async Task PopulateDeliveryManifestEntitiesAsync(NpgsqlDataReader reader, List<IDeliveryManifest> deliveryManifestEntities, CancellationToken cancellationToken)
     {
         var statusOrdinal = reader.GetOrdinal(_statusColumnName);
-        var referenceOrdinal = reader.GetOrdinal(_referenceColumnName);
         var lastUpdateOrdinal = reader.GetOrdinal(_lastUpdateColumnName);
         var destinationOrdinal = reader.GetOrdinal(_destinationColumnName);
 
         var isStatusNull = await reader.IsDBNullAsync(statusOrdinal, cancellationToken);
-        var isReferenceNull = await reader.IsDBNullAsync(referenceOrdinal, cancellationToken);
         var isTimestampNull = await reader.IsDBNullAsync(lastUpdateOrdinal, cancellationToken);
         var isDestinationNull = await reader.IsDBNullAsync(destinationOrdinal, cancellationToken);
 
-        if (isStatusNull || isTimestampNull || isDestinationNull || isReferenceNull)
+        if (isStatusNull || isTimestampNull || isDestinationNull)
         {
             return;
         }


### PR DESCRIPTION
Shipment endpoint only returns list of recipients when the sender's reference property is set.

## Description
If the sender's reference property is not set, the list of recipients is not populated. The sender's reference property is optional and should not affect the list of recipients returned

## Related Issue(s)
#868 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified logic for handling notification delivery manifests by removing checks related to the "reference" field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->