### PR TITLE
Bump Altinn.Common.PEP and add HealthCheck

### DIFF
--- a/src/Altinn.Notifications.Integrations/Altinn.Notifications.Integrations.csproj
+++ b/src/Altinn.Notifications.Integrations/Altinn.Notifications.Integrations.csproj
@@ -11,8 +11,9 @@
   <ItemGroup>
     <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="9.2.1" />
     <PackageReference Include="Altinn.Common.AccessTokenClient" Version="3.0.15" />
-    <PackageReference Include="Altinn.Common.PEP" Version="4.1.2" />
+    <PackageReference Include="Altinn.Common.PEP" Version="4.2.1" />
     <PackageReference Include="Confluent.Kafka" Version="2.11.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
The update to the Altinn.Common.PEP package caused some issues so I tried to resolve them in this separate pull request.

The package used to depend on Newtonsoft which in turn had a ton of different dependencies. One of which we were using for health check. 

## Related Issue(s)
- Weekly patching


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded the underlying authorization/policy component, providing security hardening, improved compatibility, and minor performance gains to reduce edge-case errors.
  * Added enhanced service health monitoring, improving observability for faster fault detection and proactive maintenance, which should lead to better reliability and uptime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->