### PR TITLE
Remove notifications schema creation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ In pgAdmin
 - Create the following users with password: _Password_ (see privileges in parentheses)
   - platform_notifications_admin (superuser, canlogin)
   - platform_notifications (canlogin)
-- Create schema _notifications_ in notificationsdb with owner _platform_notifications_admin_
 
 A more detailed description of the database setup is available in [our developer handbook](https://docs.altinn.studio/community/contributing/handbook/postgres/)
 


### PR DESCRIPTION
## Description
The notifications schema will be created during startup. There is a SQL statement for it in the yuniql scripts that are being executed by the admin user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated database schema setup instructions from README.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->