### PR TITLE
Add support for RecipientEmailAndSms for dual-channel notifications

### DIFF
--- a/src/Altinn.Notifications.Core/Models/Recipients/NotificationRecipient.cs
+++ b/src/Altinn.Notifications.Core/Models/Recipients/NotificationRecipient.cs
@@ -28,4 +28,10 @@ public class NotificationRecipient
     /// to deliver notifications to a contact person identified by an organization number.
     /// </summary>
     public RecipientOrganization? RecipientOrganization { get; set; }
+
+    /// <summary>
+    /// Gets or sets an object capturing all the information needed
+    /// to send both email and SMS notifications to specific addresses.
+    /// </summary>
+    public RecipientEmailAndSms? RecipientEmailAndSms { get; set; }
 }

--- a/src/Altinn.Notifications.Core/Models/Recipients/RecipientEmailAndSms.cs
+++ b/src/Altinn.Notifications.Core/Models/Recipients/RecipientEmailAndSms.cs
@@ -1,0 +1,40 @@
+namespace Altinn.Notifications.Core.Models.Recipients;
+
+/// <summary>
+/// Defines a model for sending both email and SMS notifications to specific addresses.
+/// </summary>
+public class RecipientEmailAndSms
+{
+    /// <summary>
+    /// Gets or sets the email address of the intended recipient.
+    /// </summary>
+    /// <remarks>
+    /// This is the destination address where the email will be delivered.
+    /// </remarks>
+    public required string EmailAddress { get; set; }
+
+    /// <summary>
+    /// Gets or sets the recipient's phone number in international format.
+    /// </summary>
+    /// <remarks>
+    /// This is the destination number where the SMS will be delivered.
+    /// The phone number should include the country code (e.g., +4799999999).
+    /// </remarks>
+    public required string PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the configuration options for the email message.
+    /// </summary>
+    /// <remarks>
+    /// These settings control how and when the email will be composed and delivered to the recipient.
+    /// </remarks>
+    public required EmailSendingOptions EmailSettings { get; set; }
+
+    /// <summary>
+    /// Gets or sets the configuration options for the SMS message.
+    /// </summary>
+    /// <remarks>
+    /// Contains sender information, message content, and delivery timing preferences.
+    /// </remarks>
+    public required SmsSendingOptions SmsSettings { get; set; }
+}

--- a/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -591,6 +591,19 @@ public class OrderRequestService : IOrderRequestService
 
             recipients.Add(new Recipient([], organizationNumber: recipient.RecipientOrganization.OrgNumber));
         }
+        else if (recipient.RecipientEmailAndSms != null)
+        {
+            notificationChannel = NotificationChannel.EmailAndSms;
+            smsSendingTimePolicy = recipient.RecipientEmailAndSms.SmsSettings.SendingTimePolicy;
+
+            templates.Add(CreateEmailTemplate(recipient.RecipientEmailAndSms.EmailSettings));
+            templates.Add(CreateSmsTemplate(recipient.RecipientEmailAndSms.SmsSettings));
+
+            recipients.Add(new Recipient([
+                new EmailAddressPoint(recipient.RecipientEmailAndSms.EmailAddress),
+                new SmsAddressPoint(recipient.RecipientEmailAndSms.PhoneNumber)
+            ]));
+        }
 
         return (recipients, templates, notificationChannel, ignoreReservation, resourceIdentifier, smsSendingTimePolicy);
     }

--- a/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
+++ b/src/Altinn.Notifications/Mappers/NotificationOrderChainMapper.cs
@@ -32,7 +32,8 @@ public static partial class NotificationOrderChainMapper
             RecipientSms = notificationOrderChainRequestExt.Recipient.RecipientSms?.MapToRecipientSms(),
             RecipientEmail = notificationOrderChainRequestExt.Recipient.RecipientEmail?.MapToRecipientEmail(),
             RecipientPerson = notificationOrderChainRequestExt.Recipient.RecipientPerson?.MapToRecipientPerson(),
-            RecipientOrganization = notificationOrderChainRequestExt.Recipient.RecipientOrganization?.MapToRecipientOrganization()
+            RecipientOrganization = notificationOrderChainRequestExt.Recipient.RecipientOrganization?.MapToRecipientOrganization(),
+            RecipientEmailAndSms = notificationOrderChainRequestExt.Recipient.RecipientEmailAndSms?.MapToRecipientEmailAndSms()
         };
 
         // Map the reminders and set their RequestedSendTime based on the main notification's requested time plus the delay.
