### PR TITLE
Do not log delivery information

### DIFF
--- a/src/Altinn.Notifications.Persistence/Repository/NotificationRepositoryBase.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/NotificationRepositoryBase.cs
@@ -191,12 +191,13 @@ public abstract class NotificationRepositoryBase
         {
             string status = string.Empty;
             string destination = string.Empty;
-            bool isValidMobileNumber = MobileNumberHelper.IsValidMobileNumber(destination);
+            bool isValidMobileNumber = false;
 
             try
             {
                 status = await reader.GetFieldValueAsync<string>("status");
                 destination = await reader.GetFieldValueAsync<string>("destination");
+                isValidMobileNumber = MobileNumberHelper.IsValidMobileNumber(destination);
 
                 var recipient = new Recipient
                 {


### PR DESCRIPTION
## Description
When an exception is logged and rethrown, the upstream code may not be aware that the exception has already been logged. As a result, the same exception gets logged multiple times, making it difficult to identify the root cause of the issue. This can be particularly problematic in multi-threaded applications where messages from other threads can be interwoven with the repeated log entries.

## Related Issue(s)
- #980

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the way recipients are read and processed, resulting in more streamlined handling of recipient data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->