### PR TITLE
Map sms Delivered as success status code

### DIFF
--- a/src/Altinn.Notifications.Core/Services/SmsNotificationSummaryService.cs
+++ b/src/Altinn.Notifications.Core/Services/SmsNotificationSummaryService.cs
@@ -32,7 +32,8 @@ namespace Altinn.Notifications.Core.Services
 
         private readonly static List<SmsNotificationResultType> _successResults = new()
         {
-            SmsNotificationResultType.Accepted
+            SmsNotificationResultType.Accepted,
+            SmsNotificationResultType.Delivered
         };
 
         /// <summary>

--- a/test/Altinn.Notifications.IntegrationTests/Notifications.Core/SmsNotificationSummaryTests.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Notifications.Core/SmsNotificationSummaryTests.cs
@@ -34,7 +34,7 @@ namespace Altinn.Notifications.IntegrationTests.Notifications.Core
         }
 
         [Fact]
-        public async Task GetSmsSummary_SingleNeweNotification_ReturnsSummary()
+        public async Task GetSmsSummary_SingleNewNotification_ReturnsSummary()
         {
             // Arrange
             (NotificationOrder order, SmsNotification notification) = await PostgreUtil.PopulateDBWithOrderAndSmsNotification();
@@ -57,6 +57,106 @@ namespace Altinn.Notifications.IntegrationTests.Notifications.Core
                    Assert.NotEmpty(actualNotification.Recipient.MobileNumber);
                    Assert.Equal(notification.Id, actualNotification.Id);
                    Assert.Equivalent(notification.Recipient, actualNotification.Recipient);
+                   Assert.False(actualNotification.Succeeded);
+                   return true;
+               },
+               error =>
+               {
+                   throw new Exception("Expected a summary, but got an error");
+               });
+        }
+
+        [Fact]
+        public async Task GetSmsSummary_SingleAcceptedNotification_ReturnsSummary()
+        {
+            // Arrange
+            (NotificationOrder order, SmsNotification notification) = await PostgreUtil.PopulateDBWithOrderAndSmsNotification(resultType: SmsNotificationResultType.Accepted);
+            _orderIdsToDelete.Add(order.Id);
+
+            SmsNotificationSummaryService service = (SmsNotificationSummaryService)ServiceUtil
+             .GetServices(new List<Type>() { typeof(ISmsNotificationSummaryService) })
+             .First(i => i.GetType() == typeof(SmsNotificationSummaryService));
+
+            // Act
+            Result<SmsNotificationSummary, ServiceError> result = await service.GetSummary(order.Id, "ttd");
+
+            // Assert
+            result.Match(
+               actualSummary =>
+               {
+                   Assert.Single(actualSummary.Notifications);
+                   var actualNotification = actualSummary.Notifications[0];
+                   Assert.Equal(SmsNotificationResultType.Accepted, actualNotification.ResultStatus.Result);
+                   Assert.NotEmpty(actualNotification.Recipient.MobileNumber);
+                   Assert.Equal(notification.Id, actualNotification.Id);
+                   Assert.Equivalent(notification.Recipient, actualNotification.Recipient);
+                   Assert.True(actualNotification.Succeeded);
+                   return true;
+               },
+               error =>
+               {
+                   throw new Exception("Expected a summary, but got an error");
+               });
+        }
+
+        [Fact]
+        public async Task GetSmsSummary_SingleDeliveredNotification_ReturnsSummary()
+        {
+            // Arrange
+            (NotificationOrder order, SmsNotification notification) = await PostgreUtil.PopulateDBWithOrderAndSmsNotification(resultType: SmsNotificationResultType.Delivered);
+            _orderIdsToDelete.Add(order.Id);
+
+            SmsNotificationSummaryService service = (SmsNotificationSummaryService)ServiceUtil
+             .GetServices(new List<Type>() { typeof(ISmsNotificationSummaryService) })
+             .First(i => i.GetType() == typeof(SmsNotificationSummaryService));
+
+            // Act
+            Result<SmsNotificationSummary, ServiceError> result = await service.GetSummary(order.Id, "ttd");
+
+            // Assert
+            result.Match(
+               actualSummary =>
+               {
+                   Assert.Single(actualSummary.Notifications);
+                   var actualNotification = actualSummary.Notifications[0];
+                   Assert.Equal(SmsNotificationResultType.Delivered, actualNotification.ResultStatus.Result);
+                   Assert.NotEmpty(actualNotification.Recipient.MobileNumber);
+                   Assert.Equal(notification.Id, actualNotification.Id);
+                   Assert.Equivalent(notification.Recipient, actualNotification.Recipient);
+                   Assert.True(actualNotification.Succeeded);
+                   return true;
+               },
+               error =>
+               {
+                   throw new Exception("Expected a summary, but got an error");
+               });
+        }
+
+        [Fact]
+        public async Task GetSmsSummary_SingleFailedNotification_ReturnsSummary()
+        {
+            // Arrange
+            (NotificationOrder order, SmsNotification notification) = await PostgreUtil.PopulateDBWithOrderAndSmsNotification(resultType: SmsNotificationResultType.Failed);
+            _orderIdsToDelete.Add(order.Id);
+
+            SmsNotificationSummaryService service = (SmsNotificationSummaryService)ServiceUtil
+             .GetServices(new List<Type>() { typeof(ISmsNotificationSummaryService) })
+             .First(i => i.GetType() == typeof(SmsNotificationSummaryService));
+
+            // Act
+            Result<SmsNotificationSummary, ServiceError> result = await service.GetSummary(order.Id, "ttd");
+
+            // Assert
+            result.Match(
+               actualSummary =>
+               {
+                   Assert.Single(actualSummary.Notifications);
+                   var actualNotification = actualSummary.Notifications[0];
+                   Assert.Equal(SmsNotificationResultType.Failed, actualNotification.ResultStatus.Result);
+                   Assert.NotEmpty(actualNotification.Recipient.MobileNumber);
+                   Assert.Equal(notification.Id, actualNotification.Id);
+                   Assert.Equivalent(notification.Recipient, actualNotification.Recipient);
+                   Assert.False(actualNotification.Succeeded);
                    return true;
                },
                error =>

--- a/test/Altinn.Notifications.IntegrationTests/Utils/PostgreUtil.cs
+++ b/test/Altinn.Notifications.IntegrationTests/Utils/PostgreUtil.cs
@@ -129,7 +129,7 @@ public static class PostgreUtil
         return o;
     }
 
-    public static async Task<(NotificationOrder Order, SmsNotification SmsNotification)> PopulateDBWithOrderAndSmsNotification(string? sendersReference = null, SendingTimePolicy? sendingTimePolicy = null, bool simulateCronJob = false, bool simulateConsumers = false, bool forceSendersReferenceToBeNull = false)
+    public static async Task<(NotificationOrder Order, SmsNotification SmsNotification)> PopulateDBWithOrderAndSmsNotification(string? sendersReference = null, SendingTimePolicy? sendingTimePolicy = null, bool simulateCronJob = false, bool simulateConsumers = false, bool forceSendersReferenceToBeNull = false, SmsNotificationResultType? resultType = null)
     {
         (NotificationOrder order, SmsNotification smsNotification) = TestdataUtil.GetOrderAndSmsNotification(sendingTimePolicy);
         var serviceList = ServiceUtil.GetServices(new List<Type>() { typeof(IOrderRepository), typeof(ISmsNotificationRepository) });
@@ -146,6 +146,11 @@ public static class PostgreUtil
         {
             // Force the senders reference to be null, even if a value is provided
             order.SendersReference = null;
+        }
+
+        if (resultType.HasValue)
+        {
+            smsNotification.SendResult = new NotificationResult<SmsNotificationResultType>(resultType.Value, DateTime.UtcNow);
         }
 
         /*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #1213 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SMS notification status classification has been improved to correctly recognize "Delivered" notifications as successful deliveries in notification summaries. This enhancement ensures that all delivered messages are properly accounted for in delivery metrics and status reporting, giving users more accurate visibility and understanding of their SMS delivery outcomes and success rates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->