### PR TITLE
Strip the URN before sending the resource identifier to both Profile API and authorization service

### DIFF
--- a/src/Altinn.Notifications.Core/Services/ContactPointService.cs
+++ b/src/Altinn.Notifications.Core/Services/ContactPointService.cs
@@ -179,6 +179,11 @@ public class ContactPointService(
             });
     }
 
+    private static string GetSanitizedResourceId(string resourceId)
+    {
+        return resourceId.StartsWith("urn:altinn:resource:", StringComparison.Ordinal) ? resourceId["urn:altinn:resource:".Length..] : resourceId;
+    }
+
     private static void AddPreferredOrFallbackContactPointList<TPreferred, TFallback>(
     Recipient recipient,
     List<TPreferred> preferredList,
@@ -346,9 +351,11 @@ public class ContactPointService(
 
         if (!string.IsNullOrWhiteSpace(resourceId))
         {
-            var allUserContactPoints = await _profileClient.GetUserRegisteredContactPoints(organizationNumbers, resourceId);
+            var sanitizedResourceId = GetSanitizedResourceId(resourceId);
 
-            var authorizedUserContactPoints = await _authorizationService.AuthorizeUserContactPointsForResource(allUserContactPoints, resourceId);
+            var allUserContactPoints = await _profileClient.GetUserRegisteredContactPoints(organizationNumbers, sanitizedResourceId);
+
+            var authorizedUserContactPoints = await _authorizationService.AuthorizeUserContactPointsForResource(allUserContactPoints, sanitizedResourceId);
 
             foreach (var authorizedUserContactPoint in authorizedUserContactPoints)
             {

--- a/src/Altinn.Notifications.Integrations/Authorization/AuthorizationService.cs
+++ b/src/Altinn.Notifications.Integrations/Authorization/AuthorizationService.cs
@@ -43,8 +43,6 @@ public class AuthorizationService : IAuthorizationService
     /// <returns>A new list of <see cref="OrganizationContactPoints"/> with filtered list of recipients.</returns>
     public async Task<List<OrganizationContactPoints>> AuthorizeUserContactPointsForResource(List<OrganizationContactPoints> organizationContactPoints, string resourceId)
     {
-        var sanitizedResourceId = GetSanitizedResourceId(resourceId);
-
         XacmlJsonRequestRoot jsonRequest = BuildAuthorizationRequest(organizationContactPoints, sanitizedResourceId);
 
         XacmlJsonResponse xacmlJsonResponse = await _pdp.GetDecisionForRequest(jsonRequest);
@@ -79,11 +77,6 @@ public class AuthorizationService : IAuthorizationService
         }
 
         return filtered;
-    }
-
-    private static string GetSanitizedResourceId(string resourceId)
-    {
-        return resourceId.StartsWith("urn:altinn:resource:", StringComparison.Ordinal) ? resourceId["urn:altinn:resource:".Length..] : resourceId;
     }
 
     private static XacmlJsonRequestRoot BuildAuthorizationRequest(List<OrganizationContactPoints> organizationContactPoints, string resourceId)


### PR DESCRIPTION
## Description
Move the function used to sanitize the resource identifier to the contact point service

## Related Issue(s)
- #1020 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
