### PR TITLE
Fix unconfigured domain name exception in tests

### DIFF
--- a/test/k6/src/data/orders/01-email-request.json
+++ b/test/k6/src/data/orders/01-email-request.json
@@ -1,6 +1,5 @@
 {
 	"subject": "Automated email from Altinn",
 	"body": "Dear $recipientName$! This is an automated email generated during the testing of Altinn Notifications. Your registration number is $recipientNumber$. Best regards, Altinn Team",
-	"contentType": "Html",
-	"fromAddress": "noreply@altinn.cloud"
+	"contentType": "Html"
 }

--- a/test/k6/src/data/orders/order-v2-org.json
+++ b/test/k6/src/data/orders/order-v2-org.json
@@ -4,7 +4,6 @@
   "recipient": {
     "recipientOrganization": {
       "emailSettings": {
-        "senderEmailAddress": "noreply@altinn.cloud",
         "subject": "Automated email from Altinn",
         "body": "Dear $recipientName$! This is an automated email generated during the testing of Altinn Notifications. Your registration number is $recipientNumber$. Best regards, Altinn Team",
         "contentType": "Html"


### PR DESCRIPTION
The hardcoded domain values for use case tests have been removed, stopping the "unconfigured domain name" exceptions.

## Description
The use case tests were failing in both prod environments due to a hardcoded sender value being different from the AT-environments. By removing the sender address from the input object we can let the application handle the correct domain by itself.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Updated performance test data to remove hardcoded sender email fields, aligning tests with current email handling.
  - Ensures test scenarios focus on subject, body, and content type without assuming a specific sender.
  - No changes to application behavior or user experience.
- Chores
  - Cleaned up test fixtures to reduce maintenance overhead and prevent outdated assumptions in future test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->