### PR TITLE
doc ✏️: Add an example value for resourceId 

### DIFF
--- a/components/api/src/Altinn.Notifications/Models/Recipient/RecipientBaseExt.cs
+++ b/components/api/src/Altinn.Notifications/Models/Recipient/RecipientBaseExt.cs
@@ -54,6 +54,7 @@ public abstract class RecipientBaseExt
     /// <summary>
     /// Gets or sets an optional resource identifier for authorization and auditing purposes.
     /// </summary>
+    /// <example>urn:altinn:resource:org_example_app</example>
     [JsonPropertyName("resourceId")]
     public string? ResourceId { get; set; }
 


### PR DESCRIPTION
Changes how `resourceId` is displayed in the OpenAPI request body of **FutureOrders** (`POST /notifications/api/v1/future/orders`):

`"resourceId": "string"` ->  `"resourceId": "urn:altinn:resource:org_example_app"`
The example value also gets prefilled when the user clicks "Try it out"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Related issue: #1466 

## Summary by CodeRabbit

* **Documentation**
  * Updated internal code documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->