### PR TITLE
Do not rethrow the original exception that was caught

### DIFF
--- a/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
@@ -136,7 +136,7 @@ public class EmailNotificationRepository : NotificationRepositoryBase, IEmailNot
             /// throw;
             /// Temporary: Log error but don't rethrow to reduce notification volume (Issue #980)
             /// TODO: Remove this suppression once root cause is fixed
-            _logger.LogError(ex, "Failed to update email notification status for NotificationId: {NotificationId}, OperationId: {OperationId}, Status: {Status}", notificationId, operationId, status);
+            _logger.LogError(ex, "Failed to update email notification status for NotificationId: {NotificationId}, Status: {Status}", notificationId, status);
         }
     }
 

--- a/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
@@ -129,10 +129,14 @@ public class EmailNotificationRepository : NotificationRepositoryBase, IEmailNot
 
             await transaction.CommitAsync();
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             await transaction.RollbackAsync();
-            ///throw;
+
+            /// throw;
+            /// Temporary: Log error but don't rethrow to reduce notification volume (Issue #980)
+            /// TODO: Remove this suppression once root cause is fixed
+            _logger.LogError(ex, "Failed to update email notification status for NotificationId: {NotificationId}, OperationId: {OperationId}, Status: {Status}", notificationId, operationId, status);
         }
     }
 

--- a/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
@@ -133,9 +133,9 @@ public class EmailNotificationRepository : NotificationRepositoryBase, IEmailNot
         {
             await transaction.RollbackAsync();
 
-            /// throw;
-            /// Temporary: Log error but don't rethrow to reduce notification volume (Issue #980)
-            /// TODO: Remove this suppression once root cause is fixed
+            //throw;
+            //Temporary: Log error but don't rethrow to reduce notification volume (Issue #980)
+            //TODO: Remove this suppression once root cause is fixed
             _logger.LogError(ex, "Failed to update email notification status for NotificationId: {NotificationId}, Status: {Status}", notificationId, status);
         }
     }

--- a/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
@@ -132,7 +132,7 @@ public class EmailNotificationRepository : NotificationRepositoryBase, IEmailNot
         catch (Exception)
         {
             await transaction.RollbackAsync();
-            throw;
+            ///throw;
         }
     }
 


### PR DESCRIPTION
## Description
The watchman is receiving a high volume of push notifications due to a bug in the Notification API. To mitigate the issue temporarily, I disabled the part of the code that rethrows the original exception caught during the processing of email notification statuses.

## Related Issue(s)
- #980 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during email notification status updates to prevent exceptions from being propagated to the user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->