### PR TITLE
Extract email handler policies in separate files

### DIFF
--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 
 using Altinn.Notifications.Email.Core.Models;
 using Altinn.Notifications.Email.Integrations.Configuration;
+using Altinn.Notifications.Email.Integrations.Wolverine.Policies;
 using Altinn.Notifications.Shared.Configuration;
 using Altinn.Notifications.Shared.Extensions;
 
@@ -74,6 +75,8 @@ public static class WolverineServiceCollectionExtensions
 
         wolverineOptions.ListenToAzureServiceBusQueue(wolverineSettings.EmailSendQueueName)
                         .ListenerCount(wolverineSettings.ListenerCount);
+
+        wolverineOptions.Policies.Add(new SendEmailCommandHandlerPolicy(wolverineSettings));
     }
 
     /// <summary>
@@ -116,5 +119,7 @@ public static class WolverineServiceCollectionExtensions
 
         wolverineOptions.ListenToAzureServiceBusQueue(wolverineSettings.EmailStatusCheckQueueName)
                         .ListenerCount(wolverineSettings.ListenerCount);
+
+        wolverineOptions.Policies.Add(new CheckEmailSendStatusHandlerPolicy(wolverineSettings));
     }
 }

--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using Altinn.Notifications.Email.Core.Models;
 using Altinn.Notifications.Email.Integrations.Configuration;
 using Altinn.Notifications.Email.Integrations.Wolverine.Policies;
+using Altinn.Notifications.Shared.Commands;
 using Altinn.Notifications.Shared.Configuration;
 using Altinn.Notifications.Shared.Extensions;
 
@@ -57,10 +58,12 @@ public static class WolverineServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds the email send queue listener.
+    /// Registers the Wolverine listener for the Azure Service Bus email send queue, enabling
+    /// the email service to consume <see cref="SendEmailCommand"/> messages.
+    /// This method is invoked only when <see cref="WolverineSettings.EnableSendEmailListener"/> is <c>true</c>.
     /// </summary>
