### PR TITLE
Revert "Feat/1311 resource action api approach v1 backport"

### DIFF
--- a/components/api/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderRequest.cs
+++ b/components/api/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderRequest.cs
@@ -49,11 +49,6 @@ public class NotificationOrderRequest
     public string? ResourceId { get; internal set; }
 
     /// <summary>
-    /// Gets the action to authorize against the resource
-    /// </summary>
-    public string? ResourceAction { get; internal set; }
-
-    /// <summary>
     /// Gets or sets the condition endpoint used to check the send condition
     /// </summary>
     public Uri? ConditionEndpoint { get; set; }
@@ -70,8 +65,7 @@ public class NotificationOrderRequest
         List<Recipient> recipients,
         bool? ignoreReservation,
         string? resourceId,
-        Uri? conditionEndpoint,
-        string? resourceAction)
+        Uri? conditionEndpoint)
     {
         SendersReference = sendersReference;
         Creator = new(creatorShortName);
@@ -81,7 +75,6 @@ public class NotificationOrderRequest
         Recipients = recipients;
         IgnoreReservation = ignoreReservation;
         ResourceId = resourceId;
-        ResourceAction = resourceAction;
         ConditionEndpoint = conditionEndpoint;
     }
 

--- a/components/api/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderWithStatus.cs
+++ b/components/api/src/Altinn.Notifications.Core/Models/Orders/NotificationOrderWithStatus.cs
@@ -71,8 +71,7 @@ public class NotificationOrderWithStatus : IBaseNotificationOrder
         string? resourceId,
         Uri? conditionEndpoint,
         ProcessingStatus processingStatus, 
-        OrderType type,
-        string? resourceAction)
+        OrderType type)
     {
         Id = id;
         SendersReference = sendersReference;
@@ -82,7 +81,6 @@ public class NotificationOrderWithStatus : IBaseNotificationOrder
         NotificationChannel = notificationChannel;
         IgnoreReservation = ignoreReservation;
         ResourceId = resourceId;
-        ResourceAction = resourceAction;
         ConditionEndpoint = conditionEndpoint;
         ProcessingStatus = processingStatus;
         Type = type;

--- a/components/api/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/components/api/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -51,7 +51,7 @@ public class OrderRequestService : IOrderRequestService
         Guid orderId = _guid.NewGuid();
         DateTime currentTime = _dateTime.UtcNow();
 
-        var lookupResult = await GetRecipientLookupResult(orderRequest.Recipients, orderRequest.NotificationChannel, orderRequest.ResourceId, orderRequest.ResourceAction);
+        var lookupResult = await GetRecipientLookupResult(orderRequest.Recipients, orderRequest.NotificationChannel, orderRequest.ResourceId);
 
         var templates = SetSenderIfNotDefined(orderRequest.Templates);
 
@@ -63,7 +63,6 @@ public class OrderRequestService : IOrderRequestService
             Creator = orderRequest.Creator,
             Recipients = orderRequest.Recipients,
             ResourceId = orderRequest.ResourceId,
-            ResourceAction = orderRequest.ResourceAction,
             SendersReference = orderRequest.SendersReference,
             IgnoreReservation = orderRequest.IgnoreReservation,
             ConditionEndpoint = orderRequest.ConditionEndpoint,

--- a/components/api/src/Altinn.Notifications/Mappers/OrderMapper.cs
+++ b/components/api/src/Altinn.Notifications/Mappers/OrderMapper.cs
@@ -73,8 +73,7 @@ public static partial class OrderMapper
             recipients,
             extRequest.IgnoreReservation,
             extRequest.ResourceId,
-            extRequest.ConditionEndpoint,
-            extRequest.ResourceAction);
+            extRequest.ConditionEndpoint);
     }
 
     /// <summary>
@@ -112,8 +111,7 @@ public static partial class OrderMapper
             recipients,
             extRequest.IgnoreReservation,
             extRequest.ResourceId,
-            extRequest.ConditionEndpoint,
-            extRequest.ResourceAction);
+            extRequest.ConditionEndpoint);
     }
 
     /// <summary>
@@ -147,8 +145,7 @@ public static partial class OrderMapper
             recipients,
             extRequest.IgnoreReservation,
             extRequest.ResourceId,
-            extRequest.ConditionEndpoint,
-            extRequest.ResourceAction);
+            extRequest.ConditionEndpoint);
     }
 
     /// <summary>
@@ -332,7 +329,6 @@ public static partial class OrderMapper
         orderExt.RequestedSendTime = order.RequestedSendTime;
         orderExt.IgnoreReservation = order.IgnoreReservation;
         orderExt.ResourceId = order.ResourceId;
-        orderExt.ResourceAction = order.ResourceAction;
         orderExt.ConditionEndpoint = order.ConditionEndpoint;
 
         return orderExt;

--- a/components/api/src/Altinn.Notifications/Models/BaseNotificationOrderExt.cs
+++ b/components/api/src/Altinn.Notifications/Models/BaseNotificationOrderExt.cs
@@ -68,16 +68,9 @@ public class BaseNotificationOrderExt
     public string? ResourceId { get; set; }
 
     /// <summary>
-    /// Gets or sets the action to authorize against the resource
-    /// </summary>
-    [JsonPropertyName("resourceAction")]
-    [JsonPropertyOrder(9)]
-    public string? ResourceAction { get; set; }
-
-    /// <summary>
     /// Gets or sets the condition endpoint used to check the send condition
     /// </summary>
     [JsonPropertyName("conditionEndpoint")]
-    [JsonPropertyOrder(10)]
+    [JsonPropertyOrder(9)]
     public Uri? ConditionEndpoint { get; set; }
 }