@@ -116,7 +117,8 @@ public static partial class NotificationOrderChainMapper
                 RecipientSms = notificationReminderExt.Recipient.RecipientSms?.MapToRecipientSms(),
                 RecipientEmail = notificationReminderExt.Recipient.RecipientEmail?.MapToRecipientEmail(),
                 RecipientPerson = notificationReminderExt.Recipient.RecipientPerson?.MapToRecipientPerson(),
-                RecipientOrganization = notificationReminderExt.Recipient.RecipientOrganization?.MapToRecipientOrganization()
+                RecipientOrganization = notificationReminderExt.Recipient.RecipientOrganization?.MapToRecipientOrganization(),
+                RecipientEmailAndSms = notificationReminderExt.Recipient.RecipientEmailAndSms?.MapToRecipientEmailAndSms()
             },
 
             OrderId = Guid.NewGuid(),
@@ -196,6 +198,20 @@ public static partial class NotificationOrderChainMapper
             Body = smsSendingOptionsExt.Body,
             Sender = smsSendingOptionsExt.Sender?.Trim(),
             SendingTimePolicy = (SendingTimePolicy)smsSendingOptionsExt.SendingTimePolicy
+        };
+    }
+
+    /// <summary>
+    /// Maps a <see cref="RecipientEmailAndSmsExt"/> to a <see cref="RecipientEmailAndSms"/>.
+    /// </summary>
+    private static RecipientEmailAndSms MapToRecipientEmailAndSms(this RecipientEmailAndSmsExt recipientEmailAndSmsExt)
+    {
+        return new RecipientEmailAndSms
+        {
+            EmailAddress = recipientEmailAndSmsExt.EmailAddress,
+            PhoneNumber = recipientEmailAndSmsExt.PhoneNumber,
+            EmailSettings = recipientEmailAndSmsExt.EmailSettings.MapToEmailSendingOptions(),
+            SmsSettings = recipientEmailAndSmsExt.SmsSettings.MapToSmsSendingOptions()
         };
     }
 

--- a/src/Altinn.Notifications/Models/NotificationRecipientExt.cs
+++ b/src/Altinn.Notifications/Models/NotificationRecipientExt.cs
@@ -52,4 +52,14 @@ public class NotificationRecipientExt
     /// </remarks>
     [JsonPropertyName("recipientOrganization")]
     public RecipientOrganizationExt? RecipientOrganization { get; set; }
+
+    /// <summary>
+    /// Gets or sets the configuration for delivering notifications through both email and SMS channels.
+    /// </summary>
+    /// <remarks>
+    /// Use when you have both the recipient's email address and phone number and want to send
+    /// notifications through both channels simultaneously.
+    /// </remarks>
+    [JsonPropertyName("recipientEmailAndSms")]
+    public RecipientEmailAndSmsExt? RecipientEmailAndSms { get; set; }
 }

--- a/src/Altinn.Notifications/Models/Recipient/RecipientEmailAndSmsExt.cs
+++ b/src/Altinn.Notifications/Models/Recipient/RecipientEmailAndSmsExt.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+using Altinn.Notifications.Models.Email;
+using Altinn.Notifications.Models.Sms;
+
+namespace Altinn.Notifications.Models.Recipient;
+
+/// <summary>
+/// Defines a request for sending both email and SMS notifications to specific addresses.
+/// </summary>
+/// <remarks>
+/// This class is used in the API for configuring notification delivery to a single recipient
+/// through both email and SMS channels simultaneously, with specific content and delivery preferences for each channel.
+/// </remarks>
+public class RecipientEmailAndSmsExt
+{
+    /// <summary>
+    /// Gets or sets the email address of the intended recipient.
+    /// </summary>
+    /// <remarks>
+    /// This is the destination address where the email will be delivered.
+    /// </remarks>
+    [Required]
+    [JsonPropertyName("emailAddress")]
+    public required string EmailAddress { get; set; }
+
+    /// <summary>
+    /// Gets or sets the recipient's phone number in international format.
+    /// </summary>
+    /// <remarks>
+    /// This is the destination number where the SMS will be delivered.
+    /// The phone number should include the country code (e.g., +4799999999).
+    /// </remarks>
+    [Required]
+    [JsonPropertyName("phoneNumber")]
+    public required string PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets the configuration options for the email message.
+    /// </summary>
+    /// <remarks>
+    /// These settings control how and when the email will be composed and delivered to the recipient.
+    /// </remarks>
+    [Required]
+    [JsonPropertyName("emailSettings")]
+    public required EmailSendingOptionsExt EmailSettings { get; set; }
+
+    /// <summary>
+    /// Gets or sets the configuration options for the SMS message.
+    /// </summary>
+    /// <remarks>
+    /// Contains sender information, message content, and delivery timing preferences.
+    /// </remarks>
+    [Required]
+    [JsonPropertyName("smsSettings")]
+    public required SmsSendingOptionsExt SmsSettings { get; set; }
+}