-    /// <param name="wolverineSettings">The wolverine settings.</param>
-    /// <param name="wolverineOptions">The opts.</param>
+    /// <param name="wolverineSettings">The Wolverine settings containing queue names and feature flags.</param>
+    /// <param name="wolverineOptions">The Wolverine options to configure.</param>
     private static void AddEmailSendQueueListener(WolverineSettings wolverineSettings, WolverineOptions wolverineOptions)
     {
         if (!wolverineSettings.EnableSendEmailListener)
@@ -80,9 +83,12 @@ public static class WolverineServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Registers Wolverine publishing rules for <see cref="CheckEmailSendStatusCommand"/>, routing outbound commands to the Azure Service Bus email status check queue.
+    /// Registers Wolverine publishing rules for <see cref="CheckEmailSendStatusCommand"/>, routing
+    /// outbound commands to the Azure Service Bus email status check queue.
     /// This method is invoked only when <see cref="WolverineSettings.EnableEmailStatusCheckListener"/> is <c>true</c>.
     /// </summary>
+    /// <param name="wolverineSettings">The Wolverine settings containing queue names and feature flags.</param>
+    /// <param name="wolverineOptions">The Wolverine options to configure.</param>
     private static void AddEmailStatusCheckPublisher(WolverineSettings wolverineSettings, WolverineOptions wolverineOptions)
     {
         if (!wolverineSettings.EnableEmailStatusCheckListener)
@@ -105,6 +111,8 @@ public static class WolverineServiceCollectionExtensions
     /// poll Azure Communication Services (ACS) for delivery status.
     /// This method is invoked only when <see cref="WolverineSettings.EnableEmailStatusCheckListener"/> is <c>true</c>.
     /// </summary>
+    /// <param name="wolverineSettings">The Wolverine settings containing queue names and feature flags.</param>
+    /// <param name="wolverineOptions">The Wolverine options to configure.</param>
     private static void AddEmailStatusCheckListener(WolverineSettings wolverineSettings, WolverineOptions wolverineOptions)
     {
         if (!wolverineSettings.EnableEmailStatusCheckListener)

--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Handlers/CheckEmailSendStatusHandler.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Handlers/CheckEmailSendStatusHandler.cs
@@ -1,20 +1,11 @@
-using System.Diagnostics.CodeAnalysis;
-
 using Altinn.Notifications.Email.Core;
 using Altinn.Notifications.Email.Core.Configuration;
 using Altinn.Notifications.Email.Core.Dependencies;
 using Altinn.Notifications.Email.Core.Models;
 using Altinn.Notifications.Email.Core.Status;
-using Altinn.Notifications.Email.Integrations.Configuration;
-
-using Azure.Messaging.ServiceBus;
-
-using Microsoft.Extensions.Options;
 
 using Wolverine;
 using Wolverine.Attributes;
-using Wolverine.ErrorHandling;
-using Wolverine.Runtime.Handlers;
 
 namespace Altinn.Notifications.Email.Integrations.Wolverine.Handlers;
 
@@ -25,32 +16,6 @@ namespace Altinn.Notifications.Email.Integrations.Wolverine.Handlers;
 public static class CheckEmailSendStatusHandler
 {
     private const int _statusPollDelayMs = 8000;
-
-    /// <summary>
-    /// Configures error-handling and retry policies for the polling-loop handler chain.
-    /// Wolverine resolves <paramref name="options"/> from the IoC container at chain-compilation time.
-    /// </summary>
-    /// <remarks>
-    /// <see cref="ArgumentException"/> is intentionally excluded from the retry policy.
-    /// Messages that fail guard-clause validation are malformed and must not be retried — they
-    /// will be moved to the dead-letter queue by Wolverine's default failure handling.
-    /// </remarks>
-    /// <param name="chain">The Wolverine handler chain to apply the retry policies to.</param>
-    /// <param name="options">The Wolverine settings resolved from the IoC container.</param>
-    [ExcludeFromCodeCoverage]
-    public static void Configure(HandlerChain chain, IOptions<WolverineSettings> options)
-    {
-        var policy = options.Value.EmailStatusCheckQueuePolicy;
-
-        chain
-            .OnException<TimeoutException>()
-            .Or<ServiceBusException>()
-            .Or<TaskCanceledException>()
-            .Or<InvalidOperationException>()
-            .RetryWithCooldown(policy.GetCooldownDelays())
-            .Then.ScheduleRetry(policy.GetScheduleDelays())
-            .Then.MoveToErrorQueue();
-    }
 
     /// <summary>
     /// Polls ACS for delivery status. If the result is terminal, publishes

--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Handlers/SendEmailCommandHandler.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Handlers/SendEmailCommandHandler.cs
@@ -1,45 +1,15 @@
-using System.Diagnostics.CodeAnalysis;
-
 using Altinn.Notifications.Email.Core.Sending;
-using Altinn.Notifications.Email.Integrations.Configuration;
 using Altinn.Notifications.Shared.Commands;
 
-using Azure.Messaging.ServiceBus;
-
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
-using Wolverine.ErrorHandling;
-using Wolverine.Runtime.Handlers;
-
-namespace Altinn.Notifications.Email.Integrations.Wolverine;
+namespace Altinn.Notifications.Email.Integrations.Wolverine.Handlers;
 
 /// <summary>
 /// Wolverine handler for <see cref="SendEmailCommand"/> messages received from Azure Service Bus.
 /// </summary>
 public static class SendEmailCommandHandler
 {
-    /// <summary>
-    /// Configures error-handling and retry policies for the email send queue handler.
-    /// Wolverine resolves <paramref name="options"/> from the IoC container at chain-compilation time.
-    /// </summary>
-    /// <param name="chain">The Wolverine handler chain to apply the retry policies to.</param>
-    /// <param name="options">The Wolverine settings resolved from the IoC container.</param>
-    [ExcludeFromCodeCoverage]
-    public static void Configure(HandlerChain chain, IOptions<WolverineSettings> options)
-    {
-        var policy = options.Value.EmailSendQueuePolicy;
-
-        chain
-            .OnException<TimeoutException>()
-            .Or<ServiceBusException>()
-            .Or<TaskCanceledException>()
-            .Or<InvalidOperationException>()
-            .RetryWithCooldown(policy.GetCooldownDelays())
-            .Then.ScheduleRetry(policy.GetScheduleDelays())
-            .Then.MoveToErrorQueue();
-    }
-
     /// <summary>
     /// Handles a <see cref="SendEmailCommand"/> by mapping it to an <see cref="Core.Sending.Email"/>
     /// and delegating sending to <see cref="ISendingService"/>.

--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Policies/CheckEmailSendStatusHandlerPolicy.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Policies/CheckEmailSendStatusHandlerPolicy.cs
@@ -1,0 +1,41 @@
+using Altinn.Notifications.Email.Core.Models;
+using Altinn.Notifications.Email.Integrations.Configuration;
+
+using Azure.Messaging.ServiceBus;
+
+using JasperFx;
+using JasperFx.CodeGeneration;
+
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+using Wolverine.Runtime.Handlers;
+
+namespace Altinn.Notifications.Email.Integrations.Wolverine.Policies;
+
+/// <summary>
+/// Wolverine handler policy that configures error handling for the <see cref="CheckEmailSendStatusCommand"/> handler chain.
+/// </summary>
+/// <param name="settings">Wolverine settings used to retrieve retry and cooldown delay configuration.</param>
+internal sealed class CheckEmailSendStatusHandlerPolicy(WolverineSettings settings) : IHandlerPolicy
+{
+    /// <inheritdoc/>
+    public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        var chain = chains.FirstOrDefault(c => c.MessageType == typeof(CheckEmailSendStatusCommand));
+        if (chain is null)
+        {
+            return;
+        }
+
+        var policy = settings.EmailStatusCheckQueuePolicy;
+
+        chain
+            .OnException<TimeoutException>()
+            .Or<ServiceBusException>()
+            .Or<TaskCanceledException>()
+            .Or<InvalidOperationException>()
+            .RetryWithCooldown(policy.GetCooldownDelays())
+            .Then.ScheduleRetry(policy.GetScheduleDelays())
+            .Then.MoveToErrorQueue();
+    }
+}

--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Policies/CheckEmailSendStatusHandlerPolicy.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Policies/CheckEmailSendStatusHandlerPolicy.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 using Altinn.Notifications.Email.Core.Models;
 using Altinn.Notifications.Email.Integrations.Configuration;
 
@@ -21,11 +23,8 @@ internal sealed class CheckEmailSendStatusHandlerPolicy(WolverineSettings settin
     /// <inheritdoc/>
     public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
     {
-        var chain = chains.FirstOrDefault(c => c.MessageType == typeof(CheckEmailSendStatusCommand));
-        if (chain is null)
-        {
-            return;
-        }
+        var chain = chains.FirstOrDefault(c => c.MessageType == typeof(CheckEmailSendStatusCommand))
+            ?? throw new UnreachableException($"No handler chain found for {nameof(CheckEmailSendStatusCommand)}. Ensure the handler is registered before adding this policy.");
 
         var policy = settings.EmailStatusCheckQueuePolicy;
 

--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Policies/SendEmailCommandHandlerPolicy.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Policies/SendEmailCommandHandlerPolicy.cs
@@ -1,0 +1,41 @@
+using Altinn.Notifications.Email.Integrations.Configuration;
+using Altinn.Notifications.Shared.Commands;
+
+using Azure.Messaging.ServiceBus;
+
+using JasperFx;
+using JasperFx.CodeGeneration;
+
+using Wolverine.Configuration;
+using Wolverine.ErrorHandling;
+using Wolverine.Runtime.Handlers;
+
+namespace Altinn.Notifications.Email.Integrations.Wolverine.Policies;
+
+/// <summary>
+/// Wolverine handler policy that configures error handling for the <see cref="SendEmailCommand"/> handler chain.
+/// </summary>
+/// <param name="settings">Wolverine settings used to retrieve retry and cooldown delay configuration.</param>
+internal sealed class SendEmailCommandHandlerPolicy(WolverineSettings settings) : IHandlerPolicy
+{
+    /// <inheritdoc/>
+    public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
+    {
+        var chain = chains.FirstOrDefault(c => c.MessageType == typeof(SendEmailCommand));
+        if (chain is null)
+        {
+            return;
+        }
+
+        var policy = settings.EmailSendQueuePolicy;
+
+        chain
+            .OnException<TimeoutException>()
+            .Or<ServiceBusException>()
+            .Or<TaskCanceledException>()
+            .Or<InvalidOperationException>()
+            .RetryWithCooldown(policy.GetCooldownDelays())
+            .Then.ScheduleRetry(policy.GetScheduleDelays())
+            .Then.MoveToErrorQueue();
+    }
+}

--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Policies/SendEmailCommandHandlerPolicy.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Policies/SendEmailCommandHandlerPolicy.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 using Altinn.Notifications.Email.Integrations.Configuration;
 using Altinn.Notifications.Shared.Commands;
 
@@ -21,11 +23,8 @@ internal sealed class SendEmailCommandHandlerPolicy(WolverineSettings settings) 
     /// <inheritdoc/>
     public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
     {
-        var chain = chains.FirstOrDefault(c => c.MessageType == typeof(SendEmailCommand));
-        if (chain is null)
-        {
-            return;
-        }
+        var chain = chains.FirstOrDefault(c => c.MessageType == typeof(SendEmailCommand))
+            ?? throw new UnreachableException($"No handler chain found for {nameof(SendEmailCommand)}. Ensure the handler is registered before adding this policy.");
 
         var policy = settings.EmailSendQueuePolicy;
 

--- a/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/GlobalSuppressions.cs
+++ b/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Test description should be in the name of the test.", Scope = "module")]

--- a/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/Infrastructure/IntegrationTestWebApplicationFactory.cs
+++ b/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/Infrastructure/IntegrationTestWebApplicationFactory.cs
@@ -18,7 +18,10 @@ namespace Altinn.Notifications.Email.IntegrationTestsASB.Infrastructure;
 public class IntegrationTestWebApplicationFactory(IntegrationTestContainersFixture fixture)
     : IntegrationTestWebApplicationFactoryBase<Program, IntegrationTestWebApplicationFactory>(fixture)
 {
-    private WolverineSettings? _wolverineSettings;
+    /// <summary>
+    /// Gets the Wolverine settings loaded from configuration.
+    /// </summary>
+    public WolverineSettings? WolverineSettings { get; private set; }
 
     /// <inheritdoc/>
     protected override Dictionary<string, string?> GetFixtureConfigOverrides() => new()
@@ -29,7 +32,7 @@ public class IntegrationTestWebApplicationFactory(IntegrationTestContainersFixtu
     /// <inheritdoc/>
     protected override void ConfigureComponentServices(IConfiguration configuration, IServiceCollection services)
     {
-        _wolverineSettings = configuration.GetSection("WolverineSettings").Get<WolverineSettings>()
+        WolverineSettings = configuration.GetSection("WolverineSettings").Get<WolverineSettings>()
             ?? throw new InvalidOperationException("WolverineSettings not found in configuration");
 
         Console.WriteLine($"[EmailFactory] ServiceBus connection: {Truncate(Fixture.ServiceBusConnectionString, 50)}...");
@@ -42,14 +45,14 @@ public class IntegrationTestWebApplicationFactory(IntegrationTestContainersFixtu
     /// <inheritdoc/>
     protected override async Task DrainQueuesAsync()
     {
-        if (_wolverineSettings == null || !_wolverineSettings.EnableWolverine)
+        if (WolverineSettings == null || !WolverineSettings.EnableWolverine)
         {
             return;
         }
 
         await DrainDeadLetterQueuesAsync(
             Fixture.ServiceBusConnectionString,
-            _wolverineSettings.EmailSendQueueName,
-            _wolverineSettings.EmailStatusCheckQueueName);
+            WolverineSettings.EmailSendQueueName,
+            WolverineSettings.EmailStatusCheckQueueName);
     }
 }

--- a/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/Tests/CheckEmailSendStatusHandlerTests.cs
+++ b/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/Tests/CheckEmailSendStatusHandlerTests.cs
@@ -1,0 +1,199 @@
+using Altinn.Notifications.Email.Core.Dependencies;
+using Altinn.Notifications.Email.Core.Models;
+using Altinn.Notifications.Email.Core.Status;
+using Altinn.Notifications.Email.IntegrationTestsASB.Infrastructure;
+using Altinn.Notifications.Shared.TestInfrastructure.Infrastructure;
+using Altinn.Notifications.Shared.TestInfrastructure.Utils;
+
+using Moq;
+
+using Xunit;
+
+namespace Altinn.Notifications.Email.IntegrationTestsASB.Tests;
+
+/// <summary>
+/// Integration tests for the <see cref="CheckEmailSendStatusCommand"/> Wolverine handler.
+/// Boots the real host with Wolverine and ASB emulator, sends commands through the message bus,
+/// and verifies the handler polls ACS correctly and applies the configured retry policy.
+/// </summary>
+[Collection(nameof(IntegrationTestContainersCollection))]
+public class CheckEmailSendStatusHandlerTests(IntegrationTestContainersFixture fixture)
+{
+    private readonly IntegrationTestContainersFixture _fixture = fixture;
+
+    private static CheckEmailSendStatusCommand ValidCommand() => new()
+    {
+        NotificationId = Guid.NewGuid(),
+        SendOperationId = Guid.NewGuid().ToString(),
+        LastCheckedAtUtc = DateTime.UtcNow
+    };
+
+    /// <summary>
+    /// Verifies that a terminal ACS result causes the handler to publish to Kafka via <see cref="ICommonProducer"/>.
+    /// </summary>
+    [Theory]
+    [InlineData(EmailSendResult.Delivered)]
+    [InlineData(EmailSendResult.Failed)]
+    [InlineData(EmailSendResult.Failed_Bounced)]
+    [InlineData(EmailSendResult.Failed_FilteredSpam)]
+    public async Task CheckEmailSendStatus_WhenTerminalResult_PublishesToKafka(EmailSendResult terminalResult)
+    {
+        // Arrange
+        var command = ValidCommand();
+        var producerCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var producerMock = new Mock<ICommonProducer>();
+        producerMock
+            .Setup(p => p.ProduceAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<string, string>((_, _) => producerCalled.TrySetResult())
+            .ReturnsAsync(true);
+
+        var emailClientMock = new Mock<IEmailServiceClient>();
+        emailClientMock
+            .Setup(c => c.GetOperationUpdate(command.SendOperationId))
+            .ReturnsAsync(terminalResult);
+
+        var factory = new IntegrationTestWebApplicationFactory(_fixture)
+            .WithConfig("WolverineSettings:EnableEmailStatusCheckListener", "true")
+            .ReplaceService<ICommonProducer>(_ => producerMock.Object)
+            .ReplaceService<IEmailServiceClient>(_ => emailClientMock.Object)
+            .Initialize();
+
+        await using (factory)
+        {
+            string queueName = factory.WolverineSettings!.EmailStatusCheckQueueName;
+
+            // Act
+            await factory.SendToQueueAsync(queueName, command);
+
+            // Assert - Producer is called once ACS returns a terminal result
+            var completed = await WaitForUtils.WaitForAsync(
+                () => Task.FromResult(producerCalled.Task.IsCompleted),
+                maxAttempts: 20,
+                delayMs: 500);
+            Assert.True(completed, "Handler should publish to Kafka when ACS returns a terminal result");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that when ACS returns <see cref="EmailSendResult.Sending"/>, the handler reschedules
+    /// the command and eventually publishes to Kafka once a terminal result is received.
+    /// </summary>
+    [Fact]
+    public async Task CheckEmailSendStatus_WhenStillSending_ReschedulesAndEventuallyPublishes()
+    {
+        // Arrange
+        var command = ValidCommand();
+        var producerCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var producerMock = new Mock<ICommonProducer>();
+        producerMock
+            .Setup(p => p.ProduceAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Callback<string, string>((_, _) => producerCalled.TrySetResult())
+            .ReturnsAsync(true);
+
+        var emailClientMock = new Mock<IEmailServiceClient>();
+        emailClientMock
+            .SetupSequence(c => c.GetOperationUpdate(command.SendOperationId))
+            .ReturnsAsync(EmailSendResult.Sending)
+            .ReturnsAsync(EmailSendResult.Delivered);
+
+        var factory = new IntegrationTestWebApplicationFactory(_fixture)
+            .WithConfig("WolverineSettings:EnableEmailStatusCheckListener", "true")
+            .ReplaceService<ICommonProducer>(_ => producerMock.Object)
+            .ReplaceService<IEmailServiceClient>(_ => emailClientMock.Object)
+            .Initialize();
+
+        await using (factory)
+        {
+            string queueName = factory.WolverineSettings!.EmailStatusCheckQueueName;
+
+            // Act
+            await factory.SendToQueueAsync(queueName, command);
+
+            // Assert - Handler reschedules on first call (Sending) and publishes on second (Delivered)
+            // Higher timeout to account for the 8-second rescheduling delay in the handler
+            var completed = await WaitForUtils.WaitForAsync(
+                () => Task.FromResult(producerCalled.Task.IsCompleted),
+                maxAttempts: 40,
+                delayMs: 500);
+            Assert.True(completed, "Handler should reschedule and eventually publish once ACS returns a terminal result");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="InvalidOperationException"/> from the ACS client triggers the retry
+    /// policy — cooldown retries followed by scheduled retries — before the message is moved to the DLQ.
+    /// </summary>
+    [Fact]
+    public async Task CheckEmailSendStatus_WhenAcsClientThrows_RetriesAndMovesToDeadLetterQueue()
+    {
+        // Arrange
+        int attemptCount = 0;
+
+        var emailClientMock = new Mock<IEmailServiceClient>();
+        emailClientMock
+            .Setup(c => c.GetOperationUpdate(It.IsAny<string>()))
+            .Callback(() => Interlocked.Increment(ref attemptCount))
+            .ThrowsAsync(new InvalidOperationException("Simulated ACS error"));
+
+        var factory = new IntegrationTestWebApplicationFactory(_fixture)
+            .WithConfig("WolverineSettings:EnableEmailStatusCheckListener", "true")
+            .ReplaceService<IEmailServiceClient>(_ => emailClientMock.Object)
+            .Initialize();
+
+        await using (factory)
+        {
+            string queueName = factory.WolverineSettings!.EmailStatusCheckQueueName;
+
+            // Act
+            await factory.SendToQueueAsync(queueName, ValidCommand());
+
+            // Assert - Message should land in DLQ after retries are exhausted
+            var deadLetterMessage = await ServiceBusTestUtils.WaitForDeadLetterMessageAsync(
+                _fixture.ServiceBusConnectionString,
+                queueName,
+                TimeSpan.FromSeconds(30));
+            Assert.NotNull(deadLetterMessage);
+
+            // Assert - Verify the handler was called the expected number of times
+            // RetryWithCooldown(100ms, 100ms, 100ms) = 3 retries within same lock
+            // ScheduleRetry(500ms, 500ms, 500ms) = 3 more retries with new locks
+            // Total: 1 initial + 3 cooldown retries + 3 scheduled retries = 7 attempts
+            Console.WriteLine($"[Test] Handler was called {attemptCount} times");
+            Assert.Equal(7, attemptCount);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a command with an empty <see cref="CheckEmailSendStatusCommand.NotificationId"/>
+    /// is moved to the DLQ immediately — <see cref="ArgumentException"/> is not in the retry policy.
+    /// </summary>
+    [Fact]
+    public async Task CheckEmailSendStatus_WhenNotificationIdIsEmpty_GoesToDeadLetterQueueWithoutRetry()
+    {
+        var factory = new IntegrationTestWebApplicationFactory(_fixture)
+            .WithConfig("WolverineSettings:EnableEmailStatusCheckListener", "true")
+            .Initialize();
+
+        await using (factory)
+        {
+            string queueName = factory.WolverineSettings!.EmailStatusCheckQueueName;
+
+            // Act - NotificationId = Guid.Empty triggers ArgumentException in the handler guard clause
+            await factory.SendToQueueAsync(queueName, new CheckEmailSendStatusCommand
+            {
+                NotificationId = Guid.Empty,
+                SendOperationId = Guid.NewGuid().ToString(),
+                LastCheckedAtUtc = DateTime.UtcNow
+            });
+
+            // Assert - Message should appear in DLQ quickly (ArgumentException is not retried)
+            var deadLetterMessage = await ServiceBusTestUtils.WaitForDeadLetterMessageAsync(
+                _fixture.ServiceBusConnectionString,
+                queueName,
+                TimeSpan.FromSeconds(10));
+            Assert.NotNull(deadLetterMessage);
+        }
+    }
+}

--- a/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/Tests/CheckEmailSendStatusHandlerTests.cs
+++ b/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/Tests/CheckEmailSendStatusHandlerTests.cs
@@ -11,11 +11,6 @@ using Xunit;
 
 namespace Altinn.Notifications.Email.IntegrationTestsASB.Tests;
 
-/// <summary>
-/// Integration tests for the <see cref="CheckEmailSendStatusCommand"/> Wolverine handler.
-/// Boots the real host with Wolverine and ASB emulator, sends commands through the message bus,
-/// and verifies the handler polls ACS correctly and applies the configured retry policy.
-/// </summary>
 [Collection(nameof(IntegrationTestContainersCollection))]
 public class CheckEmailSendStatusHandlerTests(IntegrationTestContainersFixture fixture)
 {
@@ -28,9 +23,6 @@ public class CheckEmailSendStatusHandlerTests(IntegrationTestContainersFixture f
         LastCheckedAtUtc = DateTime.UtcNow
     };
 
-    /// <summary>
-    /// Verifies that a terminal ACS result causes the handler to publish to Kafka via <see cref="ICommonProducer"/>.
-    /// </summary>
     [Theory]
     [InlineData(EmailSendResult.Delivered)]
     [InlineData(EmailSendResult.Failed)]
@@ -55,8 +47,8 @@ public class CheckEmailSendStatusHandlerTests(IntegrationTestContainersFixture f
 
         var factory = new IntegrationTestWebApplicationFactory(_fixture)
             .WithConfig("WolverineSettings:EnableEmailStatusCheckListener", "true")
-            .ReplaceService<ICommonProducer>(_ => producerMock.Object)
-            .ReplaceService<IEmailServiceClient>(_ => emailClientMock.Object)
+            .ReplaceService(_ => producerMock.Object)
+            .ReplaceService(_ => emailClientMock.Object)
             .Initialize();
 
         await using (factory)
@@ -66,7 +58,7 @@ public class CheckEmailSendStatusHandlerTests(IntegrationTestContainersFixture f
             // Act
             await factory.SendToQueueAsync(queueName, command);
 
-            // Assert - Producer is called once ACS returns a terminal result
+            // Assert
             var completed = await WaitForUtils.WaitForAsync(
                 () => Task.FromResult(producerCalled.Task.IsCompleted),
                 maxAttempts: 20,
@@ -75,10 +67,6 @@ public class CheckEmailSendStatusHandlerTests(IntegrationTestContainersFixture f
         }
     }
 
-    /// <summary>
-    /// Verifies that when ACS returns <see cref="EmailSendResult.Sending"/>, the handler reschedules
-    /// the command and eventually publishes to Kafka once a terminal result is received.
-    /// </summary>
     [Fact]
     public async Task CheckEmailSendStatus_WhenStillSending_ReschedulesAndEventuallyPublishes()
     {
@@ -100,8 +88,8 @@ public class CheckEmailSendStatusHandlerTests(IntegrationTestContainersFixture f
 
         var factory = new IntegrationTestWebApplicationFactory(_fixture)
             .WithConfig("WolverineSettings:EnableEmailStatusCheckListener", "true")
-            .ReplaceService<ICommonProducer>(_ => producerMock.Object)
-            .ReplaceService<IEmailServiceClient>(_ => emailClientMock.Object)
+            .ReplaceService(_ => producerMock.Object)
+            .ReplaceService(_ => emailClientMock.Object)
             .Initialize();
 
         await using (factory)
@@ -111,8 +99,7 @@ public class CheckEmailSendStatusHandlerTests(IntegrationTestContainersFixture f
             // Act
             await factory.SendToQueueAsync(queueName, command);
 
-            // Assert - Handler reschedules on first call (Sending) and publishes on second (Delivered)
-            // Higher timeout to account for the 8-second rescheduling delay in the handler
+            // Assert - Higher timeout to account for the 8-second rescheduling delay in the handler
             var completed = await WaitForUtils.WaitForAsync(
                 () => Task.FromResult(producerCalled.Task.IsCompleted),
                 maxAttempts: 40,
@@ -121,10 +108,6 @@ public class CheckEmailSendStatusHandlerTests(IntegrationTestContainersFixture f
         }
     }
 
-    /// <summary>
-    /// Verifies that an <see cref="InvalidOperationException"/> from the ACS client triggers the retry
-    /// policy — cooldown retries followed by scheduled retries — before the message is moved to the DLQ.
-    /// </summary>
     [Fact]
     public async Task CheckEmailSendStatus_WhenAcsClientThrows_RetriesAndMovesToDeadLetterQueue()
     {
@@ -139,7 +122,7 @@ public class CheckEmailSendStatusHandlerTests(IntegrationTestContainersFixture f
 
         var factory = new IntegrationTestWebApplicationFactory(_fixture)
             .WithConfig("WolverineSettings:EnableEmailStatusCheckListener", "true")
-            .ReplaceService<IEmailServiceClient>(_ => emailClientMock.Object)
+            .ReplaceService(_ => emailClientMock.Object)
             .Initialize();
 
         await using (factory)
@@ -149,7 +132,7 @@ public class CheckEmailSendStatusHandlerTests(IntegrationTestContainersFixture f
             // Act
             await factory.SendToQueueAsync(queueName, ValidCommand());
 
-            // Assert - Message should land in DLQ after retries are exhausted
+            // Assert - Wait for message to appear in dead letter queue after retries exhaust
             var deadLetterMessage = await ServiceBusTestUtils.WaitForDeadLetterMessageAsync(
                 _fixture.ServiceBusConnectionString,
                 queueName,
@@ -165,10 +148,6 @@ public class CheckEmailSendStatusHandlerTests(IntegrationTestContainersFixture f
         }
     }
 
-    /// <summary>
-    /// Verifies that a command with an empty <see cref="CheckEmailSendStatusCommand.NotificationId"/>
-    /// is moved to the DLQ immediately — <see cref="ArgumentException"/> is not in the retry policy.
-    /// </summary>
     [Fact]
     public async Task CheckEmailSendStatus_WhenNotificationIdIsEmpty_GoesToDeadLetterQueueWithoutRetry()
     {

--- a/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/Tests/SendEmailCommandHandlerTests.cs
+++ b/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/Tests/SendEmailCommandHandlerTests.cs
@@ -10,20 +10,11 @@ using Xunit;
 
 namespace Altinn.Notifications.Email.IntegrationTestsASB.Tests;
 
-/// <summary>
-/// Integration tests for the <see cref="SendEmailCommand"/> Wolverine handler.
-/// Boots the real host with Wolverine and ASB emulator, publishes commands through the message bus,
-/// and verifies the handler invokes <see cref="ISendingService"/> with the correct mapped email.
-/// </summary>
 [Collection(nameof(IntegrationTestContainersCollection))]
 public class SendEmailCommandHandlerTests(IntegrationTestContainersFixture fixture)
 {
     private readonly IntegrationTestContainersFixture _fixture = fixture;
 
-    /// <summary>
-    /// Verifies that a <see cref="SendEmailCommand"/> published via Wolverine is handled
-    /// end-to-end and the sending service receives a correctly mapped email with Html content type.
-    /// </summary>
     [Fact]
     public async Task HandleAsync_ValidHtmlCommand_SendingServiceReceivesMappedEmail()
     {
@@ -63,10 +54,6 @@ public class SendEmailCommandHandlerTests(IntegrationTestContainersFixture fixtu
         }
     }
 
-    /// <summary>
-    /// Verifies that a <see cref="SendEmailCommand"/> with Plain content type
-    /// is correctly mapped and forwarded to the sending service.
-    /// </summary>
     [Fact]
     public async Task HandleAsync_PlainContentType_MapsCorrectly()
     {
@@ -101,11 +88,6 @@ public class SendEmailCommandHandlerTests(IntegrationTestContainersFixture fixtu
         }
     }
 
-    /// <summary>
-    /// Verifies that an <see cref="InvalidOperationException"/> thrown by the sending service
-    /// triggers the retry policy — cooldown retries followed by scheduled retries — before
-    /// the message is moved to the dead letter queue.
-    /// </summary>
     [Fact]
     public async Task HandleAsync_WhenSendingServiceThrows_RetriesAndMovesToDeadLetterQueue()
     {
@@ -119,7 +101,7 @@ public class SendEmailCommandHandlerTests(IntegrationTestContainersFixture fixtu
 
         var factory = new IntegrationTestWebApplicationFactory(_fixture)
             .WithConfig("WolverineSettings:EnableSendEmailListener", "true")
-            .ReplaceService<ISendingService>(_ => sendingServiceMock.Object)
+            .ReplaceService(_ => sendingServiceMock.Object)
             .Initialize();
 
         await using (factory)
@@ -137,7 +119,7 @@ public class SendEmailCommandHandlerTests(IntegrationTestContainersFixture fixtu
                 ToAddress = "recipient@example.com"
             });
 
-            // Assert - Message should land in DLQ after retries are exhausted
+            // Assert - Wait for message to appear in dead letter queue after retries exhaust
             var deadLetterMessage = await ServiceBusTestUtils.WaitForDeadLetterMessageAsync(
                 _fixture.ServiceBusConnectionString,
                 queueName,

--- a/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/Tests/SendEmailCommandHandlerTests.cs
+++ b/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/Tests/SendEmailCommandHandlerTests.cs
@@ -2,6 +2,9 @@ using Altinn.Notifications.Email.Core.Sending;
 using Altinn.Notifications.Email.IntegrationTestsASB.Infrastructure;
 using Altinn.Notifications.Shared.Commands;
 using Altinn.Notifications.Shared.TestInfrastructure.Infrastructure;
+using Altinn.Notifications.Shared.TestInfrastructure.Utils;
+
+using Moq;
 
 using Xunit;
 
@@ -38,14 +41,15 @@ public class SendEmailCommandHandlerTests(IntegrationTestContainersFixture fixtu
 
         var factory = new IntegrationTestWebApplicationFactory(_fixture)
             .WithConfig("WolverineSettings:EnableSendEmailListener", "true")
-            .WithConfig("WolverineSettings:EmailSendQueueName", "altinn.notifications.email.send")
             .ReplaceService<ISendingService>(_ => sendingService)
             .Initialize();
 
         await using (factory)
         {
+            string queueName = factory.WolverineSettings!.EmailSendQueueName;
+
             // Act
-            await factory.SendToEndpointAsync("altinn.notifications.email.send", command);
+            await factory.SendToEndpointAsync(queueName, command);
             var capturedEmail = await sendingService.WaitForEmailAsync(TimeSpan.FromSeconds(10));
 
             // Assert
@@ -80,19 +84,72 @@ public class SendEmailCommandHandlerTests(IntegrationTestContainersFixture fixtu
 
         var factory = new IntegrationTestWebApplicationFactory(_fixture)
             .WithConfig("WolverineSettings:EnableSendEmailListener", "true")
-            .WithConfig("WolverineSettings:EmailSendQueueName", "altinn.notifications.email.send")
             .ReplaceService<ISendingService>(_ => sendingService)
             .Initialize();
 
         await using (factory)
         {
+            string queueName = factory.WolverineSettings!.EmailSendQueueName;
+
             // Act
-            await factory.SendToEndpointAsync("altinn.notifications.email.send", command);
+            await factory.SendToEndpointAsync(queueName, command);
             var capturedEmail = await sendingService.WaitForEmailAsync(TimeSpan.FromSeconds(10));
 
             // Assert
             Assert.NotNull(capturedEmail);
             Assert.Equal(EmailContentType.Plain, capturedEmail.ContentType);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="InvalidOperationException"/> thrown by the sending service
+    /// triggers the retry policy — cooldown retries followed by scheduled retries — before
+    /// the message is moved to the dead letter queue.
+    /// </summary>
+    [Fact]
+    public async Task HandleAsync_WhenSendingServiceThrows_RetriesAndMovesToDeadLetterQueue()
+    {
+        // Arrange
+        int attemptCount = 0;
+        var sendingServiceMock = new Mock<ISendingService>();
+        sendingServiceMock
+            .Setup(s => s.SendAsync(It.IsAny<Core.Sending.Email>()))
+            .Callback(() => Interlocked.Increment(ref attemptCount))
+            .ThrowsAsync(new InvalidOperationException("Simulated sending failure"));
+
+        var factory = new IntegrationTestWebApplicationFactory(_fixture)
+            .WithConfig("WolverineSettings:EnableSendEmailListener", "true")
+            .ReplaceService<ISendingService>(_ => sendingServiceMock.Object)
+            .Initialize();
+
+        await using (factory)
+        {
+            string queueName = factory.WolverineSettings!.EmailSendQueueName;
+
+            // Act
+            await factory.SendToEndpointAsync(queueName, new SendEmailCommand
+            {
+                Body = "Body",
+                ContentType = "Plain",
+                Subject = "Subject",
+                NotificationId = Guid.NewGuid(),
+                FromAddress = "sender@example.com",
+                ToAddress = "recipient@example.com"
+            });
+
+            // Assert - Message should land in DLQ after retries are exhausted
+            var deadLetterMessage = await ServiceBusTestUtils.WaitForDeadLetterMessageAsync(
+                _fixture.ServiceBusConnectionString,
+                queueName,
+                TimeSpan.FromSeconds(30));
+            Assert.NotNull(deadLetterMessage);
+
+            // Assert - Verify the handler was called the expected number of times
+            // RetryWithCooldown(100ms, 100ms, 100ms) = 3 retries within same lock
+            // ScheduleRetry(500ms, 500ms, 500ms) = 3 more retries with new locks
+            // Total: 1 initial + 3 cooldown retries + 3 scheduled retries = 7 attempts
+            Console.WriteLine($"[Test] Handler was called {attemptCount} times");
+            Assert.Equal(7, attemptCount);
         }
     }
 }

--- a/components/email-service/test/Altinn.Notifications.Email.Tests/Email.Integrations/Wolverine/CheckEmailSendStatusHandlerPolicyTests.cs
+++ b/components/email-service/test/Altinn.Notifications.Email.Tests/Email.Integrations/Wolverine/CheckEmailSendStatusHandlerPolicyTests.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+
+using Altinn.Notifications.Email.Integrations.Configuration;
+using Altinn.Notifications.Email.Integrations.Wolverine.Policies;
+
+using Xunit;
+
+namespace Altinn.Notifications.Email.Tests.Email.Integrations.Wolverine;
+
+public class CheckEmailSendStatusHandlerPolicyTests
+{
+    [Fact]
+    public void Apply_WhenNoMatchingChain_ThrowsUnreachableException()
+    {
+        var policy = new CheckEmailSendStatusHandlerPolicy(new WolverineSettings());
+
+        Assert.Throws<UnreachableException>(() => policy.Apply([], null!, null!));
+    }
+}

--- a/components/email-service/test/Altinn.Notifications.Email.Tests/Email.Integrations/Wolverine/SendEmailCommandHandlerPolicyTests.cs
+++ b/components/email-service/test/Altinn.Notifications.Email.Tests/Email.Integrations/Wolverine/SendEmailCommandHandlerPolicyTests.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+
+using Altinn.Notifications.Email.Integrations.Configuration;
+using Altinn.Notifications.Email.Integrations.Wolverine.Policies;
+
+using Xunit;
+
+namespace Altinn.Notifications.Email.Tests.Email.Integrations.Wolverine;
+
+public class SendEmailCommandHandlerPolicyTests
+{
+    [Fact]
+    public void Apply_WhenNoMatchingChain_ThrowsUnreachableException()
+    {
+        var policy = new SendEmailCommandHandlerPolicy(new WolverineSettings());
+
+        Assert.Throws<UnreachableException>(() => policy.Apply([], null!, null!));
+    }
+}

--- a/components/email-service/test/Altinn.Notifications.Email.Tests/Email.Integrations/Wolverine/SendEmailCommandHandlerTests.cs
+++ b/components/email-service/test/Altinn.Notifications.Email.Tests/Email.Integrations/Wolverine/SendEmailCommandHandlerTests.cs
@@ -1,5 +1,5 @@
 ﻿using Altinn.Notifications.Email.Core.Sending;
-using Altinn.Notifications.Email.Integrations.Wolverine;
+using Altinn.Notifications.Email.Integrations.Wolverine.Handlers;
 using Altinn.Notifications.Shared.Commands;
 
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #1365

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated handler error/retry behavior into dedicated policy components, added a status-check listener and corresponding publisher, and gated listeners/publishers behind configuration flags.

* **Tests**
  * Added integration tests for email send and status-check workflows (delivery, retries, DLQ routing) and unit tests for new policy behavior; updated test setup to surface runtime messaging settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->