### PR TITLE
Modify validation rule to allow equality between firstSeen and lastAt…

### DIFF
--- a/src/Altinn.Notifications.Core/Services/DeadDeliveryReportService.cs
+++ b/src/Altinn.Notifications.Core/Services/DeadDeliveryReportService.cs
@@ -28,10 +28,10 @@ public class DeadDeliveryReportService(IDeadDeliveryReportRepository reportRepos
                 nameof(report));
         }
 
-        if (report.LastAttempt <= report.FirstSeen)
+        if (report.LastAttempt < report.FirstSeen)
         {
             throw new ArgumentException(
-                "report.LastAttempt must be greater than FirstSeen",
+                "report.LastAttempt must be greater than or equal to FirstSeen",
                 nameof(report));
         }
 

--- a/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/DeadDeliveryReportServiceTests.cs
+++ b/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/DeadDeliveryReportServiceTests.cs
@@ -119,7 +119,7 @@ public class DeadDeliveryReportServiceTests
         var exception = await Assert.ThrowsAsync<ArgumentException>(
             () => _sut.InsertAsync(deadDeliveryReport, CancellationToken.None));
 
-        Assert.Equal("report.LastAttempt must be greater than FirstSeen (Parameter 'report')", exception.Message);
+        Assert.Equal("report.LastAttempt must be greater than or equal to FirstSeen (Parameter 'report')", exception.Message);
         Assert.Equal("report", exception.ParamName);
 
         // Verify repository was never called


### PR DESCRIPTION
Modify validation rule to allow equality between firstSeen and lastAttempt

## Description
The current validation of lastAttempt and firstSeen is too strict. It requires lastAttempt to always be greater than firstSeen, which means that the message _must_ be retried within the time period allowed. This is not always the case. If the queue is too long or slow, the message might have timed out before attempts have been made, in which case lastAttempt and firstSeen are still equal. This case should not throw an argument exception.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed overly restrictive validation for dead delivery reports. The system now correctly allows cases where the last attempt timestamp equals the first attempt timestamp, previously rejected with an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->