--- a/src/Altinn.Notifications/Validators/NotificationRecipientValidator.cs
+++ b/src/Altinn.Notifications/Validators/NotificationRecipientValidator.cs
@@ -36,6 +36,9 @@ namespace Altinn.Notifications.Validators
 
             RuleFor(specification => specification.RecipientOrganization)
                 .SetValidator(validator: new RecipientOrganizationValidator());
+
+            RuleFor(specification => specification.RecipientEmailAndSms)
+                .SetValidator(validator: new RecipientEmailAndSmsValidator());
         }
 
         /// <summary>
@@ -50,7 +53,8 @@ namespace Altinn.Notifications.Validators
                 specification.RecipientEmail,
                 specification.RecipientSms,
                 specification.RecipientPerson,
-                specification.RecipientOrganization
+                specification.RecipientOrganization,
+                specification.RecipientEmailAndSms
             }.Count(recipient => recipient != null) == 1;
         }
     }

--- a/src/Altinn.Notifications/Validators/Recipient/RecipientEmailAndSmsValidator.cs
+++ b/src/Altinn.Notifications/Validators/Recipient/RecipientEmailAndSmsValidator.cs
@@ -1,0 +1,38 @@
+using Altinn.Notifications.Models.Recipient;
+using Altinn.Notifications.Validators.Email;
+using Altinn.Notifications.Validators.Sms;
+
+using FluentValidation;
+
+namespace Altinn.Notifications.Validators.Recipient;
+
+/// <summary>
+/// Represents validation logic for the recipient email and SMS model.
+/// </summary>
+public class RecipientEmailAndSmsValidator : AbstractValidator<RecipientEmailAndSmsExt?>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RecipientEmailAndSmsValidator"/> class.
+    /// </summary>
+    public RecipientEmailAndSmsValidator()
+    {
+        RuleFor(recipient => recipient!.EmailAddress)
+            .NotEmpty()
+            .EmailAddress()
+            .WithMessage("Email address must be a valid email address.");
+
+        RuleFor(recipient => recipient!.PhoneNumber)
+            .NotEmpty()
+            .WithMessage("Phone number is required.");
+
+        RuleFor(recipient => recipient!.EmailSettings)
+            .NotNull()
+            .WithMessage("Email settings are required.")
+            .SetValidator(new EmailSendingOptionsValidator());
+
+        RuleFor(recipient => recipient!.SmsSettings)
+            .NotNull()
+            .WithMessage("SMS settings are required.")
+            .SetValidator(new SmsSendingOptionsValidator());
+    }
+}

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationRecipientValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/NotificationRecipientValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Altinn.Notifications.Models;
 using Altinn.Notifications.Models.Email;
+using Altinn.Notifications.Models.Recipient;
 using Altinn.Notifications.Models.Sms;
 using Altinn.Notifications.Validators;
 