--- a/components/api/src/Altinn.Notifications/Models/NotificationOrderRequestBaseExt.cs
+++ b/components/api/src/Altinn.Notifications/Models/NotificationOrderRequestBaseExt.cs
@@ -26,10 +26,4 @@ public class NotificationOrderRequestBaseExt : NotificationOrderBaseExt
     /// </summary>
     [JsonPropertyName("resourceId")]
     public string? ResourceId { get; set; }
-
-    /// <summary>
-    /// Gets or sets the action to authorize against the resource.
-    /// </summary>
-    [JsonPropertyName("resourceAction")]
-    public string? ResourceAction { get; set; }
 }

--- a/components/api/src/Altinn.Notifications/Validators/Rules/NotificationOrderRequestBaseRules.cs
+++ b/components/api/src/Altinn.Notifications/Validators/Rules/NotificationOrderRequestBaseRules.cs
@@ -32,11 +32,6 @@ public static class NotificationOrderRequestBaseRules
                 order.RuleFor(o => o.ConditionEndpoint)
                     .Must(uri => uri == null || uri.IsValidUrl())
                     .WithMessage("The condition endpoint must be a valid URL.");
-
-                order.RuleFor(o => o.ResourceAction)
-                    .Empty()
-                    .When(o => string.IsNullOrWhiteSpace(o.ResourceId))
-                    .WithMessage("ResourceAction cannot be specified without a ResourceId.");
             });
     }
 }

--- a/components/api/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications/TestingMappers/OrderMapperTests.cs
@@ -43,9 +43,7 @@ public class OrderMapperTests
             Creator = new Creator("ttd"),
             Created = created,
             Recipients = [],
-            IgnoreReservation = true,
-            ResourceId = "urn:altinn:resource:test",
-            ResourceAction = "write"
+            IgnoreReservation = true
         };
 
         NotificationOrderExt expected = new()
@@ -74,9 +72,7 @@ public class OrderMapperTests
                 Self = $"http://localhost:5090/notifications/api/v1/orders/{order.Id}",
                 Status = $"http://localhost:5090/notifications/api/v1/orders/{order.Id}/status"
             },
-            IgnoreReservation = true,
-            ResourceId = "urn:altinn:resource:test",
-            ResourceAction = "write"
+            IgnoreReservation = true
         };
 
         // Act
@@ -305,8 +301,7 @@ public class OrderMapperTests
             RequestedSendTime = sendTime,
             ConditionEndpoint = new Uri("https://vg.no"),
             IgnoreReservation = true,
-            ResourceId = "urn:altinn:resource:test",
-            ResourceAction = "write"
+            ResourceId = "urn:altinn:resource:test"
         };
 
         NotificationOrderRequest expected = new()
@@ -333,8 +328,7 @@ public class OrderMapperTests
             },
             ConditionEndpoint = new Uri("https://vg.no"),
             IgnoreReservation = true,
-            ResourceId = "urn:altinn:resource:test",
-            ResourceAction = "write"
+            ResourceId = "urn:altinn:resource:test"
         };
 
         expected.NotificationChannel = expectedChannel;
@@ -362,8 +356,6 @@ public class OrderMapperTests
             NotificationChannel = NotificationChannel.Email,
             RequestedSendTime = sendTime,
             SendersReference = "senders-ref",
-            ResourceId = "urn:altinn:resource:test",
-            ResourceAction = "write",
             ProcessingStatus = new()
             {
                 LastUpdate = lastUpdated,
@@ -384,8 +376,6 @@ public class OrderMapperTests
             NotificationChannel = NotificationChannelExt.Email,
             RequestedSendTime = sendTime,
             SendersReference = "senders-ref",
-            ResourceId = "urn:altinn:resource:test",
-            ResourceAction = "write",
             ProcessingStatus = new()
             {
                 Status = "Registered",

--- a/components/api/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications/TestingValidators/EmailNotificationOrderRequestValidatorTests.cs
@@ -212,40 +212,6 @@ public class EmailNotificationOrderRequestValidatorTests
         Assert.Contains(actual.Errors, a => a.ErrorMessage.Equals("The condition endpoint must be a valid URL."));
     }
 
-    [Fact]
-    public void Validate_ResourceActionWithoutResourceId_ReturnsFalse()
-    {
-        var order = new EmailNotificationOrderRequestExt()
-        {
-            Subject = "This is an email subject",
-            Recipients = [new RecipientExt() { EmailAddress = "recipient2@domain.com" }],
-            Body = "This is an email body",
-            ResourceAction = "write"
-        };
-
-        var actual = _validator.Validate(order);
-
-        Assert.False(actual.IsValid);
-        Assert.Contains(actual.Errors, a => a.ErrorMessage.Equals("ResourceAction cannot be specified without a ResourceId."));
-    }
-
-    [Fact]
-    public void Validate_ResourceActionWithResourceId_ReturnsTrue()
-    {
-        var order = new EmailNotificationOrderRequestExt()
-        {
-            Subject = "This is an email subject",
-            Recipients = [new RecipientExt() { EmailAddress = "recipient2@domain.com" }],
-            Body = "This is an email body",
-            ResourceId = "urn:altinn:resource:test",
-            ResourceAction = "write"
-        };
-
-        var actual = _validator.Validate(order);
-
-        Assert.True(actual.IsValid);
-    }
-
     [Theory]
     [InlineData("æge_sjøåsen@domain.com", true)]
     [InlineData("stephanie@kul.no", true)]


### PR DESCRIPTION
Reverts Altinn/altinn-notifications#1385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the ResourceAction parameter from notification order requests throughout the notification service API. This change simplifies the API by eliminating the configuration option from order model definitions, request handling logic, validation rules, and mapping operations. Related test cases have been updated accordingly to ensure compatibility with the streamlined order creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->