### PR TITLE
Add unique constraint in status feed table

### DIFF
--- a/src/Altinn.Notifications.Persistence/Migration/v0.73/01-alter-table.sql
+++ b/src/Altinn.Notifications.Persistence/Migration/v0.73/01-alter-table.sql
@@ -2,8 +2,8 @@
 -- The design assumes each orderid only has one entry with the final status
 
 -- Step 1: Create unique index
--- Manual command to run first: CREATE UNIQUE INDEX CONCURRENTLY statusfeed_unique_orderid_idx ON notifications.statusfeed (orderid);
-CREATE UNIQUE INDEX IF NOT EXISTS statusfeed_unique_orderid_idx ON notifications.statusfeed (orderid);
+-- Manual command to run first: CREATE UNIQUE INDEX CONCURRENTLY idx_statusfeed_orderid_unique ON notifications.statusfeed (orderid);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_statusfeed_orderid_unique ON notifications.statusfeed (orderid);
 
 -- Step 2: Add constraint using the existing index
 DO $$
@@ -14,6 +14,6 @@ BEGIN
         WHERE conname = 'statusfeed_unique_orderid'
     ) THEN
         ALTER TABLE notifications.statusfeed
-        ADD CONSTRAINT statusfeed_unique_orderid UNIQUE USING INDEX statusfeed_unique_orderid_idx;
+        ADD CONSTRAINT statusfeed_unique_orderid UNIQUE USING INDEX idx_statusfeed_orderid_unique;
     END IF;
 END $$;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A unique constraint has been added for the `orderid` field in the `statusfeed` table. Should be run manually in environments before deployments.

## Related Issue(s)
- #1244

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced uniqueness for notification status entries to prevent duplicate status records, improving data consistency and reliability of notification delivery.
  * No changes to public APIs or exported entities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->