@@ -95,6 +96,73 @@ public class NotificationRecipientValidatorTests
                 {
                     Sender = "Test message",
                     Body = "hello world"
+                }
+            }
+        };
+
+        // Act
+        var actual = _validator.TestValidate(recipient);
+
+        // Assert
+        actual.ShouldHaveValidationErrorFor(recipient => recipient).WithErrorMessage("Must have exactly one recipient.");
+    }
+
+    [Fact]
+    public void Should_Have_No_Validation_Errors_When_Only_RecipientEmailAndSms()
+    {
+        // Arrange
+        var recipient = new NotificationRecipientExt
+        {
+            RecipientEmailAndSms = new RecipientEmailAndSmsExt
+            {
+                EmailAddress = "noreply@digdir.no",
+                PhoneNumber = "+4740000000",
+                EmailSettings = new EmailSendingOptionsExt
+                {
+                    Body = "Test body",
+                    Subject = "Test subject",
+                },
+                SmsSettings = new SmsSendingOptionsExt
+                {
+                    Body = "Test message"
+                }
+            }
+        };
+
+        // Act
+        var actual = _validator.TestValidate(recipient);
+
+        // Assert
+        actual.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Should_Have_Validation_Error_When_RecipientEmailAndSms_Plus_Another_Recipient()
+    {
+        // Arrange
+        var recipient = new NotificationRecipientExt
+        {
+            RecipientEmailAndSms = new RecipientEmailAndSmsExt
+            {
+                EmailAddress = "noreply@digdir.no",
+                PhoneNumber = "+4740000000",
+                EmailSettings = new EmailSendingOptionsExt
+                {
+                    Body = "Test body",
+                    Subject = "Test subject",
+                },
+                SmsSettings = new SmsSendingOptionsExt
+                {
+                    Body = "Test message"
+                }
+            },
+            RecipientEmail = new RecipientEmailExt
+            {
+                EmailAddress = "another@digdir.no",
+                Settings = new EmailSendingOptionsExt
+                {
+                    Body = "Test body",
+                    Subject = "Test subject",
                 }
             }
         };

--- a/test/Altinn.Notifications.Tests/Notifications/TestingValidators/RecipientEmailAndSmsValidatorTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingValidators/RecipientEmailAndSmsValidatorTests.cs
@@ -1,0 +1,161 @@
+using Altinn.Notifications.Models;
+using Altinn.Notifications.Models.Email;
+using Altinn.Notifications.Models.Recipient;
+using Altinn.Notifications.Models.Sms;
+using Altinn.Notifications.Validators.Recipient;
+
+using FluentValidation.TestHelper;
+
+using Xunit;
+
+namespace Altinn.Notifications.Tests.Notifications.TestingValidators;
+
+public class RecipientEmailAndSmsValidatorTests
+{
+    [Fact]
+    public void Validate_ValidRecipient_ShouldNotHaveErrors()
+    {
+        // Arrange
+        var validator = new RecipientEmailAndSmsValidator();
+        var recipient = new RecipientEmailAndSmsExt
+        {
+            EmailAddress = "test@example.com",
+            PhoneNumber = "+4799999999",
+            EmailSettings = new EmailSendingOptionsExt
+            {
+                Subject = "Test Subject",
+                Body = "Test Body",
+                ContentType = EmailContentTypeExt.Plain
+            },
+            SmsSettings = new SmsSendingOptionsExt
+            {
+                Body = "Test SMS"
+            }
+        };
+
+        // Act & Assert
+        validator.TestValidate(recipient).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_MissingEmailAddress_ShouldHaveError()
+    {
+        // Arrange
+        var validator = new RecipientEmailAndSmsValidator();
+        var recipient = new RecipientEmailAndSmsExt
+        {
+            EmailAddress = string.Empty,
+            PhoneNumber = "+4799999999",
+            EmailSettings = new EmailSendingOptionsExt
+            {
+                Subject = "Test Subject",
+                Body = "Test Body",
+                ContentType = EmailContentTypeExt.Plain
+            },
+            SmsSettings = new SmsSendingOptionsExt
+            {
+                Body = "Test SMS"
+            }
+        };
+
+        // Act & Assert
+        validator.TestValidate(recipient)
+            .ShouldHaveValidationErrorFor(r => r.EmailAddress);
+    }
+
+    [Fact]
+    public void Validate_InvalidEmailAddress_ShouldHaveError()
+    {
+        // Arrange
+        var validator = new RecipientEmailAndSmsValidator();
+        var recipient = new RecipientEmailAndSmsExt
+        {
+            EmailAddress = "invalid-email",
+            PhoneNumber = "+4799999999",
+            EmailSettings = new EmailSendingOptionsExt
+            {
+                Subject = "Test Subject",
+                Body = "Test Body",
+                ContentType = EmailContentTypeExt.Plain
+            },
+            SmsSettings = new SmsSendingOptionsExt
+            {
+                Body = "Test SMS"
+            }
+        };
+
+        // Act & Assert
+        validator.TestValidate(recipient)
+            .ShouldHaveValidationErrorFor(r => r.EmailAddress);
+    }
+
+    [Fact]
+    public void Validate_MissingPhoneNumber_ShouldHaveError()
+    {
+        // Arrange
+        var validator = new RecipientEmailAndSmsValidator();
+        var recipient = new RecipientEmailAndSmsExt
+        {
+            EmailAddress = "test@example.com",
+            PhoneNumber = string.Empty,
+            EmailSettings = new EmailSendingOptionsExt
+            {
+                Subject = "Test Subject",
+                Body = "Test Body",
+                ContentType = EmailContentTypeExt.Plain
+            },
+            SmsSettings = new SmsSendingOptionsExt
+            {
+                Body = "Test SMS"
+            }
+        };
+
+        // Act & Assert
+        validator.TestValidate(recipient)
+            .ShouldHaveValidationErrorFor(r => r.PhoneNumber);
+    }
+
+    [Fact]
+    public void Validate_MissingEmailSettings_ShouldHaveError()
+    {
+        // Arrange
+        var validator = new RecipientEmailAndSmsValidator();
+        var recipient = new RecipientEmailAndSmsExt
+        {
+            EmailAddress = "test@example.com",
+            PhoneNumber = "+4799999999",
+            EmailSettings = null!,
+            SmsSettings = new SmsSendingOptionsExt
+            {
+                Body = "Test SMS"
+            }
+        };
+
+        // Act & Assert
+        validator.TestValidate(recipient)
+            .ShouldHaveValidationErrorFor(r => r.EmailSettings);
+    }
+
+    [Fact]
+    public void Validate_MissingSmsSettings_ShouldHaveError()
+    {
+        // Arrange
+        var validator = new RecipientEmailAndSmsValidator();
+        var recipient = new RecipientEmailAndSmsExt
+        {
+            EmailAddress = "test@example.com",
+            PhoneNumber = "+4799999999",
+            EmailSettings = new EmailSendingOptionsExt
+            {
+                Subject = "Test Subject",
+                Body = "Test Body",
+                ContentType = EmailContentTypeExt.Plain
+            },
+            SmsSettings = null!
+        };
+
+        // Act & Assert
+        validator.TestValidate(recipient)
+            .ShouldHaveValidationErrorFor(r => r.SmsSettings);
+    }
+}

--- a/test/bruno/v2 (future)/create-notifications/test-recipient-email-and-sms.bru
+++ b/test/bruno/v2 (future)/create-notifications/test-recipient-email-and-sms.bru
@@ -1,0 +1,44 @@
+meta {
+  name: Test RecipientEmailAndSms notification
+  type: http
+  seq: 20
+}
+
+post {
+  url: {{host}}/notifications/api/v1/future/orders
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "idempotencyId": "{{random_idempotency_id}}",
+    "sendersReference": "test-email-and-sms-{{random_idempotency_id}}",
+    "recipient": {
+      "recipientEmailAndSms": {
+        "emailAddress": "test@example.com",
+        "phoneNumber": "+4799999999",
+        "emailSettings": {
+          "sendingTimePolicy": "Anytime",
+          "contentType": "Plain",
+          "subject": "Test notification - Both Email and SMS",
+          "body": "This is a test notification that should be sent via both email and SMS channels simultaneously. Order ID: {{random_idempotency_id}}"
+        },
+        "smsSettings": {
+          "sendingTimePolicy": "Anytime", 
+          "body": "Test SMS: Both email & SMS channels. Order: {{random_idempotency_id}}"
+        }
+      }
+    },
+    "requestedSendTime": "{{iso_current_time}}"
+  }
+}
+
+tests {
+  test("should create notification with both email and SMS", function() {
+    expect(res.status).to.equal(201);
+    expect(res.body).to.have.property('orderChainId');
+    expect(res.body).to.have.property('orderChainReceipt');
+    expect(res.body.orderChainReceipt).to.have.property('shipmentId');
+  });
+}


### PR DESCRIPTION
Implements #995 by adding a new recipient type that allows sending notifications through both email and SMS channels simultaneously to explicit addresses.

Changes:
- Add RecipientEmailAndSmsExt API model with email/phone/settings
- Add RecipientEmailAndSms domain model in Core layer
- Update NotificationRecipientExt to include new recipient type
- Add validation support with RecipientEmailAndSmsValidator
- Update mapping logic in NotificationOrderChainMapper
- Extend OrderRequestService to handle EmailAndSms channel
- Add comprehensive unit tests for new functionality
- Add Bruno test for API integration testing

The solution creates recipients with both email and SMS address points and uses EmailAndSms notification channel for simultaneous delivery.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for a combined Email+SMS recipient, enabling delivery to both channels in one request.
  * API now accepts recipientEmailAndSms with email address, phone number, and per-channel settings (content and sending time).
  * Delivery pipeline handles both email and SMS concurrently for a single recipient.

* Validation
  * New validations for recipientEmailAndSms fields (email, phone, emailSettings, smsSettings).
  * Enforced exclusivity: exactly one recipient type must be provided.

* Tests
  * Added unit tests for the new validator and recipient rules.
  * Added an HTTP test covering end-to-end Email+SMS ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->