### PR TITLE
Ensure IgnoreReservation flag is honored 

### DIFF
--- a/components/api/src/Altinn.Notifications.Core/Services/SmsOrderProcessingService.cs
+++ b/components/api/src/Altinn.Notifications.Core/Services/SmsOrderProcessingService.cs
@@ -96,7 +96,8 @@ public class SmsOrderProcessingService : ISmsOrderProcessingService
                 expirationDateTime,
                 smsAddresses,
                 smsRecipient,
-                segmentsCount);
+                segmentsCount,
+                order.IgnoreReservation ?? false);
         }
     }
 

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsOrderProcessingServiceTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsOrderProcessingServiceTests.cs
@@ -275,6 +275,53 @@ public class SmsOrderProcessingServiceTests
     }
 
     [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ProcessOrderRetry_WhenIgnoreReservationIsSet_NotificationServiceIsCalledWithCorrectValue(bool ignoreReservation)
+    {
+        // Arrange
+        var order = new NotificationOrder()
+        {
+            Id = Guid.NewGuid(),
+            IgnoreReservation = ignoreReservation,
+            NotificationChannel = NotificationChannel.Sms,
+            Templates = [new SmsTemplate("Altinn", "this is the body")],
+            Recipients =
+            [
+                new Recipient([new SmsAddressPoint("+4799999999")], nationalIdentityNumber: "23273936483")
+            ]
+        };
+
+        bool? capturedIgnoreReservation = null;
+
+        var notificationServiceMock = new Mock<ISmsNotificationService>();
+        notificationServiceMock.Setup(s => s.CreateNotification(
+            It.IsAny<Guid>(),
+            It.IsAny<DateTime>(),
+            It.IsAny<DateTime>(),
+            It.IsAny<List<SmsAddressPoint>>(),
+            It.IsAny<SmsRecipient>(),
+            It.IsAny<int>(),
+            It.IsAny<bool>()))
+            .Callback<Guid, DateTime, DateTime, List<SmsAddressPoint>, SmsRecipient, int, bool>(
+                (orderId, req, exp, addresses, recipient, segmentCount, ignoreRes) =>
+                {
+                    capturedIgnoreReservation = ignoreRes;
+                });
+
+        var smsRepoMock = new Mock<ISmsNotificationRepository>();
+        smsRepoMock.Setup(e => e.GetRecipients(It.IsAny<Guid>())).ReturnsAsync([]);
+
+        var service = GetTestService(smsRepo: smsRepoMock.Object, smsService: notificationServiceMock.Object);
+
+        // Act
+        await service.ProcessOrderRetry(order);
+
+        // Assert
+        Assert.Equal(ignoreReservation, capturedIgnoreReservation);
+    }
+
+    [Theory]
     [InlineData(160, 1)]
     [InlineData(161, 2)]
     [InlineData(18685, 16)]


### PR DESCRIPTION
## Description
This PR addresses an inconsistency in the `SmsOrderProcessingService` where the `IgnoreReservation` flag was not being passed to the `CreateNotification(Guid, DateTime, List<EmailAddressPoint>, EmailRecipient, bool)` method in the `ProcessOrderRetryWithoutAddressLookup(NotificationOrder, List<Recipient>)` method.

## Related Issue(s)
- #1352 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SMS notification processing now supports an option to ignore reservation status when handling order retries

* **Tests**
  * Added test coverage to verify reservation handling behavior is correctly applied during notification processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->