### PR TITLE
Recover unhandled messages

### DIFF
--- a/src/Altinn.Notifications.Core/Persistence/IEmailNotificationRepository.cs
+++ b/src/Altinn.Notifications.Core/Persistence/IEmailNotificationRepository.cs
@@ -2,7 +2,6 @@
 using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.Notification;
 using Altinn.Notifications.Core.Models.Recipients;
-using Altinn.Notifications.Core.Models.Status;
 
 namespace Altinn.Notifications.Core.Persistence;
 

--- a/src/Altinn.Notifications.Integrations/Kafka/Consumers/EmailStatusConsumer.cs
+++ b/src/Altinn.Notifications.Integrations/Kafka/Consumers/EmailStatusConsumer.cs
@@ -54,6 +54,11 @@ public class EmailStatusConsumer : KafkaConsumerBase<EmailStatusConsumer>
         {
             await _emailNotificationsService.UpdateSendStatus(result);
         }
+        catch (KeyNotFoundException e)
+        {
+            _logger.LogWarning(e, "Could not update email send status for message: {Message}", message);
+            await RetryStatus(message);
+        }
         catch (Exception e)
         {
             _logger.LogError(e, "Could not update email send status for message: {Message}", message);
@@ -63,6 +68,6 @@ public class EmailStatusConsumer : KafkaConsumerBase<EmailStatusConsumer>
 
     private async Task RetryStatus(string message)
     {
-        await _producer.ProduceAsync(_retryTopicName, message!);
+        await _producer.ProduceAsync(_retryTopicName, message);
     }
 }

--- a/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
@@ -44,7 +44,6 @@ public class EmailNotificationRepository : NotificationRepositoryBase, IEmailNot
     : base(dataSource, logger) // Pass required parameters to the base class constructor
     {
         _dataSource = dataSource;
-        _logger = logger;
     }
 
     /// <inheritdoc/>
@@ -105,7 +104,7 @@ public class EmailNotificationRepository : NotificationRepositoryBase, IEmailNot
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, status.ToString());
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, operationId ?? (object)DBNull.Value);
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notificationId ?? (object)DBNull.Value);
-            
+
             var alternateId = await pgcom.ExecuteScalarAsync() ?? throw new KeyNotFoundException($"Email notification not found for NotificationId '{notificationId}' or OperationId '{operationId}'. Cannot set status '{status}'.");
 
             var parseResult = Guid.TryParse(alternateId.ToString(), out Guid emailNotificationAlternateId);

--- a/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
@@ -104,14 +104,8 @@ public class EmailNotificationRepository : NotificationRepositoryBase, IEmailNot
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, status.ToString());
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, operationId ?? (object)DBNull.Value);
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, notificationId ?? (object)DBNull.Value);
-            var alternateId = await pgcom.ExecuteScalarAsync();
-
-            if (alternateId == null)
-            {
-                _logger.LogInformation("Status type for email notification {NotificationId} with operation id {OperationId} was updated to {Status}. No alternateId was returned from the updateEmailStatus query.", notificationId, operationId, status);
-                await transaction.RollbackAsync();
-                return;
-            }
+            
+            var alternateId = await pgcom.ExecuteScalarAsync() ?? throw new KeyNotFoundException($"Email notification not found for NotificationId '{notificationId}' or OperationId '{operationId}'. Cannot set status '{status}'.");
 
             var parseResult = Guid.TryParse(alternateId.ToString(), out Guid emailNotificationAlternateId);
 

--- a/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
@@ -4,7 +4,9 @@ using Altinn.Notifications.Core.Models.Notification;
 using Altinn.Notifications.Core.Models.Recipients;
 using Altinn.Notifications.Core.Persistence;
 using Altinn.Notifications.Persistence.Extensions;
+
 using Microsoft.Extensions.Logging;
+
 using Npgsql;
 
 using NpgsqlTypes;
@@ -18,7 +20,6 @@ public class EmailNotificationRepository : NotificationRepositoryBase, IEmailNot
 {
     private const string _emailSourceIdentifier = "EMAIL";
     private readonly NpgsqlDataSource _dataSource;
-    private readonly ILogger<EmailNotificationRepository> _logger;
 
     private const string _insertEmailNotificationSql = "call notifications.insertemailnotification($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"; // (__orderid, _alternateid, _recipientorgno, _recipientnin, _toaddress, _customizedbody, _customizedsubject, _result, _resulttime, _expirytime)
     private const string _getEmailNotificationsSql = "select * from notifications.getemails_statusnew_updatestatus()";

--- a/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
+++ b/src/Altinn.Notifications.Persistence/Repository/EmailNotificationRepository.cs
@@ -25,12 +25,13 @@ public class EmailNotificationRepository : NotificationRepositoryBase, IEmailNot
     private const string _getEmailNotificationsSql = "select * from notifications.getemails_statusnew_updatestatus()";
     private const string _getEmailRecipients = "select * from notifications.getemailrecipients_v2($1)"; // (_orderid)
     private const string _updateEmailStatus =
-        @"UPDATE notifications.emailnotifications 
-        SET result = $1::emailnotificationresulttype, 
-            resulttime = now(), 
-            operationid = $2
-        WHERE alternateid = $3 OR operationid = $2
-        RETURNING alternateid;"; // (_result, _operationid, _alternateid)
+        @"UPDATE notifications.emailnotifications
+    SET result = $1::emailnotificationresulttype, 
+        resulttime = now(), 
+        operationid = COALESCE($2, operationid)
+    WHERE ($3 IS NOT NULL AND alternateid = $3)
+       OR ($2 IS NOT NULL AND operationid = $2)
+    RETURNING alternateid;"; // (_result, _operationid, _alternateid)
 
     /// <inheritdoc/>
     protected override string SourceIdentifier => _emailSourceIdentifier;


### PR DESCRIPTION
## Description
The current implementation discards delivery reports received from Azure Communication Services if the associated operation identifier is not linked to an existing email notification. To ensure proper handling, the Notifications API must instead wait until the Notification Email Service returns a message containing the operation identifier. Once the relevant email notification is updated, the delivery report from Azure Communication Services can be processed accordingly.

## Related Issue(s)
- #1005

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating email notification statuses: missing, non-existent or unparsable identifiers now raise errors and cause transactional rollback to prevent silent failures.
* **Tests**
  * Integration tests updated to expect exception-based handling for non-existent notifications and to verify no unintended updates occur.
* **Chores**
  * Internal logging and control flow adjusted; no public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->