### PR TITLE
Get CodeQL coverage on GH workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,6 @@ on:
       - 'src/**'
       - '.github/workflows/**'
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [main]
     paths:
       - 'src/**'
@@ -54,4 +53,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@755f44910c12a3d7ca0d8c6e42c048b3362f7cec # v3.30.8
         with:
-          category: "/language:${{matrix.language}}"
+          category: '/language:${{matrix.language}}'


### PR DESCRIPTION
## Description
- Adds workflow folder to the trigger path filter and adds `actions` as a language in the matrix strategy, so that CodeQL analysis of workflow files is triggered whenever such files are changed in PRs or main-commits 
- Removes the CodeQL `Autobuild` step, as this is apparently redundant - can be replaced by setting `build-mode: autobuild` in the `init` step, [ref. docs](https://github.com/github/codeql-action?tab=readme-ov-file#actions)
  - Seems to work as expected - PR check run output shows `dotnet build ` ([link](https://github.com/Altinn/altinn-notifications/actions/runs/18583607569/job/52983040534?pr=1101#step:5:138))
- Adds a conditional check for `csharp` language on .NET setup step, so that time and resources are saved when the analyze job runs for `actions` (this workflow/yml-analyzing job doesn't need.NET setup)

## Related Issue(s)
- [#350](https://github.com/Altinn/team-core-private/issues/350)(team-core-private)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow triggers and expanded the analysis matrix to include a tooling-only entry and a C# entry.
  * Made .NET setup conditional and streamlined how build modes are propagated to initialization and analysis steps.
  * Removed the automatic autobuild stage and adjusted analysis categorization to run per-language, improving targeted scans and clarity in results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->