### PR TITLE
Move the function used to sanitize the resource identifier to the authorization service

### DIFF
--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -147,7 +147,7 @@ public class OrderRequestService : IOrderRequestService
     {
         var (recipients, templates, channel, ignoreReservation, resourceId, sendingTimePolicyForSms) = ExtractDeliveryComponents(orderRequest.Recipient);
 
-        var lookupResult = await GetRecipientLookupResult(recipients, channel, GetSanitizedResourceId(resourceId));
+        var lookupResult = await GetRecipientLookupResult(recipients, channel, resourceId);
 
         if (lookupResult?.MissingContact?.Count > 0)
         {
@@ -232,7 +232,7 @@ public class OrderRequestService : IOrderRequestService
 
             var (recipients, templates, channel, ignoreReservation, resourceId, sendingTimePolicyForSms) = ExtractDeliveryComponents(notificationReminder.Recipient);
 
-            var lookupResult = await GetRecipientLookupResult(recipients, channel, GetSanitizedResourceId(resourceId));
+            var lookupResult = await GetRecipientLookupResult(recipients, channel, resourceId);
 
             if (lookupResult?.MissingContact?.Count > 0)
             {
@@ -338,16 +338,6 @@ public class OrderRequestService : IOrderRequestService
         };
 
         return response;
-    }
-
-    private static string? GetSanitizedResourceId(string? resourceId)
-    {
-        if (string.IsNullOrWhiteSpace(resourceId))
-        {
-            return null;
-        }
-
-        return resourceId.StartsWith("urn:altinn:resource:", StringComparison.Ordinal) ? resourceId["urn:altinn:resource:".Length..] : resourceId;
     }
 
     private async Task<RecipientLookupResult?> GetRecipientLookupResult(List<Recipient> originalRecipients, NotificationChannel channel, string? resourceId)

--- a/src/Altinn.Notifications.Integrations/Authorization/AuthorizationService.cs
+++ b/src/Altinn.Notifications.Integrations/Authorization/AuthorizationService.cs
@@ -83,11 +83,6 @@ public class AuthorizationService : IAuthorizationService
 
     private static string GetSanitizedResourceId(string resourceId)
     {
-        if (string.IsNullOrWhiteSpace(resourceId))
-        {
-            return resourceId;
-        }
-
         return resourceId.StartsWith("urn:altinn:resource:", StringComparison.Ordinal) ? resourceId["urn:altinn:resource:".Length..] : resourceId;
     }
 

--- a/src/Altinn.Notifications.Integrations/Authorization/AuthorizationService.cs
+++ b/src/Altinn.Notifications.Integrations/Authorization/AuthorizationService.cs
@@ -41,14 +41,15 @@ public class AuthorizationService : IAuthorizationService
     /// <param name="organizationContactPoints">The list organizations with associated right holders.</param>
     /// <param name="resourceId">The id of the resource.</param>
     /// <returns>A new list of <see cref="OrganizationContactPoints"/> with filtered list of recipients.</returns>
-    public async Task<List<OrganizationContactPoints>> AuthorizeUserContactPointsForResource(
-        List<OrganizationContactPoints> organizationContactPoints, string resourceId)
+    public async Task<List<OrganizationContactPoints>> AuthorizeUserContactPointsForResource(List<OrganizationContactPoints> organizationContactPoints, string resourceId)
     {
-        XacmlJsonRequestRoot jsonRequest = BuildAuthorizationRequest(organizationContactPoints, resourceId);
+        var sanitizedResourceId = GetSanitizedResourceId(resourceId);
+
+        XacmlJsonRequestRoot jsonRequest = BuildAuthorizationRequest(organizationContactPoints, sanitizedResourceId);
 
         XacmlJsonResponse xacmlJsonResponse = await _pdp.GetDecisionForRequest(jsonRequest);
 
-        List<OrganizationContactPoints> filtered = 
+        List<OrganizationContactPoints> filtered =
             organizationContactPoints.Select(o => o.CloneWithoutContactPoints()).ToList();
 
         foreach (var response in xacmlJsonResponse.Response.Where(r => r.Decision == "Permit"))
@@ -78,6 +79,16 @@ public class AuthorizationService : IAuthorizationService
         }
 
         return filtered;
+    }
+
+    private static string GetSanitizedResourceId(string resourceId)
+    {
+        if (string.IsNullOrWhiteSpace(resourceId))
+        {
+            return resourceId;
+        }
+
+        return resourceId.StartsWith("urn:altinn:resource:", StringComparison.Ordinal) ? resourceId["urn:altinn:resource:".Length..] : resourceId;
     }
 
     private static XacmlJsonRequestRoot BuildAuthorizationRequest(List<OrganizationContactPoints> organizationContactPoints, string resourceId)

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -795,8 +795,10 @@ public class OrderRequestServiceTests
     }
 
     [Theory]
-    [InlineData("urn:altinn:resource:tax-2025")]
+    [InlineData("")]
+    [InlineData("   ")]
     [InlineData("tax-2025")]
