### PR TITLE
Add page size parameter

### DIFF
--- a/src/Altinn.Notifications.Core/Configuration/StatusFeedConfig.cs
+++ b/src/Altinn.Notifications.Core/Configuration/StatusFeedConfig.cs
@@ -1,0 +1,12 @@
+﻿namespace Altinn.Notifications.Core.Configuration;
+
+/// <summary>
+/// Configuration class for status feed
+/// </summary>
+public class StatusFeedConfig
+{
+    /// <summary>
+    /// The maximum number of entries to return in one page
+    /// </summary>
+    public int MaxPageSizeValue { get; set; }
+}

--- a/src/Altinn.Notifications.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Altinn.Notifications.Core/Extensions/ServiceCollectionExtensions.cs
@@ -52,6 +52,7 @@ public static class ServiceCollectionExtensions
             .AddSingleton<INotificationDeliveryManifestService, NotificationDeliveryManifestService>()
             .AddSingleton<INotificationsEmailServiceUpdateService, NotificationsEmailServiceUpdateService>()
             .Configure<KafkaSettings>(config.GetSection("KafkaSettings"))
-            .Configure<NotificationConfig>(config.GetSection("NotificationConfig"));
+            .Configure<NotificationConfig>(config.GetSection("NotificationConfig"))
+            .Configure<StatusFeedConfig>(config.GetSection("StatusFeedConfig"));
     }
 }

--- a/src/Altinn.Notifications.Core/Persistence/IStatusFeedRepository.cs
+++ b/src/Altinn.Notifications.Core/Persistence/IStatusFeedRepository.cs
@@ -26,8 +26,8 @@ public interface IStatusFeedRepository
     /// </summary>
     /// <param name="seq">Start sequence id for getting array of status feed entries</param>
     /// <param name="creatorName">Name of service owner</param>
+    /// <param name="maxPageSize">Parameter for setting the total number of entries returned</param>
     /// <param name="cancellationToken">Token for cancelling the current asynchronous request</param>
-    /// <param name="limit">Optional parameter for setting the total number of entries returned</param>
     /// <returns>List of status feed entries</returns>
-    public Task<List<StatusFeed>> GetStatusFeed(int seq, string creatorName, CancellationToken cancellationToken, int limit = 50);
+    public Task<List<StatusFeed>> GetStatusFeed(int seq, string creatorName, int maxPageSize, CancellationToken cancellationToken);
 }

--- a/src/Altinn.Notifications.Core/Services/Interfaces/IStatusFeedService.cs
+++ b/src/Altinn.Notifications.Core/Services/Interfaces/IStatusFeedService.cs
@@ -12,10 +12,11 @@ public interface IStatusFeedService
     /// Get status feed
     /// </summary>
     /// <param name="seq">The exclusive sequence number starting point of the status feed. Sequence ids after this point will be returned</param>
+    /// <param name="pageSize">Number of items returned per request</param>
     /// <param name="creatorName">Name of the service owner</param>
     /// <param name="cancellationToken">A CancellationToken for cancelling an ongoing asynchronous Task</param>
     /// <returns>Result object containing, on success: a list of order status objects following the sequence number. On failure: contains a ServiceError object</returns>
-    Task<Result<List<StatusFeed>, ServiceError>> GetStatusFeed(int seq, string creatorName, CancellationToken cancellationToken);
+    Task<Result<List<StatusFeed>, ServiceError>> GetStatusFeed(int seq, int? pageSize, string creatorName, CancellationToken cancellationToken);
 
     /// <summary>
     /// Deletes outdated records from the status feed table.

--- a/src/Altinn.Notifications.Persistence/Repository/StatusFeedRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/StatusFeedRepository.cs
@@ -32,12 +32,12 @@ public class StatusFeedRepository(NpgsqlDataSource dataSource) : IStatusFeedRepo
     };
 
     /// <inheritdoc/>
