### PR TITLE
Feature/1084 remove task delay

### DIFF
--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Integrations/TestingConsumers/AltinnServiceUpdateConsumerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Integrations/TestingConsumers/AltinnServiceUpdateConsumerTests.cs
@@ -44,10 +44,10 @@ public class AltinnServiceUpdateConsumerTests : IAsyncLifetime
             Data = data.Serialize()
         };
 
-        await KafkaUtil.PublishMessageOnTopic(_serviceUpdateTopicName, serviceUpdate.Serialize());
-
         // Act
         await consumerService.StartAsync(CancellationToken.None);
+
+        await KafkaUtil.PublishMessageOnTopic(_serviceUpdateTopicName, serviceUpdate.Serialize());
 
         DateTime? actualTimeout = null;
         await IntegrationTestUtil.EventuallyAsync(

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Integrations/TestingConsumers/PastDueOrdersConsumerTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Integrations/TestingConsumers/PastDueOrdersConsumerTests.cs
@@ -38,9 +38,9 @@ public class PastDueOrdersConsumerTests : IDisposable
         // Act
         await consumerService.StartAsync(CancellationToken.None);
 
-        await KafkaUtil.PublishMessageOnTopic(_pastDueOrdersTopicName, persistedOrder.Serialize());
-
         await UpdateProcessingStatus(persistedOrder.Id, OrderProcessingStatus.Processing);
+
+        await KafkaUtil.PublishMessageOnTopic(_pastDueOrdersTopicName, persistedOrder.Serialize());
 
         // Assert
         var selectProcessedOrderCount = 0L;


### PR DESCRIPTION
Remove task.delay(10000) for integration tests involving Kafka consumers

## Description
By utilising Task.Delay in Kafka consumer integration tests to initialize infrastructure causes unnecessary wait.
We should use the EventuallyAsync method introduced by @Ahmed-Ghanam to poll for results at a given polling interval, to get the desired result as fast as possible. This ensures we don't wait longer than necessary for consumption and production.

## Related Issue(s)
- #1084 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by replacing fixed delays with condition-based polling mechanisms that wait for specific outcomes to occur
  * Enhanced test execution flow to verify results more robustly using polling intervals instead of static wait times
<!-- end of auto-generated comment: release notes by coderabbit.ai -->