+    [InlineData("urn:altinn:resource:tax-2025")]
     public async Task RegisterNotificationOrderChain_RecipientPersonWithMultipleReminders_OrderChainCreated(string resourceId)
     {
         // Arrange

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -1061,7 +1061,7 @@ public class OrderRequestServiceTests
                     cp => cp.AddPreferredContactPoints(
                         It.Is<NotificationChannel>(ch => ch == NotificationChannel.EmailPreferred),
                         It.Is<List<Recipient>>(r => r.Any(rec => rec.NationalIdentityNumber == "29105573746")),
-                        It.Is<string?>(s => s == "tax-2025")),
+                        It.Is<string?>(s => s == resourceId)),
                     Times.Exactly(2));
 
                 // Verify contact point added the expected email address
@@ -1069,7 +1069,7 @@ public class OrderRequestServiceTests
                     cp => cp.AddPreferredContactPoints(
                         It.Is<NotificationChannel>(ch => ch == NotificationChannel.SmsPreferred),
                         It.Is<List<Recipient>>(r => r.Any(rec => rec.NationalIdentityNumber == "29105573746")),
-                        It.Is<string?>(s => s == "tax-2025")),
+                        It.Is<string?>(s => s == resourceId)),
                     Times.Once);
 
                 return true;
@@ -1200,7 +1200,7 @@ public class OrderRequestServiceTests
                 contactPointServiceMock.Verify(
                     cp => cp.AddEmailAndSmsContactPointsAsync(
                     It.Is<List<Recipient>>(r => r.Any(rec => rec.OrganizationNumber == "312508729")),
-                    It.Is<string?>(s => s == "email-sms-resource-name")), // prefix urn:altinn:resource: is stripped
+                    It.Is<string?>(s => s == "urn:altinn:resource:email-sms-resource-name")), // prefix urn:altinn:resource: is stripped
                     Times.Once);
 
                 return true;
@@ -1388,7 +1388,7 @@ public class OrderRequestServiceTests
                 contactPointServiceMock.Verify(
                     cp => cp.AddSmsContactPoints(
                         It.Is<List<Recipient>>(r => r.Any(rec => rec.NationalIdentityNumber == "16069412345")),
-                        It.Is<string?>(s => s == "sms-test")),
+                        It.Is<string?>(s => s == "urn:altinn:resource:sms-test")),
                     Times.Once);
 
                 return true;
@@ -1675,7 +1675,7 @@ public class OrderRequestServiceTests
                 contactPointMock.Verify(
                     contactService => contactService.AddEmailContactPoints(
                         It.Is<List<Recipient>>(r => r.Any(rec => rec.NationalIdentityNumber == "16069412345")),
-                        It.Is<string?>(s => s == "test")),
+                        It.Is<string?>(s => s == "urn:altinn:resource:test")),
                     Times.Once);
 
                 return true;

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -1200,7 +1200,7 @@ public class OrderRequestServiceTests
                 contactPointServiceMock.Verify(
                     cp => cp.AddEmailAndSmsContactPointsAsync(
                     It.Is<List<Recipient>>(r => r.Any(rec => rec.OrganizationNumber == "312508729")),
-                    It.Is<string?>(s => s == "urn:altinn:resource:email-sms-resource-name")), // prefix urn:altinn:resource: is stripped
+                    It.Is<string?>(s => s == "urn:altinn:resource:email-sms-resource-name")),
                     Times.Once);
 
                 return true;

--- a/test/Altinn.Notifications.Tests/Notifications.Integrations/Authorization/AuthorizationServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Integrations/Authorization/AuthorizationServiceTests.cs
@@ -51,7 +51,7 @@ public class AuthorizationServiceTests
 
         // Act
         List<OrganizationContactPoints> actualResult =
-            await _target.AuthorizeUserContactPointsForResource(organizationContactPoints, "app_ttd_apps-test");
+            await _target.AuthorizeUserContactPointsForResource(organizationContactPoints, "urn:altinn:resource:app_ttd_apps-test");
 
         // Assert
         XacmlJsonRequestRoot expectedRequest = await TestDataLoader.Load<XacmlJsonRequestRoot>("PermitAll");
@@ -132,7 +132,7 @@ public class AuthorizationServiceTests
 
         // Act
         List<OrganizationContactPoints> actualResult =
-            await _target.AuthorizeUserContactPointsForResource(organizationContactPoints, "app_ttd_apps-test");
+            await _target.AuthorizeUserContactPointsForResource(organizationContactPoints, "urn:altinn:resource:app_ttd_apps-test");
 
         // Assert
         XacmlJsonRequestRoot expectedRequest = await TestDataLoader.Load<XacmlJsonRequestRoot>("DenyAll");


### PR DESCRIPTION
## Description
Move the function used to sanitize the resource identifier to the authorization service

## Related Issue(s)
- #975 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of resource identifiers to ensure consistent processing and authorization of user contact points.
  * Updated tests to reflect the use of fully qualified resource identifiers with standardized prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->