### PR TITLE
Chore/mend broken docker scanning

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -49,7 +49,7 @@ jobs:
               - 'components/email-service/Dockerfile'
 
   scan-api:
-    name: "Scan: Notifications API"
+    name: 'Scan: Notifications API'
     needs: changes
     if: github.event_name == 'schedule' || needs.changes.outputs.api == 'true'
     runs-on: ubuntu-latest
@@ -68,12 +68,13 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+          trivyignores: '.trivyignore.yaml'
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
 
   scan-email:
-    name: "Scan: Email Delivery Service"
+    name: 'Scan: Email Delivery Service'
     needs: changes
     if: github.event_name == 'schedule' || needs.changes.outputs.email == 'true'
     runs-on: ubuntu-latest
@@ -92,12 +93,13 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+          trivyignores: '.trivyignore.yaml'
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
 
   scan-sms:
-    name: "Scan: SMS Delivery Service"
+    name: 'Scan: SMS Delivery Service'
     needs: changes
     if: github.event_name == 'schedule' || needs.changes.outputs.sms == 'true'
     runs-on: ubuntu-latest
@@ -116,6 +118,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+          trivyignores: '.trivyignore.yaml'
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -6,11 +6,15 @@ on:
     paths:
       - 'components/*/src/**'
       - 'components/*/Dockerfile'
+      - '.trivyignore.yaml'
+      - '.github/workflows/container-scan.yml'
   pull_request:
     branches: [main]
     paths:
       - 'components/*/src/**'
       - 'components/*/Dockerfile'
+      - '.trivyignore.yaml'
+      - '.github/workflows/container-scan.yml'
   schedule:
     - cron: '0 8 * * 1,4'
 

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -76,6 +76,7 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
+          TRIVY_SHOW_SUPPRESSED: true
 
   scan-email:
     name: 'Scan: Email Delivery Service'

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -102,6 +102,7 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
+          TRIVY_SHOW_SUPPRESSED: true
 
   scan-sms:
     name: 'Scan: SMS Delivery Service'
@@ -127,3 +128,4 @@ jobs:
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
+          TRIVY_SHOW_SUPPRESSED: true

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -43,14 +43,20 @@ jobs:
               - 'components/api/src/**'
               - 'components/api/Dockerfile'
               - 'components/shared/src/**'
+              - '.trivyignore.yaml'
+              - '.github/workflows/container-scan.yml'
             sms:
               - 'components/shared/src/**'
               - 'components/sms-service/src/**'
               - 'components/sms-service/Dockerfile'
+              - '.trivyignore.yaml'
+              - '.github/workflows/container-scan.yml'
             email:
               - 'components/shared/src/**'
               - 'components/email-service/src/**'
               - 'components/email-service/Dockerfile'
+              - '.trivyignore.yaml'
+              - '.github/workflows/container-scan.yml'
 
   scan-api:
     name: 'Scan: Notifications API'

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,4 @@
+vulnerabilities:
+  - id: CVE-2026-28390 # libcrypto3/libssl3
+    statement: Not exploitable - application does not process attacker-controlled CMS data
+    expired_at: 2026-05-10 # revisit in 1 month, might have a patch by then

--- a/components/api/Dockerfile
+++ b/components/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.200-alpine3.23@sha256:a0116e63beedf9197c3d491eb224aea9ae7d1692079eda9eebe2809f06d580e3 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.201-alpine3.23@sha256:a65df8d9ad0661a1a785a4f26188b3a2826540d448df317ac69cfb6e801e1592 AS build
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -16,7 +16,7 @@ COPY components/shared/src ./components/shared/src
 RUN dotnet publish -c Release -o out ./components/api/src/Altinn.Notifications/Altinn.Notifications.csproj
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.4-alpine3.23@sha256:512d643dce0e7daa25c85407eb4e14dbea33b72e4a7792427949666636934019 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.5-alpine3.23@sha256:8c7671a6f0f984d0c102ee70d61e8010857de032b320561dea97cc5781aea5f8 AS final
 WORKDIR /app
 EXPOSE 5090
 

--- a/components/email-service/Dockerfile
+++ b/components/email-service/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official .NET SDK image with Alpine Linux as a base image
-FROM mcr.microsoft.com/dotnet/sdk:10.0.200-alpine3.23@sha256:a0116e63beedf9197c3d491eb224aea9ae7d1692079eda9eebe2809f06d580e3 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.201-alpine3.23@sha256:a65df8d9ad0661a1a785a4f26188b3a2826540d448df317ac69cfb6e801e1592 AS build
 
 # Set the working directory in the container
 WORKDIR /app
@@ -20,7 +20,7 @@ RUN dotnet publish -c Release -o out \
     ./components/email-service/src/Altinn.Notifications.Email/Altinn.Notifications.Email.csproj
 
 # Use the official .NET runtime image with Alpine Linux as a base image
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.4-alpine3.23@sha256:512d643dce0e7daa25c85407eb4e14dbea33b72e4a7792427949666636934019 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.5-alpine3.23@sha256:8c7671a6f0f984d0c102ee70d61e8010857de032b320561dea97cc5781aea5f8 AS final
 EXPOSE 5091
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/components/sms-service/Dockerfile
+++ b/components/sms-service/Dockerfile
@@ -1,5 +1,5 @@
 #Use the official .NET SDK image with Alpine Linux as a base image
-FROM mcr.microsoft.com/dotnet/sdk:10.0.200-alpine3.23@sha256:a0116e63beedf9197c3d491eb224aea9ae7d1692079eda9eebe2809f06d580e3 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.201-alpine3.23@sha256:a65df8d9ad0661a1a785a4f26188b3a2826540d448df317ac69cfb6e801e1592 AS build
 
 # Set the working directory in the container
 WORKDIR /app
@@ -21,7 +21,7 @@ RUN dotnet publish -c Release -o out \
 
 
 # Use the official .NET runtime image with Alpine Linux as a base image
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.4-alpine3.23@sha256:512d643dce0e7daa25c85407eb4e14dbea33b72e4a7792427949666636934019 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.5-alpine3.23@sha256:8c7671a6f0f984d0c102ee70d61e8010857de032b320561dea97cc5781aea5f8 AS final
 EXPOSE 5092
 WORKDIR /app
 COPY --from=build /app/out ./


### PR DESCRIPTION
- Patching to latest dotnet Docker images, as these include a fix for the old `zlib `library vulnerability. 
- Adding a new `.trivyignore.yaml` file where we can keep temporary records of unexploitable vulnerabilities that unnecessarily break our scanning job
  - Includes the latest vulnerability ([CVE-2026-28390](https://nvd.nist.gov/vuln/detail/CVE-2026-28390)) 
- Necessary extension of the trivy-action (tell it to use the new ignore-file)
- Extend PR trigger / path filters for the container-scan workflow, so that the workflow is triggered in PR/push when edits are made to it or to the ignore file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container vulnerability scanning configuration to enhance security checks across services.
  * Upgraded Docker base images for API, email, and SMS service components to newer stable versions for improved security and stability.
  * Added vulnerability suppression rules to streamline security scanning processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->