### PR TITLE
Use fromaddress for request instead of default

### DIFF
--- a/src/Altinn.Notifications/Mappers/OrderMapper.cs
+++ b/src/Altinn.Notifications/Mappers/OrderMapper.cs
@@ -47,9 +47,9 @@ public static partial class OrderMapper
         List<INotificationTemplate> templateList = [];
 
         if (extRequest.EmailTemplate != null)
-        {
+        {   
             var emailTemplate = new EmailTemplate(
-                null,
+                extRequest.EmailTemplate.FromAddress,
                 NormalizeLineEndingsRegex().Replace(extRequest.EmailTemplate.Subject, SingleWhiteSpace),
                 extRequest.EmailTemplate.Body,
                 (EmailContentType)extRequest.EmailTemplate.ContentType);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The old controller endpoint overrides every fromAddress for email to defaultEmailAddress.

- [x] Update OrderMapper to insert fromAddress in NotificationOrderRequestExt instead of null

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the sender address in email notifications to use the specified "From" address from the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->