### PR TITLE
Remove both the Username and the partial Password from the log message.

### DIFF
--- a/components/sms-service/src/Altinn.Notifications.Sms/Configuration/BasicAuthenticationHandler.cs
+++ b/components/sms-service/src/Altinn.Notifications.Sms/Configuration/BasicAuthenticationHandler.cs
@@ -5,7 +5,6 @@ using System.Text.Encodings.Web;
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
 
 namespace Altinn.Notifications.Sms.Configuration;
 
@@ -42,12 +41,9 @@ public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSc
     {
         if (!Request.Path.StartsWithSegments("/notifications/sms/api/v1/reports"))
         {
-            // Bypass authentication for all endspoint not reports related
+            // Bypass authentication for all endpoint not reports related
             return Task.FromResult(AuthenticateResult.NoResult());
         }
-
-        string username = string.Empty;
-        string password = string.Empty;
 
         if (!Request.Headers.TryGetValue("Authorization", out var authorizationHeader))
         {
@@ -55,6 +51,9 @@ public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSc
 
             return Task.FromResult(AuthenticateResult.Fail("Missing Authorization Header"));
         }
+
+        string username;
+        string password;
 
         try
         {
@@ -71,7 +70,7 @@ public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSc
 
         if (username != _smsDeliveryReportSettings.UserSettings.Username || password != _smsDeliveryReportSettings.UserSettings.Password)
         {
-            _logger.LogError("// BasicAuthenticationHandler // HandleAuthenticateAsync // Invalid Username {Username} or Password: {Password}", username, password[^5..]);
+            _logger.LogError("// BasicAuthenticationHandler // HandleAuthenticateAsync // Invalid Username or Password.");
             return Task.FromResult(AuthenticateResult.Fail("Invalid Username or Password"));
         }
 


### PR DESCRIPTION
## Description
Remove both the Username and the partial Password from the log message.

## Related Issue(s)
- https://github.com/Altinn/team-core-private/issues/449

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for authentication credential handling by removing sensitive information from system logs.
  * Fixed minor documentation typo in authentication logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->