### PR TITLE
Use correct PostgreSql version during build and analysis of pull requests

### DIFF
--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           # Restart only the Postgres service
           docker ps \
-            --filter "ancestor=postgres:17@sha256:6efd0df010dc3cb40d5e33e3ef84acecc5e73161bd3df06029ee8698e5e12c60" \
+            --filter "ancestor=postgres:16@sha256:918e8e72b35b5370901965ce3da5a355c3537cb5e10c38e82c2b6f174b758334" \
             -q \
           | xargs docker restart
       - name: Set up Kafka


### PR DESCRIPTION
## Description
Downgrade PostgreSQL service from version 17 to 16 in order to match the version we use in all environments.

## Related Issue(s)
- Weekly patching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the PostgreSQL service version used in the build and test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->