-    public async Task<List<StatusFeed>> GetStatusFeed(int seq, string creatorName, CancellationToken cancellationToken, int limit = 50)
+    public async Task<List<StatusFeed>> GetStatusFeed(int seq, string creatorName, int maxPageSize, CancellationToken cancellationToken)
     {
         await using NpgsqlCommand command = _dataSource.CreateCommand(_getStatusFeedSql);
         command.Parameters.AddWithValue("seq", NpgsqlDbType.Integer, seq);
         command.Parameters.AddWithValue("creatorName", NpgsqlDbType.Varchar, creatorName);
-        command.Parameters.AddWithValue("limit", NpgsqlDbType.Integer, limit);
+        command.Parameters.AddWithValue("limit", NpgsqlDbType.Integer, maxPageSize);
 
         List<StatusFeed> statusFeedEntries = [];
 

--- a/src/Altinn.Notifications/Controllers/StatusFeedController.cs
+++ b/src/Altinn.Notifications/Controllers/StatusFeedController.cs
@@ -27,12 +27,13 @@ public class StatusFeedController(IStatusFeedService statusFeedService) : Contro
     /// Retrieve an array of order status change history.
     /// </summary>
     /// <param name="seq">The sequence number to start fetching status feed entries from</param>
+    /// <param name="pageSize">The number of items to return in one page. The default value is set by the API</param>
     /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
     [HttpGet("feed")]
     [Consumes("application/json")]
     [Produces("application/json")]
     [SwaggerResponse(200, "Successfully retrieved status feed entries", typeof(List<StatusFeedExt>))]
-    public async Task<ActionResult<List<StatusFeedExt>>> GetStatusFeed([FromQuery][Range(0, int.MaxValue)] int seq = 0)
+    public async Task<ActionResult<List<StatusFeedExt>>> GetStatusFeed([FromQuery][Range(0, int.MaxValue)] int seq = 0, int? pageSize = null)
     {
         try
         {
@@ -42,7 +43,7 @@ public class StatusFeedController(IStatusFeedService statusFeedService) : Contro
                 return Forbid();
             }
 
-            var result = await statusFeedService.GetStatusFeed(seq, creatorName, HttpContext.RequestAborted);
+            var result = await statusFeedService.GetStatusFeed(seq, pageSize, creatorName, HttpContext.RequestAborted);
 
             return result.Match<ActionResult>(
                 statusFeed =>

--- a/src/Altinn.Notifications/appsettings.json
+++ b/src/Altinn.Notifications/appsettings.json
@@ -19,6 +19,9 @@
     "SmsSendWindowStartHour": 9,
     "SmsSendWindowEndHour": 17
   },
+  "StatusFeedConfig": {
+    "MaxPageSizeValue": 500
+  },
   "KafkaSettings": {
     "BrokerAddress": "localhost:9092",
     "Consumer": {

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/StatusFeedRepositoryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/StatusFeedRepositoryTests.cs
@@ -12,6 +12,7 @@ namespace Altinn.Notifications.IntegrationTests.Notifications.Persistence;
 
 public class StatusFeedRepositoryTests : IAsyncLifetime
 {
+    private const int _maxPageSize = 500;
     private readonly string _creatorName = "testcase";
 
     public async Task DisposeAsync()
@@ -36,7 +37,7 @@ public class StatusFeedRepositoryTests : IAsyncLifetime
             .First(i => i.GetType() == typeof(StatusFeedRepository));
 
         // Act
-        var results = await statusFeedRepository.GetStatusFeed(0, _creatorName, CancellationToken.None);
+        var results = await statusFeedRepository.GetStatusFeed(0, _creatorName, _maxPageSize, CancellationToken.None);
 
         // Assert
         var item = Assert.Single(results);
@@ -53,7 +54,7 @@ public class StatusFeedRepositoryTests : IAsyncLifetime
             .First(i => i.GetType() == typeof(StatusFeedRepository));
         
         // Act
-        var results = await statusFeedRepository.GetStatusFeed(1, string.Empty, CancellationToken.None);
+        var results = await statusFeedRepository.GetStatusFeed(1, string.Empty, _maxPageSize, CancellationToken.None);
         
         // Assert
         Assert.Empty(results);
@@ -85,7 +86,7 @@ public class StatusFeedRepositoryTests : IAsyncLifetime
         Assert.Equal(1, rowsAffected); // Only the old row should be deleted
 
         // Additional verification: ensure old record is gone, recent remains
-        var remaining = await sut.GetStatusFeed(0, _creatorName, CancellationToken.None);
+        var remaining = await sut.GetStatusFeed(0, _creatorName, _maxPageSize, CancellationToken.None);
         Assert.DoesNotContain(remaining, x => x.OrderStatus.ShipmentId == oldShipmentId);
         Assert.Contains(remaining, x => x.OrderStatus.ShipmentId == recentShipmentId);
     }

--- a/test/Altinn.Notifications.Tests/Notifications/TestingControllers/StatusFeedControllerTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications/TestingControllers/StatusFeedControllerTests.cs
@@ -91,7 +91,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingControllers
                     }
                 }
             };
-            _statusFeedService.Setup(x => x.GetStatusFeed(It.IsAny<int>(), expectedCreatorName, CancellationToken.None))
+            _statusFeedService.Setup(x => x.GetStatusFeed(It.IsAny<int>(), It.IsAny<int?>(), expectedCreatorName, CancellationToken.None))
                     .ReturnsAsync(statusFeedList);
 
             // Act
@@ -100,7 +100,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingControllers
             // Assert
             Assert.NotNull(result);
             Assert.IsType<ActionResult<List<StatusFeedExt>>>(result);
-            _statusFeedService.Verify(x => x.GetStatusFeed(expectedSequenceNumber, expectedCreatorName, CancellationToken.None), Times.Once);
+            _statusFeedService.Verify(x => x.GetStatusFeed(expectedSequenceNumber, It.IsAny<int?>(), expectedCreatorName, CancellationToken.None), Times.Once);
             var ojectResult = Assert.IsType<OkObjectResult>(result.Result);
             var returnedItems = Assert.IsType<List<StatusFeedExt>>(ojectResult.Value);
             Assert.Equal(statusFeedList.Count, returnedItems.Count);
@@ -111,7 +111,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingControllers
         public async Task Get_WhenServiceThrowsOperationCanceledException_IsCaughtWithCorrectStatusCodeReturned()
         {
             // Arrange
-            _statusFeedService.Setup(x => x.GetStatusFeed(It.IsAny<int>(), It.IsAny<string>(), CancellationToken.None))
+            _statusFeedService.Setup(x => x.GetStatusFeed(It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<string>(), CancellationToken.None))
                 .ThrowsAsync(new OperationCanceledException());
 
             // Act
@@ -129,7 +129,7 @@ namespace Altinn.Notifications.Tests.Notifications.TestingControllers
         {
             // Arrange
             var error = new ServiceError(400, "Bad request");
-            _statusFeedService.Setup(x => x.GetStatusFeed(It.IsAny<int>(), It.IsAny<string>(), CancellationToken.None))
+            _statusFeedService.Setup(x => x.GetStatusFeed(It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<string>(), CancellationToken.None))
                 .ReturnsAsync(error);
 
             // Act


### PR DESCRIPTION
Max page size value, which is also the default page size, is read from appSettings. Page size can be overridden as a query parameter to the API endpoint. However, the value cannot be higher than the max, default value. 

## Related Issue(s)
- #991 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
