### PR TITLE
Fix automatic postgres upgrades for renovate bot

### DIFF
--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build, test & analyze
     runs-on: ubuntu-latest
     services:
-      postgres: # note that updating this image (might break the pipeline if the agent doesn't support the new version) AND (requires updating the version on line 55 below)
+      postgres: # note that updating this image might break the pipeline if the agent doesn't support the new version
         image: postgres:16@sha256:21f6013073bc6b92830a2129570e2f5ec42a6c734b5a985a41e83aa58f54c3c1
         env:
           POSTGRES_USER: platform_notifications_admin
@@ -50,9 +50,9 @@ jobs:
           ./dbsetup.sh
       - name: Restart database to enable config changes
         run: |
-          # Restart only the Postgres service
+          # Restart only the Postgres service by filtering on the published port
           docker ps \
-            --filter "ancestor=postgres:16@sha256:21f6013073bc6b92830a2129570e2f5ec42a6c734b5a985a41e83aa58f54c3c1" \
+            --filter "publish=5432" \
             -q \
           | xargs docker restart
       - name: Set up Kafka


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The `build-and-analyze.yml` workflow now filters by port when restarting the database, instead of matching a specific postgres image hash. This should resolve the pipeline errors when renovate bot updates only the postgres image under services, making the process automatic.

## Related Issue(s)
- #1138

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved database management during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->