### PR TITLE
Ensure workflow runs to completion on main and remove redundant Kafka wait

### DIFF
--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -361,17 +361,6 @@ jobs:
         with:
           dotnet-version: |
             10.0.x
-      - name: Wait for Kafka readiness
-        run: |
-          echo "Waiting for Kafka to be fully ready..."
-          for i in {1..30}; do
-            if kafka-topics --bootstrap-server localhost:9092 --list > /dev/null 2>&1; then
-              echo "✅ Kafka is ready"
-              break
-            fi
-            echo "⏳ Attempt $i/30: Kafka not ready yet, waiting..."
-            sleep 2
-          done
       - name: Run Email unit tests
         run: |
           dotnet test components/email-service/test/Altinn.Notifications.Email.Tests/Altinn.Notifications.Email.Tests.csproj \
@@ -456,17 +445,6 @@ jobs:
         with:
           dotnet-version: |
             10.0.x
-      - name: Wait for Kafka readiness
-        run: |
-          echo "Waiting for Kafka to be fully ready..."
-          for i in {1..30}; do
-            if kafka-topics --bootstrap-server localhost:9092 --list > /dev/null 2>&1; then
-              echo "✅ Kafka is ready"
-              break
-            fi
-            echo "⏳ Attempt $i/30: Kafka not ready yet, waiting..."
-            sleep 2
-          done
       - name: Run SMS unit tests
         run: |
           dotnet test components/sms-service/test/Altinn.Notifications.Sms.Tests/Altinn.Notifications.Sms.Tests.csproj \


### PR DESCRIPTION
## Description
- Prevents workflow runs triggered by merges to `main` from cancelling each other so component tests from earlier merges always complete.
- Removes redundant manual Kafka health-check steps to save CI resources.

## Related Issue(s)
- #1387 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now cancels in-progress jobs only for pull request events.
  * Removed redundant Kafka readiness waiting steps to streamline test workflow startup and reduce runtime polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->