### PR TITLE
Add the ability to schedule a reminder delivery using date and time.

### DIFF
--- a/src/Altinn.Notifications.Core/Services/Interfaces/IOrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/Interfaces/IOrderRequestService.cs
@@ -37,9 +37,6 @@ public interface IOrderRequestService
     /// 
     /// The operation is idempotent when using the same <see cref="NotificationOrderChainRequest.IdempotencyId"/>,
     /// ensuring that repeated calls with identical parameters won't create duplicate notification chains.
-    /// 
-    /// When reminders are specified, they will be scheduled for delivery after the main notification
-    /// according to their respective <see cref="NotificationReminder.DelayDays"/> value.
     /// </remarks>
     /// <exception cref="OperationCanceledException">
     /// Thrown when the operation is canceled through the provided <paramref name="cancellationToken"/>.

--- a/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
+++ b/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
@@ -39,7 +39,7 @@ public static partial class NotificationOrderChainMapper
         var reminders = notificationOrderChainRequestExt.Reminders?
             .Select(reminder =>
             {
-                DateTime requestedSendTime = DateTime.UtcNow;
+                DateTime requestedSendTime = notificationOrderChainRequestExt.RequestedSendTime;
 
                 if (reminder.DelayDays.HasValue)
                 {

--- a/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
+++ b/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
@@ -39,6 +39,7 @@ public static partial class NotificationOrderChainMapper
         var reminders = notificationOrderChainRequestExt.Reminders?
             .Select(reminder =>
             {
+                var reminderDelayDays = 0;
                 DateTime requestedSendTime = notificationOrderChainRequestExt.RequestedSendTime;
 
                 if (reminder.DelayDays.HasValue)
@@ -48,9 +49,10 @@ public static partial class NotificationOrderChainMapper
                 else if (reminder.RequestedSendTime.HasValue)
                 {
                     requestedSendTime = reminder.RequestedSendTime.Value.ToUniversalTime();
+                    reminderDelayDays = reminder.RequestedSendTime.Value.Subtract(notificationOrderChainRequestExt.RequestedSendTime).Days;
                 }
 
-                return reminder.MapToNotificationReminder(requestedSendTime);
+                return reminder.MapToNotificationReminder(requestedSendTime, reminderDelayDays);
             })
             .ToList();
 
@@ -103,8 +105,9 @@ public static partial class NotificationOrderChainMapper
     /// </summary>
     /// <param name="notificationReminderExt">The external notification reminder object to map from.</param>
     /// <param name="requestedSendTime">The requested send time for the reminder.</param>
+    /// <param name="reminderDelayDays">The number of days to delay the reminder relative to the main notification.</param>
     /// <returns>A <see cref="NotificationReminder"/> object mapped from the provided notification reminder.</returns>
-    private static NotificationReminder MapToNotificationReminder(this NotificationReminderExt notificationReminderExt, DateTime requestedSendTime)
+    private static NotificationReminder MapToNotificationReminder(this NotificationReminderExt notificationReminderExt, DateTime requestedSendTime, int reminderDelayDays)
     {
         return new()
         {
@@ -119,9 +122,9 @@ public static partial class NotificationOrderChainMapper
             OrderId = Guid.NewGuid(),
             Type = OrderType.Reminder,
             RequestedSendTime = requestedSendTime,
-            DelayDays = notificationReminderExt.DelayDays ?? 0,
             SendersReference = notificationReminderExt.SendersReference,
-            ConditionEndpoint = notificationReminderExt.ConditionEndpoint
+            ConditionEndpoint = notificationReminderExt.ConditionEndpoint,
+            DelayDays = notificationReminderExt.DelayDays ?? reminderDelayDays
         };
     }
 

--- a/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
+++ b/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
@@ -39,7 +39,16 @@ public static partial class NotificationOrderChainMapper
         var reminders = notificationOrderChainRequestExt.Reminders?
             .Select(reminder =>
             {
-                var requestedSendTime = notificationOrderChainRequestExt.RequestedSendTime.AddDays(reminder.DelayDays).ToUniversalTime();
+                DateTime requestedSendTime = DateTime.UtcNow;
+
+                if (reminder.DelayDays.HasValue)
+                {
+                    requestedSendTime = notificationOrderChainRequestExt.RequestedSendTime.AddDays(reminder.DelayDays.Value).ToUniversalTime();
+                }
+                else if (reminder.RequestedSendTime.HasValue)
+                {
+                    requestedSendTime = reminder.RequestedSendTime.Value.ToUniversalTime();
+                }
 
                 return reminder.MapToNotificationReminder(requestedSendTime);
             })
@@ -110,7 +119,7 @@ public static partial class NotificationOrderChainMapper
             OrderId = Guid.NewGuid(),
             Type = OrderType.Reminder,
             RequestedSendTime = requestedSendTime,
-            DelayDays = notificationReminderExt.DelayDays,
+            DelayDays = notificationReminderExt.DelayDays ?? 0,
             SendersReference = notificationReminderExt.SendersReference,
             ConditionEndpoint = notificationReminderExt.ConditionEndpoint
         };

--- a/src/Altinn.Notifications/Models/NotificationReminderExt.cs
+++ b/src/Altinn.Notifications/Models/NotificationReminderExt.cs
@@ -12,7 +12,7 @@ namespace Altinn.Notifications.Models;
 /// specific conditions or time delays after the initial notification. Each reminder can be
 /// customized with its own recipient details and timing parameters.
 /// </remarks>
-public class NotificationReminderExt
+public record NotificationReminderExt
 {
     /// <summary>
     /// Gets or sets the sender's reference for this reminder.
@@ -21,7 +21,7 @@ public class NotificationReminderExt
     /// A unique identifier used by the sender to correlate this reminder with their internal systems.
     /// </remarks>
     [JsonPropertyName("sendersReference")]
-    public string? SendersReference { get; set; }
+    public string? SendersReference { get; init; }
 
     /// <summary>
     /// Gets or sets the condition endpoint used to determine if the reminder should be sent.
@@ -32,15 +32,25 @@ public class NotificationReminderExt
     /// This allows for dynamic decision-making about whether the reminder is still relevant.
     /// </remarks>
     [JsonPropertyName("conditionEndpoint")]
-    public Uri? ConditionEndpoint { get; set; }
+    public Uri? ConditionEndpoint { get; init; }
 
     /// <summary>
     /// Gets or sets the number of days to delay this reminder.
     /// </summary>
-    [Required]
     [DefaultValue(1)]
     [JsonPropertyName("delayDays")]
-    public required int DelayDays { get; set; } = 1;
+    public int? DelayDays { get; init; } = 1;
+
+    /// <summary>
+    /// Gets or sets the earliest date and time when the reminder should be delivered.
+    /// </summary>
+    /// <remarks>
+    /// Allows scheduling reminder for future delivery. The system will not deliver the reminder
+    /// before this time, but may deliver it later depending on system load and availability.
+    /// Defaults to the current UTC time if not specified.
+    /// </remarks>
+    [JsonPropertyName("requestedSendTime")]
+    public DateTime? RequestedSendTime { get; init; } = DateTime.UtcNow;
 
     /// <summary>
     /// Gets or sets the recipient information for this reminder.
@@ -52,5 +62,5 @@ public class NotificationReminderExt
     /// </remarks>
     [Required]
     [JsonPropertyName("recipient")]
-    public required NotificationRecipientExt Recipient { get; set; }
+    public required NotificationRecipientExt Recipient { get; init; }
 }

--- a/src/Altinn.Notifications/Models/NotificationReminderExt.cs
+++ b/src/Altinn.Notifications/Models/NotificationReminderExt.cs
@@ -39,7 +39,7 @@ public record NotificationReminderExt
     /// </summary>
     [DefaultValue(1)]
     [JsonPropertyName("delayDays")]
-    public int? DelayDays { get; init; } = 1;
+    public int? DelayDays { get; init; }
 
     /// <summary>
     /// Gets or sets the earliest date and time when the reminder should be delivered.
@@ -50,7 +50,7 @@ public record NotificationReminderExt
     /// Defaults to the current UTC time if not specified.
     /// </remarks>
     [JsonPropertyName("requestedSendTime")]
-    public DateTime? RequestedSendTime { get; init; } = DateTime.UtcNow;
+    public DateTime? RequestedSendTime { get; init; }
 
     /// <summary>
     /// Gets or sets the recipient information for this reminder.

--- a/src/Altinn.Notifications/Validators/NotificationReminderValidator.cs
+++ b/src/Altinn.Notifications/Validators/NotificationReminderValidator.cs
@@ -39,7 +39,7 @@ internal sealed class NotificationReminderValidator : AbstractValidator<Notifica
                 .WithMessage("DelayDays must be null when RequestedSendTime is set.");
 
             RuleFor(option => option.RequestedSendTime)
-                .Must(sendTime => sendTime!.Value.Kind != DateTimeKind.Unspecified)
+                .Must(sendTime => sendTime.HasValue && sendTime.Value.Kind != DateTimeKind.Unspecified)
                 .WithMessage("The RequestedSendTime must have specified a time zone.")
 
                 .GreaterThanOrEqualTo(DateTime.UtcNow)

--- a/src/Altinn.Notifications/Validators/NotificationReminderValidator.cs
+++ b/src/Altinn.Notifications/Validators/NotificationReminderValidator.cs
@@ -1,5 +1,6 @@
 ﻿using Altinn.Notifications.Models;
 using Altinn.Notifications.Validators.Rules;
+
 using FluentValidation;
 
 namespace Altinn.Notifications.Validators;
@@ -14,9 +15,36 @@ internal sealed class NotificationReminderValidator : AbstractValidator<Notifica
     /// </summary>
     public NotificationReminderValidator()
     {
-        RuleFor(options => options.DelayDays)
-            .GreaterThan(0)
-            .WithMessage("DelayDays must be greater than 0.");
+        RuleFor(options => options)
+            .Must(options =>
+                (options.DelayDays.HasValue && !options.RequestedSendTime.HasValue) ||
+                (!options.DelayDays.HasValue && options.RequestedSendTime.HasValue))
+            .WithMessage("Either DelayDays or RequestedSendTime must be defined, but not both.");
+
+        When(options => options.DelayDays.HasValue, () =>
+        {
+            RuleFor(options => options.DelayDays)
+                .GreaterThanOrEqualTo(1)
+                .WithMessage("DelayDays must be greater than or equal to 1 day.");
+
+            RuleFor(options => options.RequestedSendTime)
+                .Null()
+                .WithMessage("RequestedSendTime must be null when DelayDays is set.");
+        });
+
+        When(options => options.RequestedSendTime.HasValue, () =>
+        {
+            RuleFor(options => options.DelayDays)
+                .Null()
+                .WithMessage("DelayDays must be null when RequestedSendTime is set.");
+
+            RuleFor(option => option.RequestedSendTime)
+                .Must(sendTime => sendTime!.Value.Kind != DateTimeKind.Unspecified)
+                .WithMessage("The RequestedSendTime must have specified a time zone.")
+
+                .GreaterThanOrEqualTo(DateTime.UtcNow)
+                .WithMessage("RequestedSendTime must be greater than or equal to the current UTC time.");
+        });
 
         When(options => options.ConditionEndpoint != null, () =>
         {

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/FutureOrdersController/FutureOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/FutureOrdersController/FutureOrdersControllerTests.cs
@@ -87,7 +87,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_InvalidRequest_RequestedSendTimeInPast_ReturnsBadRequest()
     {
         // Arrange
-        var requestExt = CreateValidRequest();
+        var requestExt = CreateFutureEmailOrderChainRequest();
         requestExt.RequestedSendTime = DateTime.UtcNow.AddHours(-2);
 
         HttpClient client = GetTestClient();
@@ -113,7 +113,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_MissingBearer_ReturnsUnauthorized()
     {
         // Arrange
-        var requestExt = CreateValidRequest();
+        var requestExt = CreateFutureEmailOrderChainRequest();
         HttpClient client = GetTestClient();
 
         // Act
@@ -127,7 +127,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_OrganizationTokenWithInvalidScope_ReturnsForbidden()
     {
         // Arrange
-        var requestExt = CreateValidRequest();
+        var requestExt = CreateFutureEmailOrderChainRequest();
         HttpClient client = GetTestClient();
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
             "Bearer",
@@ -144,7 +144,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_RegularUserWithValidToken_ReturnsForbidden()
     {
         // Arrange
-        var requestExt = CreateValidRequest();
+        var requestExt = CreateFutureEmailOrderChainRequest();
         HttpClient client = GetTestClient();
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
             "Bearer",
@@ -165,9 +165,9 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_InvalidRequest_MissingCreatorShortName_ReturnsForbidden()
     {
         // Arrange
-        var requestExt = CreateValidRequest();
+        var requestExt = CreateFutureEmailOrderChainRequest();
         var orderRequestServiceMock = new Mock<IOrderRequestService>();
-        var validatorMock = SetupValidValidator();
+        var validatorMock = SetupValidator();
 
         var httpContextMock = new Mock<HttpContext>();
         httpContextMock.Setup(e => e.Items).Returns(new Dictionary<object, object?> { { "Org", null } });
@@ -191,7 +191,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_OrganizationTokenWithCorrectScope_ReturnsCreateddWithOrderDetails()
     {
         // Arrange
-        var requestExt = CreateValidRequest();
+        var requestExt = CreateFutureEmailOrderChainRequest();
         var expectedResponse = new NotificationOrderChainResponse
         {
             OrderChainId = Guid.NewGuid(),
@@ -234,7 +234,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_PlatformAccessTokenAuthentication_ReturnsCreatedWithOrderDetails()
     {
         // Arrange
-        var requestExt = CreateValidRequest();
+        var requestExt = CreateFutureEmailOrderChainRequest();
         var expectedResponse = new NotificationOrderChainResponse
         {
             OrderChainId = Guid.NewGuid(),
@@ -280,10 +280,12 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_ValidRequest_WithReminders_ReturnsCreatedResponseWithReminderDetails()
     {
         // Arrange
-        var requestExt = new NotificationOrderChainRequestExt
+        var requestedSendTime = DateTime.UtcNow.AddHours(2);
+
+        var orderChainRequest = new NotificationOrderChainRequestExt
         {
+            RequestedSendTime = requestedSendTime,
             IdempotencyId = Guid.NewGuid().ToString(),
-            RequestedSendTime = DateTime.UtcNow.AddHours(2),
             Recipient = new NotificationRecipientExt
             {
                 RecipientSms = new RecipientSmsExt
@@ -301,7 +303,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
             [
                 new NotificationReminderExt
                 {
-                    DelayDays = 2,
+                    RequestedSendTime = requestedSendTime.AddHours(48),
                     Recipient = new NotificationRecipientExt
                     {
                         RecipientSms = new RecipientSmsExt
@@ -320,13 +322,15 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
         };
 
         var expectedResponse = CreateNotificationOrderChainResponse(Guid.NewGuid(), 1);
+
         var client = GetTestClient(expectedResponse);
+        
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
             "Bearer",
             PrincipalUtil.GetOrgToken("ttd", scope: "altinn:serviceowner/notifications.create"));
 
         // Act
-        var response = await SendPostRequest(client, requestExt);
+        var response = await SendPostRequest(client, orderChainRequest);
         var responseObject = await DeserializeResponse(response);
 
         // Assert
@@ -346,7 +350,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_ValidRequestUsingRecipientEmail_WithoutReminders_ReturnsCreated()
     {
         // Arrange
-        var requestExt = CreateValidRequest();
+        var requestExt = CreateFutureEmailOrderChainRequest();
         var expectedResponse = CreateNotificationOrderChainResponse(Guid.NewGuid());
         var client = GetTestClient(expectedResponse);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
@@ -421,10 +425,11 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_ValidRequestUsingOrganizationRecipient_WithReminders_ReturnsCreated()
     {
         // Arrange
+        var requestedSendTime = DateTime.UtcNow.AddHours(2);
         var requestExt = new NotificationOrderChainRequestExt
         {
+            RequestedSendTime = requestedSendTime,
             IdempotencyId = Guid.NewGuid().ToString(),
-            RequestedSendTime = DateTime.UtcNow.AddHours(2),
             Recipient = new NotificationRecipientExt
             {
                 RecipientOrganization = new RecipientOrganizationExt
@@ -466,7 +471,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
                 },
                 new NotificationReminderExt
                 {
-                    DelayDays = 7,
+                    RequestedSendTime = requestedSendTime.AddDays(7),
                     SendersReference = "0CBF6860-77BC-4D53-B7F4-926BE85A138C",
                     Recipient = new NotificationRecipientExt
                     {
@@ -514,9 +519,9 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_ValidRequestWithExistingOrder_ReturnsOkWithExistingOrderDetails()
     {
         // Arrange
-        var request = CreateValidRequest();
+        var request = CreateFutureEmailOrderChainRequest();
         var existingResponse = CreateOrderChainResponse();
-        var validatorMock = SetupValidValidator();
+        var validatorMock = SetupValidator();
         var orderServiceMock = new Mock<IOrderRequestService>();
 
         orderServiceMock.Setup(s => s.RetrieveOrderChainTracking("ttd", request.IdempotencyId, It.IsAny<CancellationToken>()))
@@ -546,10 +551,10 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_ValidRequest_FirstTimeSubmission_ReturnsCreatedWithSelfReferenceUrl()
     {
         // Arrange
-        var request = CreateValidRequest();
+        var request = CreateFutureEmailOrderChainRequest();
         var newResponse = CreateOrderChainResponse();
         var expectedUrl = newResponse.OrderChainId.GetSelfLinkFromOrderChainId();
-        var validatorMock = SetupValidValidator();
+        var validatorMock = SetupValidator();
         var orderServiceMock = new Mock<IOrderRequestService>();
 
         orderServiceMock.Setup(s => s.RetrieveOrderChainTracking("ttd", request.IdempotencyId, It.IsAny<CancellationToken>()))
@@ -580,8 +585,8 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_OperationCanceled_ReturnsClientClosedRequest()
     {
         // Arrange
-        var request = CreateValidRequest();
-        var validatorMock = SetupValidValidator();
+        var request = CreateFutureEmailOrderChainRequest();
+        var validatorMock = SetupValidator();
         var orderServiceMock = new Mock<IOrderRequestService>();
 
         orderServiceMock.Setup(s => s.RetrieveOrderChainTracking(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -612,8 +617,8 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_MissingRecipients_ReturnsProblemDetails422Status()
     {
         // Arrange
-        var request = CreateValidRequest();
-        var validatorMock = SetupValidValidator();
+        var request = CreateFutureEmailOrderChainRequest();
+        var validatorMock = SetupValidator();
         var orderServiceMock = new Mock<IOrderRequestService>();
         orderServiceMock.Setup(s => s.RetrieveOrderChainTracking("ttd", request.IdempotencyId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((NotificationOrderChainResponse?)null);
@@ -641,8 +646,8 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_OperationCanceledDuringRegistration_Returns499Status()
     {
         // Arrange
-        var request = CreateValidRequest();
-        var validatorMock = SetupValidValidator();
+        var request = CreateFutureEmailOrderChainRequest();
+        var validatorMock = SetupValidator();
         var orderServiceMock = new Mock<IOrderRequestService>();
 
         orderServiceMock.Setup(s => s.RetrieveOrderChainTracking("ttd", request.IdempotencyId, It.IsAny<CancellationToken>()))
@@ -673,7 +678,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     }
 
     [Fact]
-    public async Task Post_RequestDtoToInternalModelMapping_PreservesAllPropertiesIncludingReminders()
+    public async Task Post_RequestToInternalModelMapping_PreservesAllPropertiesIncludingReminders()
     {
         // Arrange
         var request = new NotificationOrderChainRequestExt
@@ -721,7 +726,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
         };
 
         NotificationOrderChainRequest? capturedRequest = null;
-        var validatorMock = SetupValidValidator();
+        var validatorMock = SetupValidator();
         var orderServiceMock = new Mock<IOrderRequestService>();
 
         orderServiceMock.Setup(s => s.RetrieveOrderChainTracking("ttd", request.IdempotencyId, It.IsAny<CancellationToken>()))
@@ -759,8 +764,8 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     public async Task Post_EnsuresCancellationTokenPassedToController_IsForwardedToAllServiceLayerMethods()
     {
         // Arrange
-        var request = CreateValidRequest();
-        var validatorMock = SetupValidValidator();
+        var request = CreateFutureEmailOrderChainRequest();
+        var validatorMock = SetupValidator();
         var cancellationToken = CancellationToken.None;
         var orderServiceMock = new Mock<IOrderRequestService>();
 
@@ -843,7 +848,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     /// Creates a valid notification order chain request for testing.
     /// </summary>
     /// <returns>A properly configured <see cref="NotificationOrderChainRequestExt"/> instance.</returns>
-    private static NotificationOrderChainRequestExt CreateValidRequest()
+    private static NotificationOrderChainRequestExt CreateFutureEmailOrderChainRequest()
     {
         return new NotificationOrderChainRequestExt
         {
@@ -888,12 +893,23 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     /// Configures a mock validator that always returns a valid validation result.
     /// </summary>
     /// <returns>A configured mock of <see cref="IValidator{T}"/> for <see cref="NotificationOrderChainRequestExt"/>.</returns>
-    private static Mock<IValidator<NotificationOrderChainRequestExt>> SetupValidValidator()
+    private static Mock<IValidator<NotificationOrderChainRequestExt>> SetupValidator()
     {
         var validatorMock = new Mock<IValidator<NotificationOrderChainRequestExt>>();
         validatorMock.Setup(v => v.Validate(It.IsAny<NotificationOrderChainRequestExt>()))
             .Returns(new ValidationResult());
         return validatorMock;
+    }
+
+    /// <summary>
+    /// Deserializes the HTTP response content into a <see cref="NotificationOrderChainResponseExt"/> object.
+    /// </summary>
+    /// <param name="response">The HTTP response message containing JSON content.</param>
+    /// <returns>A deserialized <see cref="NotificationOrderChainResponseExt"/> object, or <c>null</c> if deserialization fails.</returns>
+    private static async Task<NotificationOrderChainResponseExt?> DeserializeResponse(HttpResponseMessage response)
+    {
+        string responseString = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<NotificationOrderChainResponseExt>(responseString, _options);
     }
 
     /// <summary>
@@ -906,54 +922,6 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
     {
         using var content = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
         return await client.PostAsync(BasePath, content);
-    }
-
-    /// <summary>
-    /// Deserializes the HTTP response content into a <see cref="NotificationOrderChainResponseExt"/> object.
-    /// </summary>
-    /// <param name="response">The HTTP response message containing JSON content.</param>
-    /// <returns>A deserialized <see cref="NotificationOrderChainResponseExt"/> object, or <c>null</c> if deserialization fails.</returns>
-    private async Task<NotificationOrderChainResponseExt?> DeserializeResponse(HttpResponseMessage response)
-    {
-        string responseString = await response.Content.ReadAsStringAsync();
-        return JsonSerializer.Deserialize<NotificationOrderChainResponseExt>(responseString, _options);
-    }
-
-    /// <summary>
-    /// Creates a test notification order chain response with optional reminders.
-    /// </summary>
-    /// <param name="orderId">The unique identifier for the notification order.</param>
-    /// <param name="reminderCount">The number of reminder shipments to include.</param>
-    /// <param name="sendersReference">Custom sender's reference for the main notification.</param>
-    /// <returns>A configured <see cref="NotificationOrderChainResponse"/> for testing.</returns>
-    private static NotificationOrderChainResponse CreateNotificationOrderChainResponse(Guid orderId, int reminderCount = 0, string sendersReference = "notification-ref")
-    {
-        List<NotificationOrderChainShipment>? reminders = null;
-
-        if (reminderCount > 0)
-        {
-            reminders = new List<NotificationOrderChainShipment>(reminderCount);
-
-            for (int i = 0; i < reminderCount; i++)
-            {
-                reminders.Add(new NotificationOrderChainShipment
-                {
-                    ShipmentId = Guid.NewGuid(),
-                    SendersReference = Guid.NewGuid().ToString()
-                });
-            }
-        }
-
-        return new NotificationOrderChainResponse
-        {
-            OrderChainId = orderId,
-            OrderChainReceipt = new NotificationOrderChainReceipt
-            {
-                Reminders = reminders,
-                ShipmentId = Guid.NewGuid(),
-                SendersReference = sendersReference
-            }
-        };
     }
 
     /// <summary>
@@ -994,5 +962,42 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
                 services.AddSingleton<IPostConfigureOptions<JwtCookieOptions>, JwtCookiePostConfigureOptionsStub>();
             });
         }).CreateClient();
+    }
+
+    /// <summary>
+    /// Creates a test notification order chain response with optional reminders.
+    /// </summary>
+    /// <param name="orderId">The unique identifier for the notification order.</param>
+    /// <param name="reminderCount">The number of reminder shipments to include.</param>
+    /// <param name="sendersReference">Custom sender's reference for the main notification.</param>
+    /// <returns>A configured <see cref="NotificationOrderChainResponse"/> for testing.</returns>
+    private static NotificationOrderChainResponse CreateNotificationOrderChainResponse(Guid orderId, int reminderCount = 0, string sendersReference = "notification-ref")
+    {
+        List<NotificationOrderChainShipment>? reminders = null;
+
+        if (reminderCount > 0)
+        {
+            reminders = new List<NotificationOrderChainShipment>(reminderCount);
+
+            for (int i = 0; i < reminderCount; i++)
+            {
+                reminders.Add(new NotificationOrderChainShipment
+                {
+                    ShipmentId = Guid.NewGuid(),
+                    SendersReference = Guid.NewGuid().ToString()
+                });
+            }
+        }
+
+        return new NotificationOrderChainResponse
+        {
+            OrderChainId = orderId,
+            OrderChainReceipt = new NotificationOrderChainReceipt
+            {
+                Reminders = reminders,
+                ShipmentId = Guid.NewGuid(),
+                SendersReference = sendersReference
+            }
+        };
     }
 }

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/FutureOrdersController/FutureOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/FutureOrdersController/FutureOrdersControllerTests.cs
@@ -42,21 +42,20 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
 {
     private const string BasePath = "/notifications/api/v1/future/orders";
 
-    private readonly JsonSerializerOptions _options;
+    private static readonly JsonSerializerOptions _options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
     private readonly IntegrationTestWebApplicationFactory<FutureOrdersController> _factory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FutureOrdersControllerTests"/> class.
     /// </summary>
-    /// <param name="factory">The test web application factory.</param>
     public FutureOrdersControllerTests(IntegrationTestWebApplicationFactory<FutureOrdersController> factory)
     {
         _factory = factory;
-        _options = new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true,
-            Converters = { new JsonStringEnumConverter() }
-        };
     }
 
     [Fact]

--- a/test/Altinn.Notifications.IntegrationTests/Notifications/FutureOrdersController/FutureOrdersControllerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications/FutureOrdersController/FutureOrdersControllerTests.cs
@@ -758,6 +758,7 @@ public class FutureOrdersControllerTests : IClassFixture<IntegrationTestWebAppli
         Assert.Single(capturedRequest.Reminders);
         Assert.Equal(3, capturedRequest.Reminders[0].DelayDays);
         Assert.Equal("reminder-ref-1", capturedRequest.Reminders[0].SendersReference);
+        Assert.Equal(request.RequestedSendTime.AddDays(3), capturedRequest.Reminders[0].RequestedSendTime);
     }
 
     [Fact]

--- a/test/Altinn.Notifications.Tests/Notifications/TestingMappers/NotificationOrderChainMapperTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingMappers/NotificationOrderChainMapperTests.cs
@@ -141,7 +141,7 @@ public class NotificationOrderChainMapperTests
                 },
                 new NotificationReminderExt
                 {
-                    DelayDays = 5,
+                    RequestedSendTime = baseTime.AddDays(5),
                     SendersReference = "7B1A786D-4767-4113-8401-836D1D176BC2",
                     ConditionEndpoint = new Uri("https://vg.no/second-reminder-condition"),
 
@@ -586,7 +586,7 @@ public class NotificationOrderChainMapperTests
                 },
                 new NotificationReminderExt
                 {
-                    DelayDays = 7,
+                    RequestedSendTime = baseTime.AddDays(7),
                     Recipient = new NotificationRecipientExt
                     {
                         RecipientOrganization = new RecipientOrganizationExt
@@ -845,7 +845,7 @@ public class NotificationOrderChainMapperTests
             [
                 new NotificationReminderExt
                 {
-                    DelayDays = 3,
+                    RequestedSendTime = baseTime.AddDays(3),
                     Recipient = new NotificationRecipientExt
                     {
                         RecipientOrganization = new RecipientOrganizationExt
@@ -1088,7 +1088,7 @@ public class NotificationOrderChainMapperTests
             [
                 new NotificationReminderExt
                 {
-                    DelayDays = 3,
+                    RequestedSendTime = baseTime.AddDays(3),
                     SendersReference = "ref-reminder-A3BCFE4284D6",
                     ConditionEndpoint = new Uri("https://vg.no/first-reminder-condition"),
 
@@ -1633,7 +1633,7 @@ public class NotificationOrderChainMapperTests
                 },
                 new NotificationReminderExt
                 {
-                    DelayDays = 7,
+                    RequestedSendTime = baseTime.AddDays(7),
                     Recipient = new NotificationRecipientExt
                     {
                         RecipientPerson = new RecipientPersonExt

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationOrderChainRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationOrderChainRequestValidatorTests.cs
@@ -217,7 +217,7 @@ public class NotificationOrderChainRequestValidatorTests
                 new NotificationReminderExt
                 {
                     SendersReference = "te-123-123",
-                    RequestedSendTime = DateTime.Now.AddDays(10),
+                    RequestedSendTime = DateTime.UtcNow.AddDays(10),
                     ConditionEndpoint = new Uri("https://api.te.no/altinn/te-123-145/?seen=true"),
                     Recipient = new NotificationRecipientExt
                     {

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationOrderChainRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationOrderChainRequestValidatorTests.cs
@@ -290,33 +290,33 @@ public class NotificationOrderChainRequestValidatorTests
             Reminders =
             [
                 new NotificationReminderExt
-            {
-                ConditionEndpoint = new Uri("https://api.te.no/altinn/te-123-123/?seen=true"),
-                SendersReference = "te-123-123",
-                DelayDays = 7,
-                Recipient = new NotificationRecipientExt
                 {
-                    RecipientPerson = new RecipientPersonExt
+                    ConditionEndpoint = new Uri("https://api.te.no/altinn/te-123-123/?seen=true"),
+                    SendersReference = "te-123-123",
+                    DelayDays = 7,
+                    Recipient = new NotificationRecipientExt
                     {
-                        NationalIdentityNumber = "11122233300",
-                        ResourceId = "urn:altinn:resource:te_svc123",
-                        IgnoreReservation = true,
-                        ChannelSchema = NotificationChannelExt.SmsPreferred,
-                        SmsSettings = new SmsSendingOptionsExt
+                        RecipientPerson = new RecipientPersonExt
                         {
-                            SendingTimePolicy = SendingTimePolicyExt.Daytime,
-                            Body = "Du har en melding fra TE som krever handling. Logg inn i Altinn for å gjøre deg kjent med innholdet.",
-                            Sender = "1234 TE"
-                        },
-                        EmailSettings = new EmailSendingOptionsExt
-                        {
-                            SendingTimePolicy = SendingTimePolicyExt.Anytime,
-                            Subject = "Påminnelse: Melding fra TE",
-                            Body = "Du har en melding fra TE som krever handling. Logg inn i Altinn for å gjøre deg kjent med innholdet."
+                            NationalIdentityNumber = "11122233300",
+                            ResourceId = "urn:altinn:resource:te_svc123",
+                            IgnoreReservation = true,
+                            ChannelSchema = NotificationChannelExt.SmsPreferred,
+                            SmsSettings = new SmsSendingOptionsExt
+                            {
+                                SendingTimePolicy = SendingTimePolicyExt.Daytime,
+                                Body = "Du har en melding fra TE som krever handling. Logg inn i Altinn for å gjøre deg kjent med innholdet.",
+                                Sender = "1234 TE"
+                            },
+                            EmailSettings = new EmailSendingOptionsExt
+                            {
+                                SendingTimePolicy = SendingTimePolicyExt.Anytime,
+                                Subject = "Påminnelse: Melding fra TE",
+                                Body = "Du har en melding fra TE som krever handling. Logg inn i Altinn for å gjøre deg kjent med innholdet."
+                            }
                         }
                     }
                 }
-            }
             ]
         };
 

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationOrderChainRequestValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationOrderChainRequestValidatorTests.cs
@@ -8,6 +8,7 @@ using Altinn.Notifications.Models.Sms;
 using Altinn.Notifications.Validators;
 
 using FluentValidation.TestHelper;
+
 using Xunit;
 
 namespace Altinn.Notifications.Tests.Notifications.TestingValidators;
@@ -72,7 +73,7 @@ public class NotificationOrderChainRequestValidatorTests
                 {
                     ConditionEndpoint = new Uri("https://api.te.no/altinn/te-123-123/?seen=true"),
                     SendersReference = "te-123-123-rem-2",
-                    DelayDays = 14,
+                    RequestedSendTime = DateTime.UtcNow.AddDays(14),
                     Recipient = new NotificationRecipientExt
                     {
                         RecipientOrganization = new RecipientOrganizationExt
@@ -189,6 +190,35 @@ public class NotificationOrderChainRequestValidatorTests
                     ConditionEndpoint = new Uri("https://api.te.no/altinn/te-123-123/?seen=true"),
                     SendersReference = "te-123-123",
                     DelayDays = 7,
+                    Recipient = new NotificationRecipientExt
+                    {
+                        RecipientPerson = new RecipientPersonExt
+                        {
+                            NationalIdentityNumber = "11122233300",
+                            ResourceId = "urn:altinn:resource:te_svc123",
+                            IgnoreReservation = false,
+                            ChannelSchema = NotificationChannelExt.EmailPreferred,
+                            SmsSettings = new SmsSendingOptionsExt
+                            {
+                                SendingTimePolicy = SendingTimePolicyExt.Daytime,
+                                Sender = "1234 TE",
+                                Body = "Du har en melding fra TE som krever handling. Logg inn i Altinn for å gjøre deg kjent med innholdet."
+                            },
+                            EmailSettings = new EmailSendingOptionsExt
+                            {
+                                SenderEmailAddress = "noreply-te@example.com",
+                                SendingTimePolicy = SendingTimePolicyExt.Anytime,
+                                Subject = "Påminnelse: Melding fra TE",
+                                Body = "Du har en melding fra TE som krever handling"
+                            }
+                        }
+                    }
+                },
+                new NotificationReminderExt
+                {
+                    SendersReference = "te-123-123",
+                    RequestedSendTime = DateTime.Now.AddDays(10),
+                    ConditionEndpoint = new Uri("https://api.te.no/altinn/te-123-145/?seen=true"),
                     Recipient = new NotificationRecipientExt
                     {
                         RecipientPerson = new RecipientPersonExt


### PR DESCRIPTION
## Description
Introduce a new parameter 'requestedSendTime' for reminder so that users can send reminder the same date as the main notification.

## Related Issue(s)
- #871 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying either an explicit send time or a delay in days for notification reminders, providing more flexible scheduling options.

* **Bug Fixes**
  * Improved validation to ensure only one of delay days or requested send time is set for reminders, preventing conflicting configurations.

* **Refactor**
  * Updated data models to be immutable and enhanced the handling of reminder scheduling.
  * Standardized and clarified test setup and utility methods for better maintainability.

* **Tests**
  * Updated and expanded test cases to cover new reminder scheduling options and validation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->