### PR TITLE
Fix missing failed_ttl mapping

### DIFF
--- a/src/Altinn.Notifications.Core/Enums/ProcessingLifecycle.cs
+++ b/src/Altinn.Notifications.Core/Enums/ProcessingLifecycle.cs
@@ -168,6 +168,11 @@ public enum ProcessingLifecycle
     SMS_Failed_RecipientNotIdentified,
 
     /// <summary>
+    /// The sms notification failed to reach the delivered state during the time-to-live (TTL) timeframe.
+    /// </summary>
+    SMS_Failed_TTL,
+
+    /// <summary>
     /// The SMS notification was rejected by the service provider, carrier, or recipient's device.
     /// </summary>
     /// <remarks>
@@ -278,11 +283,6 @@ public enum ProcessingLifecycle
     /// The message was flagged by security systems for manual review before potential delivery.
     /// </remarks>
     Email_Failed_Quarantined,
-
-    /// <summary>
-    /// The sms notification failed to reach the delivered state during the time-to-live (TTL) timeframe.
-    /// </summary>
-    SMS_Failed_TTL,
 
     /// <summary>
     /// The email notification failed to reach the delivered state during the time-to-live (TTL) timeframe.

--- a/src/Altinn.Notifications/Mappers/NotificationDeliveryManifestMapper.cs
+++ b/src/Altinn.Notifications/Mappers/NotificationDeliveryManifestMapper.cs
@@ -66,6 +66,7 @@ public static class NotificationDeliveryManifestMapper
             ProcessingLifecycle.SMS_Failed_InvalidRecipient => ProcessingLifecycleExt.SMS_Failed_InvalidRecipient,
             ProcessingLifecycle.SMS_Failed_RecipientReserved => ProcessingLifecycleExt.SMS_Failed_RecipientReserved,
             ProcessingLifecycle.SMS_Failed_RecipientNotIdentified => ProcessingLifecycleExt.SMS_Failed_RecipientNotIdentified,
+            ProcessingLifecycle.SMS_Failed_TTL => ProcessingLifecycleExt.SMS_Failed_TTL,
 
             // Email statuses
             ProcessingLifecycle.Email_New => ProcessingLifecycleExt.Email_New,
@@ -81,6 +82,7 @@ public static class NotificationDeliveryManifestMapper
             ProcessingLifecycle.Email_Failed_RecipientReserved => ProcessingLifecycleExt.Email_Failed_RecipientReserved,
             ProcessingLifecycle.Email_Failed_SuppressedRecipient => ProcessingLifecycleExt.Email_Failed_SuppressedRecipient,
             ProcessingLifecycle.Email_Failed_RecipientNotIdentified => ProcessingLifecycleExt.Email_Failed_RecipientNotIdentified,
+            ProcessingLifecycle.Email_Failed_TTL => ProcessingLifecycleExt.Email_Failed_TTL,
 
             // In case a new status is added to the enum but not to this mapping:
             _ => throw new ArgumentOutOfRangeException(nameof(status), $"Unsupported status: {status}")

--- a/src/Altinn.Notifications/Models/Status/ProcessingLifecycleExt.cs
+++ b/src/Altinn.Notifications/Models/Status/ProcessingLifecycleExt.cs
@@ -182,6 +182,11 @@ public enum ProcessingLifecycleExt
     SMS_Failed_Rejected = 37,
 
     /// <summary>
+    /// The SMS notification failed because it exceeded the time-to-live (TTL) limit set by the service provider.
+    /// </summary>
+    SMS_Failed_TTL = 38,
+
+    /// <summary>
     /// The email notification has been received and registered in the system but processing has not yet begun.
     /// </summary>
     /// <remarks>
@@ -283,5 +288,10 @@ public enum ProcessingLifecycleExt
     /// <remarks>
     /// The message was flagged by security systems for manual review before potential delivery.
     /// </remarks>
-    Email_Failed_Quarantined = 62
+    Email_Failed_Quarantined = 62,
+
+    /// <summary>
+    /// The email notification failed because it exceeded the time-to-live (TTL) limit set by the service provider.
+    /// </summary>
+    Email_Failed_TTL = 63
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
#856 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new status indicators for SMS and Email notifications that fail due to exceeding time-to-live (TTL) limits. Users may now see more detailed failure reasons for undelivered messages.
- **Refactor**
	- Improved grouping of SMS failure statuses for better clarity in status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->