### PR TITLE
1439 update k6 tests to use correct instant endpoints

### DIFF
--- a/.github/workflows/regression-test-PROD.yaml
+++ b/.github/workflows/regression-test-PROD.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: components/api/test/k6/src/tests/orders-v2.js
-          flags: -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}} -e subscriptionKey=${{ secrets.AUTOMATEDTEST_APIM_SUBSCRIPTION_KEY}}
+          flags: -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}} -e subscriptionKey=${{ secrets.AUTOMATEDTEST_APIM_SUBSCRIPTION_KEY}}
           inspect-flags: -e altinn_env=Prod # Supplies the value for pre-run validation, when env vars / flags are not yet defined
 
       - name: Run API v2 org lookup regression tests

--- a/.github/workflows/regression-test-TT02.yaml
+++ b/.github/workflows/regression-test-TT02.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: components/api/test/k6/src/tests/orders-v2.js
-          flags: -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}} -e subscriptionKey=${{ secrets.AUTOMATEDTEST_APIM_SUBSCRIPTION_KEY}}
+          flags: -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}} -e subscriptionKey=${{ secrets.AUTOMATEDTEST_APIM_SUBSCRIPTION_KEY}}
           inspect-flags: -e altinn_env=TT02 # Supplies the value for pre-run validation, when env vars / flags are not yet defined
 
       - name: Run API v2 org lookup regression tests

--- a/.github/workflows/use-case-ATX.yaml
+++ b/.github/workflows/use-case-ATX.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: components/api/test/k6/src/tests/orders-v2.js
-          flags: -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}}  -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}} -e subscriptionKey=${{ secrets.AUTOMATEDTEST_APIM_SUBSCRIPTION_KEY}}
+          flags: -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}} -e subscriptionKey=${{ secrets.AUTOMATEDTEST_APIM_SUBSCRIPTION_KEY}}
           inspect-flags: -e altinn_env=${{ matrix.environment }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run API v2 recipientOrganization tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1

--- a/.github/workflows/use-case-ATX.yaml
+++ b/.github/workflows/use-case-ATX.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: components/api/test/k6/src/tests/orders-v2.js
-          flags: -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}} -e subscriptionKey=${{ secrets.AUTOMATEDTEST_APIM_SUBSCRIPTION_KEY}}
+          flags: -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}}  -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}} -e subscriptionKey=${{ secrets.AUTOMATEDTEST_APIM_SUBSCRIPTION_KEY}}
           inspect-flags: -e altinn_env=${{ matrix.environment }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run API v2 recipientOrganization tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1

--- a/.github/workflows/use-case-PROD.yaml
+++ b/.github/workflows/use-case-PROD.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: components/api/test/k6/src/tests/orders-v2.js
-          flags: -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}} -e subscriptionKey=${{ secrets.AUTOMATEDTEST_APIM_SUBSCRIPTION_KEY}}
+          flags: -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}} -e subscriptionKey=${{ secrets.AUTOMATEDTEST_APIM_SUBSCRIPTION_KEY}}
           inspect-flags: -e altinn_env=Prod # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run API v2 recipientOrganization tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1

--- a/.github/workflows/use-case-TT02.yaml
+++ b/.github/workflows/use-case-TT02.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1
         with:
           path: components/api/test/k6/src/tests/orders-v2.js
-          flags: -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}} -e subscriptionKey=${{ secrets.AUTOMATEDTEST_APIM_SUBSCRIPTION_KEY}}
+          flags: -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}} -e subscriptionKey=${{ secrets.AUTOMATEDTEST_APIM_SUBSCRIPTION_KEY}}
           inspect-flags: -e altinn_env=TT02 # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run API v2 recipientOrganization tests
         uses: grafana/run-k6-action@a15e2072ede004e8d46141e33d7f7dad8ad08d9d # v1.3.1

--- a/components/api/test/k6/src/api/notifications/v2.js
+++ b/components/api/test/k6/src/api/notifications/v2.js
@@ -11,22 +11,22 @@ export function postNotificationOrderV2(serializedOrder, token, label) {
   return http.post(endpoint, serializedOrder, params);
 }
 
-export function postSmsInstantNotificationOrderRequest(data, token) {
+export function postSmsInstantNotificationOrderRequest(data, token, label) {
   const endpoint = config.notifications.orders_sms_instant_v2;
 
   const params = apiHelpers.buildHeaderWithBearerAndContentType(token);
-  params.tags = { name: "POST SMS instant notification order request" };
+  params.tags = { name: label };
 
   const smsOrderRequest = data;
 
   return http.post(endpoint, smsOrderRequest, params);
 }
 
-export function postEmailInstantNotificationOrderRequest(data, token) {
+export function postEmailInstantNotificationOrderRequest(data, token, label) {
   const endpoint = config.notifications.orders_email_instant_v2;
 
   const params = apiHelpers.buildHeaderWithBearerAndContentType(token);
-  params.tags = { name: "POST Email instant notification order request" };
+  params.tags = { name: label };
 
   const emailOrderRequest = data;
 

--- a/components/api/test/k6/src/api/notifications/v2.js
+++ b/components/api/test/k6/src/api/notifications/v2.js
@@ -17,9 +17,16 @@ export function postSmsInstantNotificationOrderRequest(data, token, label) {
   const params = apiHelpers.buildHeaderWithBearerAndContentType(token);
   params.tags = { name: label };
 
-  const smsOrderRequest = data;
+  return http.post(endpoint, data, params);
+}
 
-  return http.post(endpoint, smsOrderRequest, params);
+export function postSmsInstantNotificationOrderRequestOld(data, token, label) {
+  const endpoint = config.notifications.orders_sms_instant_old_v2;
+
+  const params = apiHelpers.buildHeaderWithBearerAndContentType(token);
+  params.tags = { name: label };
+
+  return http.post(endpoint, data, params);
 }
 
 export function postEmailInstantNotificationOrderRequest(data, token, label) {
@@ -28,9 +35,7 @@ export function postEmailInstantNotificationOrderRequest(data, token, label) {
   const params = apiHelpers.buildHeaderWithBearerAndContentType(token);
   params.tags = { name: label };
 
-  const emailOrderRequest = data;
-
-  return http.post(endpoint, emailOrderRequest, params);
+  return http.post(endpoint, data, params);
 }
 
 export function getShipment(orderId, token, label) {

--- a/components/api/test/k6/src/api/notifications/v2.js
+++ b/components/api/test/k6/src/api/notifications/v2.js
@@ -22,6 +22,17 @@ export function postSmsInstantNotificationOrderRequest(data, token) {
   return http.post(endpoint, smsOrderRequest, params);
 }
 
+export function postEmailInstantNotificationOrderRequest(data, token) {
+  const endpoint = config.notifications.orders_email_instant_v2;
+
+  const params = apiHelpers.buildHeaderWithBearerAndContentType(token);
+  params.tags = { name: "POST Email instant notification order request" };
+
+  const emailOrderRequest = data;
+
+  return http.post(endpoint, emailOrderRequest, params);
+}
+
 export function getShipment(orderId, token, label) {
   const params = apiHelpers.buildHeaderWithBearer(token);
   params.tags = { name: label };

--- a/components/api/test/k6/src/config.js
+++ b/components/api/test/k6/src/config.js
@@ -3,30 +3,27 @@ import { environment } from "./shared/variables.js";
 
 // Base URLs for the Altinn platform across different environments.
 const baseUrls = {
-  prod: "altinn.no",
-  tt02: "tt02.altinn.no",
-  yt01: "yt01.altinn.cloud",
-  at22: "at22.altinn.cloud",
-  at23: "at23.altinn.cloud",
-  at24: "at24.altinn.cloud",
+    prod: "altinn.no",
+    tt02: "tt02.altinn.no",
+    yt01: "yt01.altinn.cloud",
+    at22: "at22.altinn.cloud",
+    at23: "at23.altinn.cloud",
+    at24: "at24.altinn.cloud"
 };
 
 // Base URLs for Maskinporten authentication service in different environments.
 const maskinportenBaseUrls = {
-  prod: "https://maskinporten.no/",
-  tt02: "https://test.maskinporten.no/",
+    prod: "https://maskinporten.no/",
+    tt02: "https://test.maskinporten.no/"
 };
 
 if (!environment) {
-  stopIterationOnFail("Environment variable 'altinn_env' is not set", false);
+    stopIterationOnFail("Environment variable 'altinn_env' is not set", false);
 }
 
 const baseUrl = baseUrls[environment];
 if (!baseUrl) {
-  stopIterationOnFail(
-    `Invalid value for environment variable 'altinn_env': '${environment}'.`,
-    false,
-  );
+    stopIterationOnFail(`Invalid value for environment variable 'altinn_env': '${environment}'.`, false);
 }
 
 const subscriptionKey = __ENV.subscriptionKey;
@@ -34,49 +31,41 @@ const maskinportenBaseUrl = maskinportenBaseUrls[environment];
 
 // Altinn TestTools token generator URL.
 export const tokenGenerator = {
-  getEnterpriseToken:
-    "https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken",
+    getEnterpriseToken:
+        "https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken"
 };
 
 // Endpoints for interacting with the Altinn Notifications API in different environments.
 export const notifications = {
-  orders_sms: `https://platform.${baseUrl}/notifications/api/v1/orders/sms/`,
+    orders_sms: `https://platform.${baseUrl}/notifications/api/v1/orders/sms/`,
 
-  orders_email: `https://platform.${baseUrl}/notifications/api/v1/orders/email/`,
+    orders_email: `https://platform.${baseUrl}/notifications/api/v1/orders/email/`,
 
-  orders_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/`,
+    orders_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/`,
 
-  orders_sms_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/sms`,
-  orders_email_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/email`,
+    orders_sms_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/sms`,
+    orders_email_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/email`,
 
-  shipment_v2: (orderId) =>
-    `https://platform.${baseUrl}/notifications/api/v1/future/shipment/${orderId}`,
+    shipment_v2: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/future/shipment/${orderId}`,
 
-  statusfeed_v2: (sequenceNumber) =>
-    `https://platform.${baseUrl}/notifications/api/v1/future/shipment/feed?seq=${sequenceNumber}`,
+    statusfeed_v2: (sequenceNumber) => `https://platform.${baseUrl}/notifications/api/v1/future/shipment/feed?seq=${sequenceNumber}`,
 
-  orders_fromId: (orderId) =>
-    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}`,
+    orders_fromId: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}`,
 
-  orders_status: (orderId) =>
-    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/status`,
+    orders_status: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/status`,
 
-  notifications_sms: (orderId) =>
-    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/sms/`,
+    notifications_sms: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/sms/`,
 
-  notifications_email: (orderId) =>
-    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/email/`,
+    notifications_email: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/email/`,
 
-  orders_fromSendersRef: (sendersReference) =>
-    `https://platform.${baseUrl}/notifications/api/v1/orders?sendersReference=${sendersReference}`,
+    orders_fromSendersRef: (sendersReference) => `https://platform.${baseUrl}/notifications/api/v1/orders?sendersReference=${sendersReference}`,
 
-  conditionCheck: (conditionMet) =>
-    `https://platform.${baseUrl}/notifications/api/v1/tests/sendcondition?conditionMet=${conditionMet}&subscription-key=${subscriptionKey}`,
+    conditionCheck: (conditionMet) => `https://platform.${baseUrl}/notifications/api/v1/tests/sendcondition?conditionMet=${conditionMet}&subscription-key=${subscriptionKey}`
 };
 
 // Provides endpoints for handling authentication work-flows on the Altinn platform.
 export const platformAuthentication = {
-  exchange: `https://platform.${baseUrl}/authentication/api/v1/exchange/maskinporten`,
+    exchange: `https://platform.${baseUrl}/authentication/api/v1/exchange/maskinporten`,
 };
 
 /**
@@ -84,6 +73,6 @@ export const platformAuthentication = {
  * Contains endpoints and audience values related to the Maskinporten authentication service.
  */
 export const maskinporten = {
-  audience: maskinportenBaseUrl,
-  token: `${maskinportenBaseUrl}token`,
+    audience: maskinportenBaseUrl,
+    token: `${maskinportenBaseUrl}token`
 };

--- a/components/api/test/k6/src/config.js
+++ b/components/api/test/k6/src/config.js
@@ -3,27 +3,30 @@ import { environment } from "./shared/variables.js";
 
 // Base URLs for the Altinn platform across different environments.
 const baseUrls = {
-    prod: "altinn.no",
-    tt02: "tt02.altinn.no",
-    yt01: "yt01.altinn.cloud",
-    at22: "at22.altinn.cloud",
-    at23: "at23.altinn.cloud",
-    at24: "at24.altinn.cloud"
+  prod: "altinn.no",
+  tt02: "tt02.altinn.no",
+  yt01: "yt01.altinn.cloud",
+  at22: "at22.altinn.cloud",
+  at23: "at23.altinn.cloud",
+  at24: "at24.altinn.cloud",
 };
 
 // Base URLs for Maskinporten authentication service in different environments.
 const maskinportenBaseUrls = {
-    prod: "https://maskinporten.no/",
-    tt02: "https://test.maskinporten.no/"
+  prod: "https://maskinporten.no/",
+  tt02: "https://test.maskinporten.no/",
 };
 
 if (!environment) {
-    stopIterationOnFail("Environment variable 'altinn_env' is not set", false);
+  stopIterationOnFail("Environment variable 'altinn_env' is not set", false);
 }
 
 const baseUrl = baseUrls[environment];
 if (!baseUrl) {
-    stopIterationOnFail(`Invalid value for environment variable 'altinn_env': '${environment}'.`, false);
+  stopIterationOnFail(
+    `Invalid value for environment variable 'altinn_env': '${environment}'.`,
+    false,
+  );
 }
 
 const subscriptionKey = __ENV.subscriptionKey;
@@ -31,40 +34,49 @@ const maskinportenBaseUrl = maskinportenBaseUrls[environment];
 
 // Altinn TestTools token generator URL.
 export const tokenGenerator = {
-    getEnterpriseToken:
-        "https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken"
+  getEnterpriseToken:
+    "https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken",
 };
 
 // Endpoints for interacting with the Altinn Notifications API in different environments.
 export const notifications = {
-    orders_sms: `https://platform.${baseUrl}/notifications/api/v1/orders/sms/`,
+  orders_sms: `https://platform.${baseUrl}/notifications/api/v1/orders/sms/`,
 
-    orders_email: `https://platform.${baseUrl}/notifications/api/v1/orders/email/`,
+  orders_email: `https://platform.${baseUrl}/notifications/api/v1/orders/email/`,
 
-    orders_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/`,
+  orders_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/`,
 
-    orders_sms_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant`,
+  orders_sms_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/sms`,
+  orders_email_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/email`,
 
-    shipment_v2: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/future/shipment/${orderId}`,
+  shipment_v2: (orderId) =>
+    `https://platform.${baseUrl}/notifications/api/v1/future/shipment/${orderId}`,
 
-    statusfeed_v2: (sequenceNumber) => `https://platform.${baseUrl}/notifications/api/v1/future/shipment/feed?seq=${sequenceNumber}`,
+  statusfeed_v2: (sequenceNumber) =>
+    `https://platform.${baseUrl}/notifications/api/v1/future/shipment/feed?seq=${sequenceNumber}`,
 
-    orders_fromId: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}`,
+  orders_fromId: (orderId) =>
+    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}`,
 
-    orders_status: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/status`,
+  orders_status: (orderId) =>
+    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/status`,
 
-    notifications_sms: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/sms/`,
+  notifications_sms: (orderId) =>
+    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/sms/`,
 
-    notifications_email: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/email/`,
+  notifications_email: (orderId) =>
+    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/email/`,
 
-    orders_fromSendersRef: (sendersReference) => `https://platform.${baseUrl}/notifications/api/v1/orders?sendersReference=${sendersReference}`,
+  orders_fromSendersRef: (sendersReference) =>
+    `https://platform.${baseUrl}/notifications/api/v1/orders?sendersReference=${sendersReference}`,
 
-    conditionCheck: (conditionMet) => `https://platform.${baseUrl}/notifications/api/v1/tests/sendcondition?conditionMet=${conditionMet}&subscription-key=${subscriptionKey}`
+  conditionCheck: (conditionMet) =>
+    `https://platform.${baseUrl}/notifications/api/v1/tests/sendcondition?conditionMet=${conditionMet}&subscription-key=${subscriptionKey}`,
 };
 
 // Provides endpoints for handling authentication work-flows on the Altinn platform.
 export const platformAuthentication = {
-    exchange: `https://platform.${baseUrl}/authentication/api/v1/exchange/maskinporten`,
+  exchange: `https://platform.${baseUrl}/authentication/api/v1/exchange/maskinporten`,
 };
 
 /**
@@ -72,6 +84,6 @@ export const platformAuthentication = {
  * Contains endpoints and audience values related to the Maskinporten authentication service.
  */
 export const maskinporten = {
-    audience: maskinportenBaseUrl,
-    token: `${maskinportenBaseUrl}token`
+  audience: maskinportenBaseUrl,
+  token: `${maskinportenBaseUrl}token`,
 };

--- a/components/api/test/k6/src/config.js
+++ b/components/api/test/k6/src/config.js
@@ -3,30 +3,27 @@ import { environment } from "./shared/variables.js";
 
 // Base URLs for the Altinn platform across different environments.
 const baseUrls = {
-  prod: "altinn.no",
-  tt02: "tt02.altinn.no",
-  yt01: "yt01.altinn.cloud",
-  at22: "at22.altinn.cloud",
-  at23: "at23.altinn.cloud",
-  at24: "at24.altinn.cloud",
+    prod: "altinn.no",
+    tt02: "tt02.altinn.no",
+    yt01: "yt01.altinn.cloud",
+    at22: "at22.altinn.cloud",
+    at23: "at23.altinn.cloud",
+    at24: "at24.altinn.cloud"
 };
 
 // Base URLs for Maskinporten authentication service in different environments.
 const maskinportenBaseUrls = {
-  prod: "https://maskinporten.no/",
-  tt02: "https://test.maskinporten.no/",
+    prod: "https://maskinporten.no/",
+    tt02: "https://test.maskinporten.no/"
 };
 
 if (!environment) {
-  stopIterationOnFail("Environment variable 'altinn_env' is not set", false);
+    stopIterationOnFail("Environment variable 'altinn_env' is not set", false);
 }
 
 const baseUrl = baseUrls[environment];
 if (!baseUrl) {
-  stopIterationOnFail(
-    `Invalid value for environment variable 'altinn_env': '${environment}'.`,
-    false,
-  );
+    stopIterationOnFail(`Invalid value for environment variable 'altinn_env': '${environment}'.`, false);
 }
 
 const subscriptionKey = __ENV.subscriptionKey;
@@ -34,50 +31,42 @@ const maskinportenBaseUrl = maskinportenBaseUrls[environment];
 
 // Altinn TestTools token generator URL.
 export const tokenGenerator = {
-  getEnterpriseToken:
-    "https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken",
+    getEnterpriseToken:
+        "https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken"
 };
 
 // Endpoints for interacting with the Altinn Notifications API in different environments.
 export const notifications = {
-  orders_sms: `https://platform.${baseUrl}/notifications/api/v1/orders/sms/`,
+    orders_sms: `https://platform.${baseUrl}/notifications/api/v1/orders/sms/`,
 
-  orders_email: `https://platform.${baseUrl}/notifications/api/v1/orders/email/`,
+    orders_email: `https://platform.${baseUrl}/notifications/api/v1/orders/email/`,
 
-  orders_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/`,
+    orders_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/`,
 
-  orders_sms_instant_old_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant`,
-  orders_sms_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/sms`,
-  orders_email_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/email`,
+    orders_sms_instant_old_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant`,
+    orders_sms_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/sms`,
+    orders_email_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/email`,
 
-  shipment_v2: (orderId) =>
-    `https://platform.${baseUrl}/notifications/api/v1/future/shipment/${orderId}`,
+    shipment_v2: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/future/shipment/${orderId}`,
 
-  statusfeed_v2: (sequenceNumber) =>
-    `https://platform.${baseUrl}/notifications/api/v1/future/shipment/feed?seq=${sequenceNumber}`,
+    statusfeed_v2: (sequenceNumber) => `https://platform.${baseUrl}/notifications/api/v1/future/shipment/feed?seq=${sequenceNumber}`,
 
-  orders_fromId: (orderId) =>
-    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}`,
+    orders_fromId: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}`,
 
-  orders_status: (orderId) =>
-    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/status`,
+    orders_status: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/status`,
 
-  notifications_sms: (orderId) =>
-    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/sms/`,
+    notifications_sms: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/sms/`,
 
-  notifications_email: (orderId) =>
-    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/email/`,
+    notifications_email: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/email/`,
 
-  orders_fromSendersRef: (sendersReference) =>
-    `https://platform.${baseUrl}/notifications/api/v1/orders?sendersReference=${sendersReference}`,
+    orders_fromSendersRef: (sendersReference) => `https://platform.${baseUrl}/notifications/api/v1/orders?sendersReference=${sendersReference}`,
 
-  conditionCheck: (conditionMet) =>
-    `https://platform.${baseUrl}/notifications/api/v1/tests/sendcondition?conditionMet=${conditionMet}&subscription-key=${subscriptionKey}`,
+    conditionCheck: (conditionMet) => `https://platform.${baseUrl}/notifications/api/v1/tests/sendcondition?conditionMet=${conditionMet}&subscription-key=${subscriptionKey}`
 };
 
 // Provides endpoints for handling authentication work-flows on the Altinn platform.
 export const platformAuthentication = {
-  exchange: `https://platform.${baseUrl}/authentication/api/v1/exchange/maskinporten`,
+    exchange: `https://platform.${baseUrl}/authentication/api/v1/exchange/maskinporten`,
 };
 
 /**
@@ -85,6 +74,6 @@ export const platformAuthentication = {
  * Contains endpoints and audience values related to the Maskinporten authentication service.
  */
 export const maskinporten = {
-  audience: maskinportenBaseUrl,
-  token: `${maskinportenBaseUrl}token`,
+    audience: maskinportenBaseUrl,
+    token: `${maskinportenBaseUrl}token`
 };

--- a/components/api/test/k6/src/config.js
+++ b/components/api/test/k6/src/config.js
@@ -3,27 +3,30 @@ import { environment } from "./shared/variables.js";
 
 // Base URLs for the Altinn platform across different environments.
 const baseUrls = {
-    prod: "altinn.no",
-    tt02: "tt02.altinn.no",
-    yt01: "yt01.altinn.cloud",
-    at22: "at22.altinn.cloud",
-    at23: "at23.altinn.cloud",
-    at24: "at24.altinn.cloud"
+  prod: "altinn.no",
+  tt02: "tt02.altinn.no",
+  yt01: "yt01.altinn.cloud",
+  at22: "at22.altinn.cloud",
+  at23: "at23.altinn.cloud",
+  at24: "at24.altinn.cloud",
 };
 
 // Base URLs for Maskinporten authentication service in different environments.
 const maskinportenBaseUrls = {
-    prod: "https://maskinporten.no/",
-    tt02: "https://test.maskinporten.no/"
+  prod: "https://maskinporten.no/",
+  tt02: "https://test.maskinporten.no/",
 };
 
 if (!environment) {
-    stopIterationOnFail("Environment variable 'altinn_env' is not set", false);
+  stopIterationOnFail("Environment variable 'altinn_env' is not set", false);
 }
 
 const baseUrl = baseUrls[environment];
 if (!baseUrl) {
-    stopIterationOnFail(`Invalid value for environment variable 'altinn_env': '${environment}'.`, false);
+  stopIterationOnFail(
+    `Invalid value for environment variable 'altinn_env': '${environment}'.`,
+    false,
+  );
 }
 
 const subscriptionKey = __ENV.subscriptionKey;
@@ -31,41 +34,50 @@ const maskinportenBaseUrl = maskinportenBaseUrls[environment];
 
 // Altinn TestTools token generator URL.
 export const tokenGenerator = {
-    getEnterpriseToken:
-        "https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken"
+  getEnterpriseToken:
+    "https://altinn-testtools-token-generator.azurewebsites.net/api/GetEnterpriseToken",
 };
 
 // Endpoints for interacting with the Altinn Notifications API in different environments.
 export const notifications = {
-    orders_sms: `https://platform.${baseUrl}/notifications/api/v1/orders/sms/`,
+  orders_sms: `https://platform.${baseUrl}/notifications/api/v1/orders/sms/`,
 
-    orders_email: `https://platform.${baseUrl}/notifications/api/v1/orders/email/`,
+  orders_email: `https://platform.${baseUrl}/notifications/api/v1/orders/email/`,
 
-    orders_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/`,
+  orders_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/`,
 
-    orders_sms_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/sms`,
-    orders_email_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/email`,
+  orders_sms_instant_old_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant`,
+  orders_sms_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/sms`,
+  orders_email_instant_v2: `https://platform.${baseUrl}/notifications/api/v1/future/orders/instant/email`,
 
-    shipment_v2: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/future/shipment/${orderId}`,
+  shipment_v2: (orderId) =>
+    `https://platform.${baseUrl}/notifications/api/v1/future/shipment/${orderId}`,
 
-    statusfeed_v2: (sequenceNumber) => `https://platform.${baseUrl}/notifications/api/v1/future/shipment/feed?seq=${sequenceNumber}`,
+  statusfeed_v2: (sequenceNumber) =>
+    `https://platform.${baseUrl}/notifications/api/v1/future/shipment/feed?seq=${sequenceNumber}`,
 
-    orders_fromId: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}`,
+  orders_fromId: (orderId) =>
+    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}`,
 
-    orders_status: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/status`,
+  orders_status: (orderId) =>
+    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/status`,
 
-    notifications_sms: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/sms/`,
+  notifications_sms: (orderId) =>
+    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/sms/`,
 
-    notifications_email: (orderId) => `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/email/`,
+  notifications_email: (orderId) =>
+    `https://platform.${baseUrl}/notifications/api/v1/orders/${orderId}/notifications/email/`,
 
-    orders_fromSendersRef: (sendersReference) => `https://platform.${baseUrl}/notifications/api/v1/orders?sendersReference=${sendersReference}`,
+  orders_fromSendersRef: (sendersReference) =>
+    `https://platform.${baseUrl}/notifications/api/v1/orders?sendersReference=${sendersReference}`,
 
-    conditionCheck: (conditionMet) => `https://platform.${baseUrl}/notifications/api/v1/tests/sendcondition?conditionMet=${conditionMet}&subscription-key=${subscriptionKey}`
+  conditionCheck: (conditionMet) =>
+    `https://platform.${baseUrl}/notifications/api/v1/tests/sendcondition?conditionMet=${conditionMet}&subscription-key=${subscriptionKey}`,
 };
 
 // Provides endpoints for handling authentication work-flows on the Altinn platform.
 export const platformAuthentication = {
-    exchange: `https://platform.${baseUrl}/authentication/api/v1/exchange/maskinporten`,
+  exchange: `https://platform.${baseUrl}/authentication/api/v1/exchange/maskinporten`,
 };
 
 /**
@@ -73,6 +85,6 @@ export const platformAuthentication = {
  * Contains endpoints and audience values related to the Maskinporten authentication service.
  */
 export const maskinporten = {
-    audience: maskinportenBaseUrl,
-    token: `${maskinportenBaseUrl}token`
+  audience: maskinportenBaseUrl,
+  token: `${maskinportenBaseUrl}token`,
 };

--- a/components/api/test/k6/src/data/orders/order-v2-email-instant.json
+++ b/components/api/test/k6/src/data/orders/order-v2-email-instant.json
@@ -1,0 +1,13 @@
+{
+  "idempotencyId": "string",
+  "sendersReference": "string",
+  "recipientEmail": {
+    "emailAddress": "string",
+    "emailSettings": {
+      "subject": "string",
+      "body": "This is a plain test body for testing Email instant services",
+      "senderEmailAddress": "string",
+      "contentType": "Plain"
+    }
+  }
+}

--- a/components/api/test/k6/src/data/orders/order-v2-email-instant.json
+++ b/components/api/test/k6/src/data/orders/order-v2-email-instant.json
@@ -6,7 +6,6 @@
     "emailSettings": {
       "subject": "Automated instant email test from Altinn",
       "body": "This is a plain test body for testing Email instant services",
-      "senderEmailAddress": "noreply@altinn.no",
       "contentType": "Plain"
     }
   }

--- a/components/api/test/k6/src/data/orders/order-v2-email-instant.json
+++ b/components/api/test/k6/src/data/orders/order-v2-email-instant.json
@@ -4,9 +4,9 @@
   "recipientEmail": {
     "emailAddress": "string",
     "emailSettings": {
-      "subject": "string",
+      "subject": "Automated instant email test from Altinn",
       "body": "This is a plain test body for testing Email instant services",
-      "senderEmailAddress": "string",
+      "senderEmailAddress": "noreply@altinn.no",
       "contentType": "Plain"
     }
   }

--- a/components/api/test/k6/src/data/orders/order-v2-sms-instant-old.json
+++ b/components/api/test/k6/src/data/orders/order-v2-sms-instant-old.json
@@ -1,0 +1,14 @@
+{
+  "idempotencyId": "string",
+  "sendersReference": "string",
+  "recipient": {
+    "recipientSms": {
+      "phoneNumber": "string",
+      "timeToLiveInSeconds": 60,
+      "smsSettings": {
+        "sender": "Altinn-test",
+        "body": "This is a plain test body for testing old SMS instant services"
+      }
+    }
+  }
+}

--- a/components/api/test/k6/src/data/orders/order-v2-sms-instant.json
+++ b/components/api/test/k6/src/data/orders/order-v2-sms-instant.json
@@ -1,14 +1,12 @@
 {
   "idempotencyId": "string",
   "sendersReference": "string",
-  "recipient": {
-    "recipientSms": {
-      "phoneNumber": "string",
-      "timeToLiveInSeconds": 60,
-      "smsSettings": {
-        "sender": "Altinn-test",
-        "body": "This is a plain test body for testing SMS instant services"
-      }
+  "recipientSms": {
+    "phoneNumber": "string",
+    "timeToLiveInSeconds": 60,
+    "smsSettings": {
+      "sender": "Altinn-test",
+      "body": "This is a plain test body for testing SMS instant services"
     }
   }
 }

--- a/components/api/test/k6/src/tests/orders-v2.js
+++ b/components/api/test/k6/src/tests/orders-v2.js
@@ -30,139 +30,106 @@ import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import * as setupToken from "../setup.js";
 import * as futureOrdersApi from "../api/notifications/v2.js";
 import {
-  post_sms_order_v2,
-  post_sms_instant_order_v2,
-  post_email_order_v2,
-  setEmptyThresholds,
-  get_email_shipment,
-  get_sms_shipment,
-  get_sms_instant_shipment,
-  get_email_instant_shipment,
-  get_status_feed,
-  post_email_instant_order_v2,
+    post_sms_order_v2, post_sms_instant_order_v2, post_email_order_v2,
+    setEmptyThresholds, get_email_shipment, get_sms_shipment,
+    get_sms_instant_shipment, get_email_instant_shipment, get_status_feed,
+    post_email_instant_order_v2
 } from "./threshold-labels.js";
 import { scopes } from "../shared/variables.js";
 import { getEmailRecipient, getSmsRecipient } from "../shared/functions.js";
 
-const labels = [
-  post_email_order_v2,
-  post_sms_order_v2,
-  post_sms_instant_order_v2,
-  post_email_instant_order_v2,
-  get_email_shipment,
-  get_sms_shipment,
-  get_status_feed,
-];
+const labels = [post_email_order_v2, post_sms_order_v2, post_sms_instant_order_v2, post_email_instant_order_v2, get_email_shipment, get_sms_shipment, get_status_feed];
 
 const emailOrderRequestJson = JSON.parse(
-  open("../data/orders/order-v2-email.json"),
+    open("../data/orders/order-v2-email.json")
 );
 const smsOrderRequestJson = JSON.parse(
-  open("../data/orders/order-v2-sms.json"),
+    open("../data/orders/order-v2-sms.json")
 );
 const smsOrderInstantRequestJson = JSON.parse(
-  open("../data/orders/order-v2-sms-instant.json"),
+    open("../data/orders/order-v2-sms-instant.json")
 );
 const emailOrderInstantRequestJson = JSON.parse(
-  open("../data/orders/order-v2-email-instant.json"),
+    open("../data/orders/order-v2-email-instant.json")
 );
 
 export const options = {
-  summaryTrendStats: [
-    "avg",
-    "min",
-    "med",
-    "max",
-    "p(95)",
-    "p(99)",
-    "p(99.5)",
-    "p(99.9)",
-    "count",
-  ],
-  thresholds: {
-    // Checks rate should be 100%. Raise error if any check has failed.
-    checks: ["rate>=1"],
-  },
+    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(95)', 'p(99)', 'p(99.5)', 'p(99.9)', 'count'],
+    thresholds: {
+        // Checks rate should be 100%. Raise error if any check has failed.
+        checks: ['rate>=1']
+    }
 };
 setEmptyThresholds(labels, options);
 
 /**
  * Initialize test data.
  * @returns {Object} The data object containing token, sendersReference, and emailOrderRequest.
- */
+*/
 export function setup() {
-  const emailRecipient = getEmailRecipient();
-  const smsRecipient = getSmsRecipient();
+    const emailRecipient = getEmailRecipient();
+    const smsRecipient = getSmsRecipient();
 
-  // used with notification email orders if applicable
-  const ninRecipient = __ENV.ninRecipient
-    ? __ENV.ninRecipient.toLowerCase()
-    : null;
+    // used with notification email orders if applicable
+    const ninRecipient = __ENV.ninRecipient ? __ENV.ninRecipient.toLowerCase() : null;
 
-  const token = setupToken.getAltinnTokenForOrg(scopes);
-  const idempotencyIdEmail = uuidv4();
-  const idempotencyIdSms = uuidv4();
-  const sendersReference = uuidv4();
+    const token = setupToken.getAltinnTokenForOrg(scopes);
+    const idempotencyIdEmail = uuidv4();
+    const idempotencyIdSms = uuidv4();
+    const sendersReference = uuidv4();
 
-  if (emailRecipient == null) {
-    // unset recipientEmail object when no email recipient is provided
-    emailOrderRequestJson.recipient["recipientEmail"] = undefined;
-  } else {
-    emailOrderRequestJson.recipient.recipientEmail.emailAddress =
-      emailRecipient;
-  }
+    if (emailRecipient == null) {
+        // unset recipientEmail object when no email recipient is provided
+        emailOrderRequestJson.recipient["recipientEmail"] = undefined;
+    }
+    else {
+        emailOrderRequestJson.recipient.recipientEmail.emailAddress = emailRecipient;
+    }
 
-  if (ninRecipient == null) {
-    // unset recipientPerson object when no national identity number is provided
-    emailOrderRequestJson.recipient["recipientPerson"] = undefined;
-  } else {
-    emailOrderRequestJson.recipient.recipientPerson.nationalIdentityNumber =
-      ninRecipient;
-  }
+    if (ninRecipient == null) {
+        // unset recipientPerson object when no national identity number is provided
+        emailOrderRequestJson.recipient["recipientPerson"] = undefined;
+    }
+    else {
+        emailOrderRequestJson.recipient.recipientPerson.nationalIdentityNumber = ninRecipient;
+    }
 
-  if (smsRecipient != null) {
-    smsOrderRequestJson.recipient.recipientSms.phoneNumber = smsRecipient;
-  }
+    if (smsRecipient != null) {
+        smsOrderRequestJson.recipient.recipientSms.phoneNumber = smsRecipient;
+    }
 
-  const emailOrderRequest = {
-    ...emailOrderRequestJson,
-    idempotencyId: idempotencyIdEmail,
-  };
+    const emailOrderRequest = { ...emailOrderRequestJson, idempotencyId: idempotencyIdEmail };
 
-  const smsOrderRequest = {
-    ...smsOrderRequestJson,
-    idempotencyId: idempotencyIdSms,
-    sendersReference,
-  };
+    const smsOrderRequest = { ...smsOrderRequestJson, idempotencyId: idempotencyIdSms, sendersReference };
 
-  const smsOrderInstantRequest = {
-    ...smsOrderInstantRequestJson,
-    idempotencyId: uuidv4(),
-    sendersReference,
-    recipientSms: {
-      ...smsOrderInstantRequestJson.recipientSms,
-      phoneNumber: smsRecipient,
-    },
-  };
+    const smsOrderInstantRequest = {
+        ...smsOrderInstantRequestJson,
+        idempotencyId: uuidv4(),
+        sendersReference,
+        recipientSms: {
+            ...smsOrderInstantRequestJson.recipientSms,
+            phoneNumber: smsRecipient
+        }
+    };
 
-  const emailOrderInstantRequest = {
-    ...emailOrderInstantRequestJson,
-    idempotencyId: uuidv4(),
-    sendersReference,
-    recipientEmail: {
-      ...emailOrderInstantRequestJson.recipientEmail,
-      emailAddress: emailRecipient,
-    },
-  };
+    const emailOrderInstantRequest = {
+        ...emailOrderInstantRequestJson,
+        idempotencyId: uuidv4(),
+        sendersReference,
+        recipientEmail: {
+            ...emailOrderInstantRequestJson.recipientEmail,
+            emailAddress: emailRecipient
+        }
+    };
 
-  return {
-    token,
-    sendersReference,
-    emailOrderRequest,
-    smsOrderRequest,
-    smsOrderInstantRequest,
-    emailOrderInstantRequest,
-  };
+    return {
+        token,
+        sendersReference,
+        emailOrderRequest,
+        smsOrderRequest,
+        smsOrderInstantRequest,
+        emailOrderInstantRequest
+    };
 }
 
 /**
@@ -171,27 +138,25 @@ export function setup() {
  * @returns {string} The response body of the created order.
  */
 function postEmailNotificationOrderRequest(data) {
-  const response = futureOrdersApi.postNotificationOrderV2(
-    JSON.stringify(data.emailOrderRequest),
-    data.token,
-    post_email_order_v2,
-  );
+    const response = futureOrdersApi.postNotificationOrderV2(
+        JSON.stringify(data.emailOrderRequest),
+        data.token,
+        post_email_order_v2
+    );
 
-  const success = check(response, {
-    "POST email notification order request. Status is 201 Created": (r) =>
-      r.status === 201,
-  });
+    const success = check(response, {
+        "POST email notification order request. Status is 201 Created": (r) => r.status === 201
+    });
 
-  stopIterationOnFail("POST email notification order request failed", success);
+    stopIterationOnFail("POST email notification order request failed", success);
 
-  const selfLink = response.headers["Location"];
+    const selfLink = response.headers["Location"];
 
-  check(response, {
-    "POST email notification order request. Location header provided": (_) =>
-      selfLink,
-  });
+    check(response, {
+        "POST email notification order request. Location header provided": (_) => selfLink,
+    });
 
-  return response.body;
+    return response.body;
 }
 
 /**
@@ -200,30 +165,28 @@ function postEmailNotificationOrderRequest(data) {
  * @returns {string} The response body of the created order.
  */
 function postSmsNotificationOrderRequest(data) {
-  const response = futureOrdersApi.postNotificationOrderV2(
-    JSON.stringify(data.smsOrderRequest),
-    data.token,
-    post_sms_order_v2,
-  );
+    const response = futureOrdersApi.postNotificationOrderV2(
+        JSON.stringify(data.smsOrderRequest),
+        data.token,
+        post_sms_order_v2
+    );
 
-  const success = check(response, {
-    "POST SMS notification order request. Status is 201 Created": (r) =>
-      r.status === 201,
-  });
+    const success = check(response, {
+        "POST SMS notification order request. Status is 201 Created": (r) => r.status === 201
+    });
 
-  stopIterationOnFail("POST SMS notification order request failed", success);
+    stopIterationOnFail("POST SMS notification order request failed", success);
 
-  const selfLink = response.headers["Location"];
+    const selfLink = response.headers["Location"];
 
-  check(response, {
-    "POST SMS notification order request. Location header provided": (_) =>
-      selfLink,
-    "POST SMS notification order request. Response body is not an empty string":
-      (r) => r.body,
-  });
+    check(response, {
+        "POST SMS notification order request. Location header provided": (_) => selfLink,
+        "POST SMS notification order request. Response body is not an empty string": (r) => r.body
+    });
 
-  return response.body;
+    return response.body;
 }
+
 
 /**
  * Post instant SMS notification order request using the v2 API.
@@ -231,26 +194,22 @@ function postSmsNotificationOrderRequest(data) {
  * @returns
  */
 function postSmsInstantNotificationOrderRequest(data) {
-  const response = futureOrdersApi.postSmsInstantNotificationOrderRequest(
-    JSON.stringify(data.smsOrderInstantRequest),
-    data.token,
-    post_sms_instant_order_v2,
-  );
+    const response = futureOrdersApi.postSmsInstantNotificationOrderRequest(
+        JSON.stringify(data.smsOrderInstantRequest),
+        data.token,
+        post_sms_instant_order_v2
+    );
 
-  const success = check(response, {
-    "POST SMS instant notification order request. Status is 201 Created": (r) =>
-      r.status === 201,
-    "POST SMS instant notification order request. Response body contains shipmentId":
-      (r) => JSON.parse(r.body).notification.shipmentId !== undefined,
-  });
+    const success = check(response, {
+        "POST SMS instant notification order request. Status is 201 Created": (r) => r.status === 201,
+        "POST SMS instant notification order request. Response body contains shipmentId": (r) => JSON.parse(r.body).notification.shipmentId !== undefined
+    });
 
-  stopIterationOnFail(
-    "POST SMS instant notification order request failed",
-    success,
-  );
+    stopIterationOnFail("POST SMS instant notification order request failed", success);
 
-  return response.body;
+    return response.body;
 }
+
 
 /**
  * Post instant Email notification order request using the v2 API.
@@ -258,27 +217,22 @@ function postSmsInstantNotificationOrderRequest(data) {
  * @returns
  */
 function postEmailInstantNotificationOrderRequest(data) {
-  const response = futureOrdersApi.postEmailInstantNotificationOrderRequest(
-    JSON.stringify(data.emailOrderInstantRequest),
-    data.token,
-    post_email_instant_order_v2,
-  );
+    const response = futureOrdersApi.postEmailInstantNotificationOrderRequest(
+        JSON.stringify(data.emailOrderInstantRequest),
+        data.token,
+        post_email_instant_order_v2
+    );
 
-  const success = check(response, {
-    "POST Email instant notification order request. Status is 201 Created": (
-      r,
-    ) => r.status === 201,
-    "POST Email instant notification order request. Response body contains shipmentId":
-      (r) => JSON.parse(r.body).notification.shipmentId !== undefined,
-  });
+    const success = check(response, {
+        "POST Email instant notification order request. Status is 201 Created": (r) => r.status === 201,
+        "POST Email instant notification order request. Response body contains shipmentId": (r) => JSON.parse(r.body).notification.shipmentId !== undefined
+    });
 
-  stopIterationOnFail(
-    "POST Email instant notification order request failed",
-    success,
-  );
+    stopIterationOnFail("POST Email instant notification order request failed", success);
 
-  return response.body;
+    return response.body;
 }
+
 
 /**
  * Gets the notification shipment status for email or SMS.
@@ -288,60 +242,46 @@ function postEmailInstantNotificationOrderRequest(data) {
  * @param {string} type - The type of notification (e.g., "Email" or "SMS").
  */
 export function getShipmentStatus(data, shipmentId, label, type) {
-  const response = futureOrdersApi.getShipment(shipmentId, data.token, label);
+    const response = futureOrdersApi.getShipment(shipmentId, data.token, label);
 
-  switch (type) {
-    case "Email":
-      check(response, {
-        "GET shipment details for Email. Status is 200 OK": (r) =>
-          r.status === 200,
-      });
-      check(JSON.parse(response.body), {
-        "GET shipment details for Email. ShipmentId property is a match": (
-          shipmentResponse,
-        ) => shipmentResponse.shipmentId === shipmentId,
-      });
-      break;
-    case "SMS":
-      check(response, {
-        "GET SMS shipment details for SMS. Status is 200 OK": (r) =>
-          r.status === 200,
-      });
-      check(JSON.parse(response.body), {
-        "GET SMS shipment details for SMS. ShipmentId property is a match": (
-          shipmentResponse,
-        ) => shipmentResponse.shipmentId === shipmentId,
-      });
-      break;
-    case "SMSInstant":
-      check(response, {
-        "GET SMS instant shipment details for SMS. Status is 200 OK": (r) =>
-          r.status === 200,
-      });
-      check(JSON.parse(response.body), {
-        "GET SMS instant shipment details for SMS. ShipmentId property is a match":
-          (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
-        "Get SMS instant shipment details for SMS. Type is Instant": (
-          shipmentResponse,
-        ) => shipmentResponse.type === "Instant",
-      });
-      break;
-    case "EmailInstant":
-      check(response, {
-        "GET Email instant shipment details. Status is 200 OK": (r) =>
-          r.status === 200,
-      });
-      check(JSON.parse(response.body), {
-        "GET Email instant shipment details. ShipmentId property is a match":
-          (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
-        "GET Email instant shipment details. Type is Instant": (
-          shipmentResponse,
-        ) => shipmentResponse.type === "Instant",
-      });
-      break;
-    default:
-      throw new Error(`Unknown notification type: ${type}`);
-  }
+    switch (type) {
+        case "Email":
+            check(response, {
+                "GET shipment details for Email. Status is 200 OK": (r) => r.status === 200
+            });
+            check(JSON.parse(response.body), {
+                "GET shipment details for Email. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId
+            });
+            break;
+        case "SMS":
+            check(response, {
+                "GET SMS shipment details for SMS. Status is 200 OK": (r) => r.status === 200,
+            });
+            check(JSON.parse(response.body), {
+                "GET SMS shipment details for SMS. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId
+            });
+            break;
+        case "SMSInstant":
+            check(response, {
+                "GET SMS instant shipment details for SMS. Status is 200 OK": (r) => r.status === 200
+            });
+            check(JSON.parse(response.body), {
+                "GET SMS instant shipment details for SMS. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
+                "Get SMS instant shipment details for SMS. Type is Instant": (shipmentResponse) => shipmentResponse.type === "Instant"
+            });
+            break;
+        case "EmailInstant":
+            check(response, {
+                "GET Email instant shipment details. Status is 200 OK": (r) => r.status === 200
+            });
+            check(JSON.parse(response.body), {
+                "GET Email instant shipment details. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
+                "GET Email instant shipment details. Type is Instant": (shipmentResponse) => shipmentResponse.type === "Instant"
+            });
+            break;
+        default:
+            throw new Error(`Unknown notification type: ${type}`);
+    }
 }
 
 /**
@@ -351,23 +291,18 @@ export function getShipmentStatus(data, shipmentId, label, type) {
  * @description This function retrieves the status feed for notifications using the sequence number query string start position.
  */
 function getStatusFeed(data, label) {
-  const sequenceNumber = 0; // starting position for the status feed
-  const response = futureOrdersApi.getStatusFeed(
-    sequenceNumber,
-    data.token,
-    label,
-  );
+    const sequenceNumber = 0; // starting position for the status feed
+    const response = futureOrdersApi.getStatusFeed(sequenceNumber, data.token, label);
 
-  check(response, {
-    "GET status feed. Status is 200 OK": (r) => r.status === 200,
-  });
+    check(response, {
+        "GET status feed. Status is 200 OK": (r) => r.status === 200,
+    });
 
-  const body = JSON.parse(response.body);
+    const body = JSON.parse(response.body);
 
-  check(body, {
-    "GET status feed. Response body is not empty": (r) =>
-      Object.keys(r).length > 0,
-  });
+    check(body, {
+        "GET status feed. Response body is not empty": (r) => Object.keys(r).length > 0,
+    });
 }
 
 /**
@@ -375,45 +310,25 @@ function getStatusFeed(data, label) {
  * @param {Object} data - The data object containing test data.
  */
 export default function runTests(data) {
-  let response = postEmailNotificationOrderRequest(data);
-  let responseObject = JSON.parse(response);
+    let response = postEmailNotificationOrderRequest(data);
+    let responseObject = JSON.parse(response);
 
-  // checking shipment details for the email order
-  getShipmentStatus(
-    data,
-    responseObject.notification.shipmentId,
-    get_email_shipment,
-    "Email",
-  );
+    // checking shipment details for the email order
+    getShipmentStatus(data, responseObject.notification.shipmentId, get_email_shipment, "Email");
 
-  response = postSmsNotificationOrderRequest(data);
-  responseObject = JSON.parse(response);
+    response = postSmsNotificationOrderRequest(data);
+    responseObject = JSON.parse(response);
 
-  // checking shipment details for the SMS order
-  getShipmentStatus(
-    data,
-    responseObject.notification.shipmentId,
-    get_sms_shipment,
-    "SMS",
-  );
+    // checking shipment details for the SMS order
+    getShipmentStatus(data, responseObject.notification.shipmentId, get_sms_shipment, "SMS");
 
-  // testing instant SMS notification order request
-  response = postSmsInstantNotificationOrderRequest(data);
-  getShipmentStatus(
-    data,
-    JSON.parse(response).notification.shipmentId,
-    get_sms_instant_shipment,
-    "SMSInstant",
-  );
+    // testing instant SMS notification order request
+    response = postSmsInstantNotificationOrderRequest(data);
+    getShipmentStatus(data, JSON.parse(response).notification.shipmentId, get_sms_instant_shipment, "SMSInstant");
 
-  // testing instant Email notification order request
-  response = postEmailInstantNotificationOrderRequest(data);
-  getShipmentStatus(
-    data,
-    JSON.parse(response).notification.shipmentId,
-    get_email_instant_shipment,
-    "EmailInstant",
-  );
+    // testing instant Email notification order request
+    response = postEmailInstantNotificationOrderRequest(data);
+    getShipmentStatus(data, JSON.parse(response).notification.shipmentId, get_email_instant_shipment, "EmailInstant");
 
-  getStatusFeed(data, get_status_feed);
+    getStatusFeed(data, get_status_feed);
 }

--- a/components/api/test/k6/src/tests/orders-v2.js
+++ b/components/api/test/k6/src/tests/orders-v2.js
@@ -37,6 +37,7 @@ import {
   get_email_shipment,
   get_sms_shipment,
   get_sms_instant_shipment,
+  get_email_instant_shipment,
   get_status_feed,
   post_email_instant_order_v2,
 } from "./threshold-labels.js";
@@ -47,6 +48,7 @@ const labels = [
   post_email_order_v2,
   post_sms_order_v2,
   post_sms_instant_order_v2,
+  post_email_instant_order_v2,
   get_email_shipment,
   get_sms_shipment,
   get_status_feed,
@@ -60,6 +62,9 @@ const smsOrderRequestJson = JSON.parse(
 );
 const smsOrderInstantRequestJson = JSON.parse(
   open("../data/orders/order-v2-sms-instant.json"),
+);
+const emailOrderInstantRequestJson = JSON.parse(
+  open("../data/orders/order-v2-email-instant.json"),
 );
 
 export const options = {
@@ -134,12 +139,19 @@ export function setup() {
     ...smsOrderInstantRequestJson,
     idempotencyId: uuidv4(),
     sendersReference,
-    recipient: {
-      ...smsOrderInstantRequestJson.recipient,
-      recipientSms: {
-        ...smsOrderInstantRequestJson.recipient.recipientSms,
-        phoneNumber: smsRecipient,
-      },
+    recipientSms: {
+      ...smsOrderInstantRequestJson.recipientSms,
+      phoneNumber: smsRecipient,
+    },
+  };
+
+  const emailOrderInstantRequest = {
+    ...emailOrderInstantRequestJson,
+    idempotencyId: uuidv4(),
+    sendersReference,
+    recipientEmail: {
+      ...emailOrderInstantRequestJson.recipientEmail,
+      emailAddress: emailRecipient,
     },
   };
 
@@ -149,6 +161,7 @@ export function setup() {
     emailOrderRequest,
     smsOrderRequest,
     smsOrderInstantRequest,
+    emailOrderInstantRequest,
   };
 }
 
@@ -252,8 +265,9 @@ function postEmailInstantNotificationOrderRequest(data) {
   );
 
   const success = check(response, {
-    "POST Email instant notification order request. Status is 201 Created": (r) =>
-      r.status === 201,
+    "POST Email instant notification order request. Status is 201 Created": (
+      r,
+    ) => r.status === 201,
     "POST Email instant notification order request. Response body contains shipmentId":
       (r) => JSON.parse(r.body).notification.shipmentId !== undefined,
   });
@@ -308,6 +322,19 @@ export function getShipmentStatus(data, shipmentId, label, type) {
         "GET SMS instant shipment details for SMS. ShipmentId property is a match":
           (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
         "Get SMS instant shipment details for SMS. Type is Instant": (
+          shipmentResponse,
+        ) => shipmentResponse.type === "Instant",
+      });
+      break;
+    case "EmailInstant":
+      check(response, {
+        "GET Email instant shipment details. Status is 200 OK": (r) =>
+          r.status === 200,
+      });
+      check(JSON.parse(response.body), {
+        "GET Email instant shipment details. ShipmentId property is a match":
+          (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
+        "GET Email instant shipment details. Type is Instant": (
           shipmentResponse,
         ) => shipmentResponse.type === "Instant",
       });
@@ -378,13 +405,13 @@ export default function runTests(data) {
     get_sms_instant_shipment,
     "SMSInstant",
   );
-    
+
   // testing instant Email notification order request
   response = postEmailInstantNotificationOrderRequest(data);
   getShipmentStatus(
     data,
     JSON.parse(response).notification.shipmentId,
-    get_sms_instant_shipment,
+    get_email_instant_shipment,
     "EmailInstant",
   );
 

--- a/components/api/test/k6/src/tests/orders-v2.js
+++ b/components/api/test/k6/src/tests/orders-v2.js
@@ -73,6 +73,20 @@ export function setup() {
     const emailRecipient = getEmailRecipient();
     const smsRecipient = getSmsRecipient();
 
+    
+    // needed for instant notifications
+    if (!smsRecipient) {
+        stopIterationOnFail("smsRecipient is required for SMS instant orders — set the 'smsRecipient' env var", false);
+    }
+
+    if (!emailRecipient) {
+        stopIterationOnFail("emailRecipient is required for email instant orders — set the 'emailRecipient' env var", false);
+    }
+
+    smsOrderRequestJson.recipient.recipientSms.phoneNumber = smsRecipient;
+    emailOrderRequestJson.recipient.recipientEmail.emailAddress = emailRecipient;
+
+
     // used with notification email orders if applicable
     const ninRecipient = __ENV.ninRecipient ? __ENV.ninRecipient.toLowerCase() : null;
 
@@ -81,13 +95,7 @@ export function setup() {
     const idempotencyIdSms = uuidv4();
     const sendersReference = uuidv4();
 
-    if (emailRecipient == null) {
-        // unset recipientEmail object when no email recipient is provided
-        emailOrderRequestJson.recipient["recipientEmail"] = undefined;
-    }
-    else {
-        emailOrderRequestJson.recipient.recipientEmail.emailAddress = emailRecipient;
-    }
+
 
     if (ninRecipient == null) {
         // unset recipientPerson object when no national identity number is provided
@@ -97,18 +105,6 @@ export function setup() {
         emailOrderRequestJson.recipient.recipientPerson.nationalIdentityNumber = ninRecipient;
     }
 
-    if (smsRecipient != null) {
-        smsOrderRequestJson.recipient.recipientSms.phoneNumber = smsRecipient;
-    }
-
-    // needed for instant notifications
-    if (!smsRecipient) {
-        stopIterationOnFail("smsRecipient is required for SMS instant orders — set the 'smsRecipient' env var", false);
-    }
-
-    if (!emailRecipient) {
-        stopIterationOnFail("emailRecipient is required for email instant orders — set the 'emailRecipient' env var", false);
-    }
 
     const emailOrderRequest = { ...emailOrderRequestJson, idempotencyId: idempotencyIdEmail };
 

--- a/components/api/test/k6/src/tests/orders-v2.js
+++ b/components/api/test/k6/src/tests/orders-v2.js
@@ -293,7 +293,7 @@ function postSmsInstantNotificationOrderRequestOld(data) {
   const response = futureOrdersApi.postSmsInstantNotificationOrderRequestOld(
     JSON.stringify(data.smsOrderInstantOldRequest),
     data.token,
-    post_sms_instant_order_v2,
+    post_sms_instant_order_old_v2,
   );
 
   const success = check(response, {

--- a/components/api/test/k6/src/tests/orders-v2.js
+++ b/components/api/test/k6/src/tests/orders-v2.js
@@ -97,12 +97,12 @@ export function setup() {
 
 
 
-    if (ninRecipient == null) {
-        // unset recipientPerson object when no national identity number is provided
-        emailOrderRequestJson.recipient["recipientPerson"] = undefined;
-    }
-    else {
+    //can only have one active recipient
+    if (ninRecipient != null && !emailRecipient) {
         emailOrderRequestJson.recipient.recipientPerson.nationalIdentityNumber = ninRecipient;
+    } else {
+          // unset recipientPerson object when no national identity number is provided
+        emailOrderRequestJson.recipient["recipientPerson"] = undefined;
     }
 
 

--- a/components/api/test/k6/src/tests/orders-v2.js
+++ b/components/api/test/k6/src/tests/orders-v2.js
@@ -30,94 +30,126 @@ import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import * as setupToken from "../setup.js";
 import * as futureOrdersApi from "../api/notifications/v2.js";
 import {
-    post_sms_order_v2, post_sms_instant_order_v2, post_email_order_v2,
-    setEmptyThresholds, get_email_shipment, get_sms_shipment,
-    get_sms_instant_shipment, get_status_feed
+  post_sms_order_v2,
+  post_sms_instant_order_v2,
+  post_email_order_v2,
+  setEmptyThresholds,
+  get_email_shipment,
+  get_sms_shipment,
+  get_sms_instant_shipment,
+  get_status_feed,
+  post_email_instant_order_v2,
 } from "./threshold-labels.js";
 import { scopes } from "../shared/variables.js";
 import { getEmailRecipient, getSmsRecipient } from "../shared/functions.js";
 
-const labels = [post_email_order_v2, post_sms_order_v2, post_sms_instant_order_v2, get_email_shipment, get_sms_shipment, get_status_feed];
+const labels = [
+  post_email_order_v2,
+  post_sms_order_v2,
+  post_sms_instant_order_v2,
+  get_email_shipment,
+  get_sms_shipment,
+  get_status_feed,
+];
 
 const emailOrderRequestJson = JSON.parse(
-    open("../data/orders/order-v2-email.json")
+  open("../data/orders/order-v2-email.json"),
 );
 const smsOrderRequestJson = JSON.parse(
-    open("../data/orders/order-v2-sms.json")
+  open("../data/orders/order-v2-sms.json"),
 );
 const smsOrderInstantRequestJson = JSON.parse(
-    open("../data/orders/order-v2-sms-instant.json")
+  open("../data/orders/order-v2-sms-instant.json"),
 );
 
 export const options = {
-    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(95)', 'p(99)', 'p(99.5)', 'p(99.9)', 'count'],
-    thresholds: {
-        // Checks rate should be 100%. Raise error if any check has failed.
-        checks: ['rate>=1']
-    }
+  summaryTrendStats: [
+    "avg",
+    "min",
+    "med",
+    "max",
+    "p(95)",
+    "p(99)",
+    "p(99.5)",
+    "p(99.9)",
+    "count",
+  ],
+  thresholds: {
+    // Checks rate should be 100%. Raise error if any check has failed.
+    checks: ["rate>=1"],
+  },
 };
 setEmptyThresholds(labels, options);
 
 /**
  * Initialize test data.
  * @returns {Object} The data object containing token, sendersReference, and emailOrderRequest.
-*/
+ */
 export function setup() {
-    const emailRecipient = getEmailRecipient();
-    const smsRecipient = getSmsRecipient();
+  const emailRecipient = getEmailRecipient();
+  const smsRecipient = getSmsRecipient();
 
-    // used with notification email orders if applicable
-    const ninRecipient = __ENV.ninRecipient ? __ENV.ninRecipient.toLowerCase() : null;
+  // used with notification email orders if applicable
+  const ninRecipient = __ENV.ninRecipient
+    ? __ENV.ninRecipient.toLowerCase()
+    : null;
 
-    const token = setupToken.getAltinnTokenForOrg(scopes);
-    const idempotencyIdEmail = uuidv4();
-    const idempotencyIdSms = uuidv4();
-    const sendersReference = uuidv4();
+  const token = setupToken.getAltinnTokenForOrg(scopes);
+  const idempotencyIdEmail = uuidv4();
+  const idempotencyIdSms = uuidv4();
+  const sendersReference = uuidv4();
 
-    if (emailRecipient == null) {
-        // unset recipientEmail object when no email recipient is provided
-        emailOrderRequestJson.recipient["recipientEmail"] = undefined;
-    }
-    else {
-        emailOrderRequestJson.recipient.recipientEmail.emailAddress = emailRecipient;
-    }
+  if (emailRecipient == null) {
+    // unset recipientEmail object when no email recipient is provided
+    emailOrderRequestJson.recipient["recipientEmail"] = undefined;
+  } else {
+    emailOrderRequestJson.recipient.recipientEmail.emailAddress =
+      emailRecipient;
+  }
 
-    if (ninRecipient == null) {
-        // unset recipientPerson object when no national identity number is provided
-        emailOrderRequestJson.recipient["recipientPerson"] = undefined;
-    }
-    else {
-        emailOrderRequestJson.recipient.recipientPerson.nationalIdentityNumber = ninRecipient;
-    }
+  if (ninRecipient == null) {
+    // unset recipientPerson object when no national identity number is provided
+    emailOrderRequestJson.recipient["recipientPerson"] = undefined;
+  } else {
+    emailOrderRequestJson.recipient.recipientPerson.nationalIdentityNumber =
+      ninRecipient;
+  }
 
-    if (smsRecipient != null) {
-        smsOrderRequestJson.recipient.recipientSms.phoneNumber = smsRecipient;
-    }
+  if (smsRecipient != null) {
+    smsOrderRequestJson.recipient.recipientSms.phoneNumber = smsRecipient;
+  }
 
-    const emailOrderRequest = { ...emailOrderRequestJson, idempotencyId: idempotencyIdEmail };
+  const emailOrderRequest = {
+    ...emailOrderRequestJson,
+    idempotencyId: idempotencyIdEmail,
+  };
 
-    const smsOrderRequest = { ...smsOrderRequestJson, idempotencyId: idempotencyIdSms, sendersReference };
+  const smsOrderRequest = {
+    ...smsOrderRequestJson,
+    idempotencyId: idempotencyIdSms,
+    sendersReference,
+  };
 
-    const smsOrderInstantRequest = {
-        ...smsOrderInstantRequestJson,
-        idempotencyId: uuidv4(),
-        sendersReference,
-        recipient: {
-            ...smsOrderInstantRequestJson.recipient,
-            recipientSms: {
-                ...smsOrderInstantRequestJson.recipient.recipientSms,
-                phoneNumber: smsRecipient
-            }
-        }
-    };
+  const smsOrderInstantRequest = {
+    ...smsOrderInstantRequestJson,
+    idempotencyId: uuidv4(),
+    sendersReference,
+    recipient: {
+      ...smsOrderInstantRequestJson.recipient,
+      recipientSms: {
+        ...smsOrderInstantRequestJson.recipient.recipientSms,
+        phoneNumber: smsRecipient,
+      },
+    },
+  };
 
-    return {
-        token,
-        sendersReference,
-        emailOrderRequest,
-        smsOrderRequest,
-        smsOrderInstantRequest
-    };
+  return {
+    token,
+    sendersReference,
+    emailOrderRequest,
+    smsOrderRequest,
+    smsOrderInstantRequest,
+  };
 }
 
 /**
@@ -126,25 +158,27 @@ export function setup() {
  * @returns {string} The response body of the created order.
  */
 function postEmailNotificationOrderRequest(data) {
-    const response = futureOrdersApi.postNotificationOrderV2(
-        JSON.stringify(data.emailOrderRequest),
-        data.token,
-        post_email_order_v2
-    );
+  const response = futureOrdersApi.postNotificationOrderV2(
+    JSON.stringify(data.emailOrderRequest),
+    data.token,
+    post_email_order_v2,
+  );
 
-    const success = check(response, {
-        "POST email notification order request. Status is 201 Created": (r) => r.status === 201
-    });
+  const success = check(response, {
+    "POST email notification order request. Status is 201 Created": (r) =>
+      r.status === 201,
+  });
 
-    stopIterationOnFail("POST email notification order request failed", success);
+  stopIterationOnFail("POST email notification order request failed", success);
 
-    const selfLink = response.headers["Location"];
+  const selfLink = response.headers["Location"];
 
-    check(response, {
-        "POST email notification order request. Location header provided": (_) => selfLink,
-    });
+  check(response, {
+    "POST email notification order request. Location header provided": (_) =>
+      selfLink,
+  });
 
-    return response.body;
+  return response.body;
 }
 
 /**
@@ -153,51 +187,84 @@ function postEmailNotificationOrderRequest(data) {
  * @returns {string} The response body of the created order.
  */
 function postSmsNotificationOrderRequest(data) {
-    const response = futureOrdersApi.postNotificationOrderV2(
-        JSON.stringify(data.smsOrderRequest),
-        data.token,
-        post_sms_order_v2
-    );
+  const response = futureOrdersApi.postNotificationOrderV2(
+    JSON.stringify(data.smsOrderRequest),
+    data.token,
+    post_sms_order_v2,
+  );
 
-    const success = check(response, {
-        "POST SMS notification order request. Status is 201 Created": (r) => r.status === 201
-    });
+  const success = check(response, {
+    "POST SMS notification order request. Status is 201 Created": (r) =>
+      r.status === 201,
+  });
 
-    stopIterationOnFail("POST SMS notification order request failed", success);
+  stopIterationOnFail("POST SMS notification order request failed", success);
 
-    const selfLink = response.headers["Location"];
+  const selfLink = response.headers["Location"];
 
-    check(response, {
-        "POST SMS notification order request. Location header provided": (_) => selfLink,
-        "POST SMS notification order request. Response body is not an empty string": (r) => r.body
-    });
+  check(response, {
+    "POST SMS notification order request. Location header provided": (_) =>
+      selfLink,
+    "POST SMS notification order request. Response body is not an empty string":
+      (r) => r.body,
+  });
 
-    return response.body;
+  return response.body;
 }
-
 
 /**
  * Post instant SMS notification order request using the v2 API.
- * @param {*} data 
- * @returns 
+ * @param {*} data
+ * @returns
  */
 function postSmsInstantNotificationOrderRequest(data) {
-    const response = futureOrdersApi.postSmsInstantNotificationOrderRequest(
-        JSON.stringify(data.smsOrderInstantRequest),
-        data.token,
-        post_sms_instant_order_v2
-    );
+  const response = futureOrdersApi.postSmsInstantNotificationOrderRequest(
+    JSON.stringify(data.smsOrderInstantRequest),
+    data.token,
+    post_sms_instant_order_v2,
+  );
 
-    const success = check(response, {
-        "POST SMS instant notification order request. Status is 201 Created": (r) => r.status === 201,
-        "POST SMS instant notification order request. Response body contains shipmentId": (r) => JSON.parse(r.body).notification.shipmentId !== undefined
-    });
+  const success = check(response, {
+    "POST SMS instant notification order request. Status is 201 Created": (r) =>
+      r.status === 201,
+    "POST SMS instant notification order request. Response body contains shipmentId":
+      (r) => JSON.parse(r.body).notification.shipmentId !== undefined,
+  });
 
-    stopIterationOnFail("POST SMS instant notification order request failed", success);
+  stopIterationOnFail(
+    "POST SMS instant notification order request failed",
+    success,
+  );
 
-    return response.body;
+  return response.body;
 }
 
+/**
+ * Post instant Email notification order request using the v2 API.
+ * @param {*} data
+ * @returns
+ */
+function postEmailInstantNotificationOrderRequest(data) {
+  const response = futureOrdersApi.postEmailInstantNotificationOrderRequest(
+    JSON.stringify(data.emailOrderInstantRequest),
+    data.token,
+    post_email_instant_order_v2,
+  );
+
+  const success = check(response, {
+    "POST Email instant notification order request. Status is 201 Created": (r) =>
+      r.status === 201,
+    "POST Email instant notification order request. Response body contains shipmentId":
+      (r) => JSON.parse(r.body).notification.shipmentId !== undefined,
+  });
+
+  stopIterationOnFail(
+    "POST Email instant notification order request failed",
+    success,
+  );
+
+  return response.body;
+}
 
 /**
  * Gets the notification shipment status for email or SMS.
@@ -207,37 +274,47 @@ function postSmsInstantNotificationOrderRequest(data) {
  * @param {string} type - The type of notification (e.g., "Email" or "SMS").
  */
 export function getShipmentStatus(data, shipmentId, label, type) {
-    const response = futureOrdersApi.getShipment(shipmentId, data.token, label);
+  const response = futureOrdersApi.getShipment(shipmentId, data.token, label);
 
-    switch (type) {
-        case "Email":
-            check(response, {
-                "GET shipment details for Email. Status is 200 OK": (r) => r.status === 200
-            });
-            check(JSON.parse(response.body), {
-                "GET shipment details for Email. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId
-            });
-            break;
-        case "SMS":
-            check(response, {
-                "GET SMS shipment details for SMS. Status is 200 OK": (r) => r.status === 200,
-            });
-            check(JSON.parse(response.body), {
-                "GET SMS shipment details for SMS. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId
-            });
-            break;
-        case "SMSInstant":
-            check(response, {
-                "GET SMS instant shipment details for SMS. Status is 200 OK": (r) => r.status === 200
-            });
-            check(JSON.parse(response.body), {
-                "GET SMS instant shipment details for SMS. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
-                "Get SMS instant shipment details for SMS. Type is Instant": (shipmentResponse) => shipmentResponse.type === "Instant"
-            });
-            break;
-        default:
-            throw new Error(`Unknown notification type: ${type}`);
-    }
+  switch (type) {
+    case "Email":
+      check(response, {
+        "GET shipment details for Email. Status is 200 OK": (r) =>
+          r.status === 200,
+      });
+      check(JSON.parse(response.body), {
+        "GET shipment details for Email. ShipmentId property is a match": (
+          shipmentResponse,
+        ) => shipmentResponse.shipmentId === shipmentId,
+      });
+      break;
+    case "SMS":
+      check(response, {
+        "GET SMS shipment details for SMS. Status is 200 OK": (r) =>
+          r.status === 200,
+      });
+      check(JSON.parse(response.body), {
+        "GET SMS shipment details for SMS. ShipmentId property is a match": (
+          shipmentResponse,
+        ) => shipmentResponse.shipmentId === shipmentId,
+      });
+      break;
+    case "SMSInstant":
+      check(response, {
+        "GET SMS instant shipment details for SMS. Status is 200 OK": (r) =>
+          r.status === 200,
+      });
+      check(JSON.parse(response.body), {
+        "GET SMS instant shipment details for SMS. ShipmentId property is a match":
+          (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
+        "Get SMS instant shipment details for SMS. Type is Instant": (
+          shipmentResponse,
+        ) => shipmentResponse.type === "Instant",
+      });
+      break;
+    default:
+      throw new Error(`Unknown notification type: ${type}`);
+  }
 }
 
 /**
@@ -247,18 +324,23 @@ export function getShipmentStatus(data, shipmentId, label, type) {
  * @description This function retrieves the status feed for notifications using the sequence number query string start position.
  */
 function getStatusFeed(data, label) {
-    const sequenceNumber = 0; // starting position for the status feed
-    const response = futureOrdersApi.getStatusFeed(sequenceNumber, data.token, label);
+  const sequenceNumber = 0; // starting position for the status feed
+  const response = futureOrdersApi.getStatusFeed(
+    sequenceNumber,
+    data.token,
+    label,
+  );
 
-    check(response, {
-        "GET status feed. Status is 200 OK": (r) => r.status === 200,
-    });
+  check(response, {
+    "GET status feed. Status is 200 OK": (r) => r.status === 200,
+  });
 
-    const body = JSON.parse(response.body);
+  const body = JSON.parse(response.body);
 
-    check(body, {
-        "GET status feed. Response body is not empty": (r) => Object.keys(r).length > 0,
-    });
+  check(body, {
+    "GET status feed. Response body is not empty": (r) =>
+      Object.keys(r).length > 0,
+  });
 }
 
 /**
@@ -266,21 +348,45 @@ function getStatusFeed(data, label) {
  * @param {Object} data - The data object containing test data.
  */
 export default function runTests(data) {
-    let response = postEmailNotificationOrderRequest(data);
-    let responseObject = JSON.parse(response);
+  let response = postEmailNotificationOrderRequest(data);
+  let responseObject = JSON.parse(response);
 
-    // checking shipment details for the email order
-    getShipmentStatus(data, responseObject.notification.shipmentId, get_email_shipment, "Email");
+  // checking shipment details for the email order
+  getShipmentStatus(
+    data,
+    responseObject.notification.shipmentId,
+    get_email_shipment,
+    "Email",
+  );
 
-    response = postSmsNotificationOrderRequest(data);
-    responseObject = JSON.parse(response);
+  response = postSmsNotificationOrderRequest(data);
+  responseObject = JSON.parse(response);
 
-    // checking shipment details for the SMS order
-    getShipmentStatus(data, responseObject.notification.shipmentId, get_sms_shipment, "SMS");
+  // checking shipment details for the SMS order
+  getShipmentStatus(
+    data,
+    responseObject.notification.shipmentId,
+    get_sms_shipment,
+    "SMS",
+  );
 
-    // testing instant SMS notification order request
-    response = postSmsInstantNotificationOrderRequest(data);
-    getShipmentStatus(data, JSON.parse(response).notification.shipmentId, get_sms_instant_shipment, "SMSInstant");
+  // testing instant SMS notification order request
+  response = postSmsInstantNotificationOrderRequest(data);
+  getShipmentStatus(
+    data,
+    JSON.parse(response).notification.shipmentId,
+    get_sms_instant_shipment,
+    "SMSInstant",
+  );
+    
+  // testing instant Email notification order request
+  response = postEmailInstantNotificationOrderRequest(data);
+  getShipmentStatus(
+    data,
+    JSON.parse(response).notification.shipmentId,
+    get_sms_instant_shipment,
+    "EmailInstant",
+  );
 
-    getStatusFeed(data, get_status_feed);
+  getStatusFeed(data, get_status_feed);
 }

--- a/components/api/test/k6/src/tests/orders-v2.js
+++ b/components/api/test/k6/src/tests/orders-v2.js
@@ -41,6 +41,7 @@ import {
   get_email_instant_shipment,
   get_status_feed,
   post_email_instant_order_v2,
+  get_sms_instant_shipment_old,
 } from "./threshold-labels.js";
 import { scopes } from "../shared/variables.js";
 import { getEmailRecipient, getSmsRecipient } from "../shared/functions.js";
@@ -51,6 +52,9 @@ const labels = [
   post_sms_instant_order_v2,
   post_sms_instant_order_old_v2,
   post_email_instant_order_v2,
+  get_sms_instant_shipment,
+  get_sms_instant_shipment_old,
+  get_email_instant_shipment,
   get_email_shipment,
   get_sms_shipment,
   get_status_feed,
@@ -482,7 +486,7 @@ export default function runTests(data) {
   getShipmentStatus(
     data,
     JSON.parse(response).notification.shipmentId,
-    get_sms_instant_shipment,
+    get_sms_instant_shipment_old,
     "SMSOldInstant",
   );
 

--- a/components/api/test/k6/src/tests/orders-v2.js
+++ b/components/api/test/k6/src/tests/orders-v2.js
@@ -30,177 +30,132 @@ import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import * as setupToken from "../setup.js";
 import * as futureOrdersApi from "../api/notifications/v2.js";
 import {
-  post_sms_order_v2,
-  post_sms_instant_order_v2,
-  post_sms_instant_order_old_v2,
-  post_email_order_v2,
-  setEmptyThresholds,
-  get_email_shipment,
-  get_sms_shipment,
-  get_sms_instant_shipment,
-  get_email_instant_shipment,
-  get_status_feed,
-  post_email_instant_order_v2,
-  get_sms_instant_shipment_old,
+    post_sms_order_v2, post_sms_instant_order_v2, post_sms_instant_order_old_v2, post_email_order_v2,
+    setEmptyThresholds, get_email_shipment, get_sms_shipment,
+    get_sms_instant_shipment, get_sms_instant_shipment_old, get_email_instant_shipment,
+    get_status_feed, post_email_instant_order_v2
 } from "./threshold-labels.js";
 import { scopes } from "../shared/variables.js";
 import { getEmailRecipient, getSmsRecipient } from "../shared/functions.js";
 
-const labels = [
-  post_email_order_v2,
-  post_sms_order_v2,
-  post_sms_instant_order_v2,
-  post_sms_instant_order_old_v2,
-  post_email_instant_order_v2,
-  get_sms_instant_shipment,
-  get_sms_instant_shipment_old,
-  get_email_instant_shipment,
-  get_email_shipment,
-  get_sms_shipment,
-  get_status_feed,
-];
+const labels = [post_email_order_v2, post_sms_order_v2, post_sms_instant_order_v2, post_sms_instant_order_old_v2, post_email_instant_order_v2, get_sms_instant_shipment, get_sms_instant_shipment_old, get_email_instant_shipment, get_email_shipment, get_sms_shipment, get_status_feed];
 
 const emailOrderRequestJson = JSON.parse(
-  open("../data/orders/order-v2-email.json"),
+    open("../data/orders/order-v2-email.json")
 );
 const smsOrderRequestJson = JSON.parse(
-  open("../data/orders/order-v2-sms.json"),
+    open("../data/orders/order-v2-sms.json")
 );
 const smsOrderInstantRequestJson = JSON.parse(
-  open("../data/orders/order-v2-sms-instant.json"),
+    open("../data/orders/order-v2-sms-instant.json")
 );
 const smsOrderInstantRequestOldJson = JSON.parse(
-  open("../data/orders/order-v2-sms-instant-old.json"),
+    open("../data/orders/order-v2-sms-instant-old.json")
 );
-
 const emailOrderInstantRequestJson = JSON.parse(
-  open("../data/orders/order-v2-email-instant.json"),
+    open("../data/orders/order-v2-email-instant.json")
 );
 
 export const options = {
-  summaryTrendStats: [
-    "avg",
-    "min",
-    "med",
-    "max",
-    "p(95)",
-    "p(99)",
-    "p(99.5)",
-    "p(99.9)",
-    "count",
-  ],
-  thresholds: {
-    // Checks rate should be 100%. Raise error if any check has failed.
-    checks: ["rate>=1"],
-  },
+    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(95)', 'p(99)', 'p(99.5)', 'p(99.9)', 'count'],
+    thresholds: {
+        // Checks rate should be 100%. Raise error if any check has failed.
+        checks: ['rate>=1']
+    }
 };
 setEmptyThresholds(labels, options);
 
 /**
  * Initialize test data.
  * @returns {Object} The data object containing token, sendersReference, and emailOrderRequest.
- */
+*/
 export function setup() {
-  const emailRecipient = getEmailRecipient();
-  const smsRecipient = getSmsRecipient();
+    const emailRecipient = getEmailRecipient();
+    const smsRecipient = getSmsRecipient();
 
-  // used with notification email orders if applicable
-  const ninRecipient = __ENV.ninRecipient
-    ? __ENV.ninRecipient.toLowerCase()
-    : null;
+    // used with notification email orders if applicable
+    const ninRecipient = __ENV.ninRecipient ? __ENV.ninRecipient.toLowerCase() : null;
 
-  const token = setupToken.getAltinnTokenForOrg(scopes);
-  const idempotencyIdEmail = uuidv4();
-  const idempotencyIdSms = uuidv4();
-  const sendersReference = uuidv4();
+    const token = setupToken.getAltinnTokenForOrg(scopes);
+    const idempotencyIdEmail = uuidv4();
+    const idempotencyIdSms = uuidv4();
+    const sendersReference = uuidv4();
 
-  if (emailRecipient == null) {
-    // unset recipientEmail object when no email recipient is provided
-    emailOrderRequestJson.recipient["recipientEmail"] = undefined;
-  } else {
-    emailOrderRequestJson.recipient.recipientEmail.emailAddress =
-      emailRecipient;
-  }
+    if (emailRecipient == null) {
+        // unset recipientEmail object when no email recipient is provided
+        emailOrderRequestJson.recipient["recipientEmail"] = undefined;
+    }
+    else {
+        emailOrderRequestJson.recipient.recipientEmail.emailAddress = emailRecipient;
+    }
 
-  if (ninRecipient == null) {
-    // unset recipientPerson object when no national identity number is provided
-    emailOrderRequestJson.recipient["recipientPerson"] = undefined;
-  } else {
-    emailOrderRequestJson.recipient.recipientPerson.nationalIdentityNumber =
-      ninRecipient;
-  }
+    if (ninRecipient == null) {
+        // unset recipientPerson object when no national identity number is provided
+        emailOrderRequestJson.recipient["recipientPerson"] = undefined;
+    }
+    else {
+        emailOrderRequestJson.recipient.recipientPerson.nationalIdentityNumber = ninRecipient;
+    }
 
-  if (smsRecipient != null) {
-    smsOrderRequestJson.recipient.recipientSms.phoneNumber = smsRecipient;
-  }
+    if (smsRecipient != null) {
+        smsOrderRequestJson.recipient.recipientSms.phoneNumber = smsRecipient;
+    }
 
-  // needed for instant notifications
-  if (!smsRecipient) {
-    stopIterationOnFail(
-      "smsRecipient is required for SMS instant orders — set the 'smsRecipient' env var",
-      false,
-    );
-  }
+    // needed for instant notifications
+    if (!smsRecipient) {
+        stopIterationOnFail("smsRecipient is required for SMS instant orders — set the 'smsRecipient' env var", false);
+    }
 
-  if (!emailRecipient) {
-    stopIterationOnFail(
-      "emailRecipient is required for email instant orders — set the 'emailRecipient' env var",
-      false,
-    );
-  }
+    if (!emailRecipient) {
+        stopIterationOnFail("emailRecipient is required for email instant orders — set the 'emailRecipient' env var", false);
+    }
 
-  const emailOrderRequest = {
-    ...emailOrderRequestJson,
-    idempotencyId: idempotencyIdEmail,
-  };
+    const emailOrderRequest = { ...emailOrderRequestJson, idempotencyId: idempotencyIdEmail };
 
-  const smsOrderRequest = {
-    ...smsOrderRequestJson,
-    idempotencyId: idempotencyIdSms,
-    sendersReference,
-  };
+    const smsOrderRequest = { ...smsOrderRequestJson, idempotencyId: idempotencyIdSms, sendersReference };
 
-  const smsOrderInstantOldRequest = {
-    ...smsOrderInstantRequestOldJson,
-    idempotencyId: uuidv4(),
-    sendersReference,
-    recipient: {
-      ...smsOrderInstantRequestOldJson.recipient,
-      recipientSms: {
-        ...smsOrderInstantRequestOldJson.recipient.recipientSms,
-        phoneNumber: smsRecipient,
-      },
-    },
-  };
+    const smsOrderInstantOldRequest = {
+        ...smsOrderInstantRequestOldJson,
+        idempotencyId: uuidv4(),
+        sendersReference,
+        recipient: {
+            ...smsOrderInstantRequestOldJson.recipient,
+            recipientSms: {
+                ...smsOrderInstantRequestOldJson.recipient.recipientSms,
+                phoneNumber: smsRecipient
+            }
+        }
+    };
 
-  const smsOrderInstantRequest = {
-    ...smsOrderInstantRequestJson,
-    idempotencyId: uuidv4(),
-    sendersReference,
-    recipientSms: {
-      ...smsOrderInstantRequestJson.recipientSms,
-      phoneNumber: smsRecipient,
-    },
-  };
-  const emailOrderInstantRequest = {
-    ...emailOrderInstantRequestJson,
-    idempotencyId: uuidv4(),
-    sendersReference,
-    recipientEmail: {
-      ...emailOrderInstantRequestJson.recipientEmail,
-      emailAddress: emailRecipient,
-    },
-  };
+    const smsOrderInstantRequest = {
+        ...smsOrderInstantRequestJson,
+        idempotencyId: uuidv4(),
+        sendersReference,
+        recipientSms: {
+            ...smsOrderInstantRequestJson.recipientSms,
+            phoneNumber: smsRecipient
+        }
+    };
 
-  return {
-    token,
-    sendersReference,
-    emailOrderRequest,
-    smsOrderRequest,
-    smsOrderInstantRequest,
-    smsOrderInstantOldRequest,
-    emailOrderInstantRequest,
-  };
+    const emailOrderInstantRequest = {
+        ...emailOrderInstantRequestJson,
+        idempotencyId: uuidv4(),
+        sendersReference,
+        recipientEmail: {
+            ...emailOrderInstantRequestJson.recipientEmail,
+            emailAddress: emailRecipient
+        }
+    };
+
+    return {
+        token,
+        sendersReference,
+        emailOrderRequest,
+        smsOrderRequest,
+        smsOrderInstantRequest,
+        smsOrderInstantOldRequest,
+        emailOrderInstantRequest
+    };
 }
 
 /**
@@ -209,27 +164,25 @@ export function setup() {
  * @returns {string} The response body of the created order.
  */
 function postEmailNotificationOrderRequest(data) {
-  const response = futureOrdersApi.postNotificationOrderV2(
-    JSON.stringify(data.emailOrderRequest),
-    data.token,
-    post_email_order_v2,
-  );
+    const response = futureOrdersApi.postNotificationOrderV2(
+        JSON.stringify(data.emailOrderRequest),
+        data.token,
+        post_email_order_v2
+    );
 
-  const success = check(response, {
-    "POST email notification order request. Status is 201 Created": (r) =>
-      r.status === 201,
-  });
+    const success = check(response, {
+        "POST email notification order request. Status is 201 Created": (r) => r.status === 201
+    });
 
-  stopIterationOnFail("POST email notification order request failed", success);
+    stopIterationOnFail("POST email notification order request failed", success);
 
-  const selfLink = response.headers["Location"];
+    const selfLink = response.headers["Location"];
 
-  check(response, {
-    "POST email notification order request. Location header provided": (_) =>
-      selfLink,
-  });
+    check(response, {
+        "POST email notification order request. Location header provided": (_) => selfLink,
+    });
 
-  return response.body;
+    return response.body;
 }
 
 /**
@@ -238,30 +191,28 @@ function postEmailNotificationOrderRequest(data) {
  * @returns {string} The response body of the created order.
  */
 function postSmsNotificationOrderRequest(data) {
-  const response = futureOrdersApi.postNotificationOrderV2(
-    JSON.stringify(data.smsOrderRequest),
-    data.token,
-    post_sms_order_v2,
-  );
+    const response = futureOrdersApi.postNotificationOrderV2(
+        JSON.stringify(data.smsOrderRequest),
+        data.token,
+        post_sms_order_v2
+    );
 
-  const success = check(response, {
-    "POST SMS notification order request. Status is 201 Created": (r) =>
-      r.status === 201,
-  });
+    const success = check(response, {
+        "POST SMS notification order request. Status is 201 Created": (r) => r.status === 201
+    });
 
-  stopIterationOnFail("POST SMS notification order request failed", success);
+    stopIterationOnFail("POST SMS notification order request failed", success);
 
-  const selfLink = response.headers["Location"];
+    const selfLink = response.headers["Location"];
 
-  check(response, {
-    "POST SMS notification order request. Location header provided": (_) =>
-      selfLink,
-    "POST SMS notification order request. Response body is not an empty string":
-      (r) => r.body,
-  });
+    check(response, {
+        "POST SMS notification order request. Location header provided": (_) => selfLink,
+        "POST SMS notification order request. Response body is not an empty string": (r) => r.body
+    });
 
-  return response.body;
+    return response.body;
 }
+
 
 /**
  * Post instant SMS notification order request using the v2 API.
@@ -269,47 +220,42 @@ function postSmsNotificationOrderRequest(data) {
  * @returns
  */
 function postSmsInstantNotificationOrderRequest(data) {
-  const response = futureOrdersApi.postSmsInstantNotificationOrderRequest(
-    JSON.stringify(data.smsOrderInstantRequest),
-    data.token,
-    post_sms_instant_order_v2,
-  );
+    const response = futureOrdersApi.postSmsInstantNotificationOrderRequest(
+        JSON.stringify(data.smsOrderInstantRequest),
+        data.token,
+        post_sms_instant_order_v2
+    );
 
-  const success = check(response, {
-    "POST SMS instant notification order request. Status is 201 Created": (r) =>
-      r.status === 201,
-    "POST SMS instant notification order request. Response body contains shipmentId":
-      (r) => JSON.parse(r.body).notification.shipmentId !== undefined,
-  });
+    const success = check(response, {
+        "POST SMS instant notification order request. Status is 201 Created": (r) => r.status === 201,
+        "POST SMS instant notification order request. Response body contains shipmentId": (r) => JSON.parse(r.body).notification.shipmentId !== undefined
+    });
 
-  stopIterationOnFail(
-    "POST SMS instant notification order request failed",
-    success,
-  );
+    stopIterationOnFail("POST SMS instant notification order request failed", success);
 
-  return response.body;
+    return response.body;
 }
+
+/**
+ * Post old instant SMS notification order request using the v2 API.
+ * @param {*} data
+ * @returns
+ */
 function postSmsInstantNotificationOrderRequestOld(data) {
-  const response = futureOrdersApi.postSmsInstantNotificationOrderRequestOld(
-    JSON.stringify(data.smsOrderInstantOldRequest),
-    data.token,
-    post_sms_instant_order_old_v2,
-  );
+    const response = futureOrdersApi.postSmsInstantNotificationOrderRequestOld(
+        JSON.stringify(data.smsOrderInstantOldRequest),
+        data.token,
+        post_sms_instant_order_old_v2
+    );
 
-  const success = check(response, {
-    "POST old SMS instant notification order request. Status is 201 Created": (
-      r,
-    ) => r.status === 201,
-    "POST old SMS instant notification order request. Response body contains shipmentId":
-      (r) => JSON.parse(r.body).notification.shipmentId !== undefined,
-  });
+    const success = check(response, {
+        "POST old SMS instant notification order request. Status is 201 Created": (r) => r.status === 201,
+        "POST old SMS instant notification order request. Response body contains shipmentId": (r) => JSON.parse(r.body).notification.shipmentId !== undefined
+    });
 
-  stopIterationOnFail(
-    "POST old SMS instant notification order request failed",
-    success,
-  );
+    stopIterationOnFail("POST old SMS instant notification order request failed", success);
 
-  return response.body;
+    return response.body;
 }
 
 /**
@@ -318,27 +264,22 @@ function postSmsInstantNotificationOrderRequestOld(data) {
  * @returns
  */
 function postEmailInstantNotificationOrderRequest(data) {
-  const response = futureOrdersApi.postEmailInstantNotificationOrderRequest(
-    JSON.stringify(data.emailOrderInstantRequest),
-    data.token,
-    post_email_instant_order_v2,
-  );
+    const response = futureOrdersApi.postEmailInstantNotificationOrderRequest(
+        JSON.stringify(data.emailOrderInstantRequest),
+        data.token,
+        post_email_instant_order_v2
+    );
 
-  const success = check(response, {
-    "POST Email instant notification order request. Status is 201 Created": (
-      r,
-    ) => r.status === 201,
-    "POST Email instant notification order request. Response body contains shipmentId":
-      (r) => JSON.parse(r.body).notification.shipmentId !== undefined,
-  });
+    const success = check(response, {
+        "POST Email instant notification order request. Status is 201 Created": (r) => r.status === 201,
+        "POST Email instant notification order request. Response body contains shipmentId": (r) => JSON.parse(r.body).notification.shipmentId !== undefined
+    });
 
-  stopIterationOnFail(
-    "POST Email instant notification order request failed",
-    success,
-  );
+    stopIterationOnFail("POST Email instant notification order request failed", success);
 
-  return response.body;
+    return response.body;
 }
+
 
 /**
  * Gets the notification shipment status for email or SMS.
@@ -348,75 +289,55 @@ function postEmailInstantNotificationOrderRequest(data) {
  * @param {string} type - The type of notification (e.g., "Email" or "SMS").
  */
 export function getShipmentStatus(data, shipmentId, label, type) {
-  const response = futureOrdersApi.getShipment(shipmentId, data.token, label);
+    const response = futureOrdersApi.getShipment(shipmentId, data.token, label);
 
-  switch (type) {
-    case "Email":
-      check(response, {
-        "GET shipment details for Email. Status is 200 OK": (r) =>
-          r.status === 200,
-      });
-      check(JSON.parse(response.body), {
-        "GET shipment details for Email. ShipmentId property is a match": (
-          shipmentResponse,
-        ) => shipmentResponse.shipmentId === shipmentId,
-      });
-      break;
-    case "SMS":
-      check(response, {
-        "GET SMS shipment details for SMS. Status is 200 OK": (r) =>
-          r.status === 200,
-      });
-      check(JSON.parse(response.body), {
-        "GET SMS shipment details for SMS. ShipmentId property is a match": (
-          shipmentResponse,
-        ) => shipmentResponse.shipmentId === shipmentId,
-      });
-      break;
-    case "SMSOldInstant":
-      check(response, {
-        "GET old SMS instant shipment details for SMS. Status is 200 OK": (r) =>
-          r.status === 200,
-      });
-      check(JSON.parse(response.body), {
-        "GET old SMS instant shipment details for SMS. ShipmentId property is a match":
-          (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
-        "Get old SMS instant shipment details for SMS. Type is Instant": (
-          shipmentResponse,
-        ) => shipmentResponse.type === "Instant",
-      });
-      break;
-
-    case "SMSInstant":
-      check(response, {
-        "GET SMS instant shipment details for SMS. Status is 200 OK": (r) =>
-          r.status === 200,
-      });
-      check(JSON.parse(response.body), {
-        "GET SMS instant shipment details for SMS. ShipmentId property is a match":
-          (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
-        "Get SMS instant shipment details for SMS. Type is Instant": (
-          shipmentResponse,
-        ) => shipmentResponse.type === "Instant",
-      });
-      break;
-    case "EmailInstant":
-      check(response, {
-        "GET Email instant shipment details. Status is 200 OK": (r) =>
-          r.status === 200,
-      });
-      check(JSON.parse(response.body), {
-        "GET Email instant shipment details. ShipmentId property is a match": (
-          shipmentResponse,
-        ) => shipmentResponse.shipmentId === shipmentId,
-        "GET Email instant shipment details. Type is Instant": (
-          shipmentResponse,
-        ) => shipmentResponse.type === "Instant",
-      });
-      break;
-    default:
-      throw new Error(`Unknown notification type: ${type}`);
-  }
+    switch (type) {
+        case "Email":
+            check(response, {
+                "GET shipment details for Email. Status is 200 OK": (r) => r.status === 200
+            });
+            check(JSON.parse(response.body), {
+                "GET shipment details for Email. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId
+            });
+            break;
+        case "SMS":
+            check(response, {
+                "GET SMS shipment details for SMS. Status is 200 OK": (r) => r.status === 200,
+            });
+            check(JSON.parse(response.body), {
+                "GET SMS shipment details for SMS. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId
+            });
+            break;
+        case "SMSOldInstant":
+            check(response, {
+                "GET old SMS instant shipment details for SMS. Status is 200 OK": (r) => r.status === 200
+            });
+            check(JSON.parse(response.body), {
+                "GET old SMS instant shipment details for SMS. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
+                "Get old SMS instant shipment details for SMS. Type is Instant": (shipmentResponse) => shipmentResponse.type === "Instant"
+            });
+            break;
+        case "SMSInstant":
+            check(response, {
+                "GET SMS instant shipment details for SMS. Status is 200 OK": (r) => r.status === 200
+            });
+            check(JSON.parse(response.body), {
+                "GET SMS instant shipment details for SMS. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
+                "Get SMS instant shipment details for SMS. Type is Instant": (shipmentResponse) => shipmentResponse.type === "Instant"
+            });
+            break;
+        case "EmailInstant":
+            check(response, {
+                "GET Email instant shipment details. Status is 200 OK": (r) => r.status === 200
+            });
+            check(JSON.parse(response.body), {
+                "GET Email instant shipment details. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
+                "GET Email instant shipment details. Type is Instant": (shipmentResponse) => shipmentResponse.type === "Instant"
+            });
+            break;
+        default:
+            throw new Error(`Unknown notification type: ${type}`);
+    }
 }
 
 /**
@@ -426,23 +347,18 @@ export function getShipmentStatus(data, shipmentId, label, type) {
  * @description This function retrieves the status feed for notifications using the sequence number query string start position.
  */
 function getStatusFeed(data, label) {
-  const sequenceNumber = 0; // starting position for the status feed
-  const response = futureOrdersApi.getStatusFeed(
-    sequenceNumber,
-    data.token,
-    label,
-  );
+    const sequenceNumber = 0; // starting position for the status feed
+    const response = futureOrdersApi.getStatusFeed(sequenceNumber, data.token, label);
 
-  check(response, {
-    "GET status feed. Status is 200 OK": (r) => r.status === 200,
-  });
+    check(response, {
+        "GET status feed. Status is 200 OK": (r) => r.status === 200,
+    });
 
-  const body = JSON.parse(response.body);
+    const body = JSON.parse(response.body);
 
-  check(body, {
-    "GET status feed. Response body is not empty": (r) =>
-      Object.keys(r).length > 0,
-  });
+    check(body, {
+        "GET status feed. Response body is not empty": (r) => Object.keys(r).length > 0,
+    });
 }
 
 /**
@@ -450,54 +366,29 @@ function getStatusFeed(data, label) {
  * @param {Object} data - The data object containing test data.
  */
 export default function runTests(data) {
-  let response = postEmailNotificationOrderRequest(data);
-  let responseObject = JSON.parse(response);
+    let response = postEmailNotificationOrderRequest(data);
+    let responseObject = JSON.parse(response);
 
-  // checking shipment details for the email order
-  getShipmentStatus(
-    data,
-    responseObject.notification.shipmentId,
-    get_email_shipment,
-    "Email",
-  );
+    // checking shipment details for the email order
+    getShipmentStatus(data, responseObject.notification.shipmentId, get_email_shipment, "Email");
 
-  response = postSmsNotificationOrderRequest(data);
-  responseObject = JSON.parse(response);
+    response = postSmsNotificationOrderRequest(data);
+    responseObject = JSON.parse(response);
 
-  // checking shipment details for the SMS order
-  getShipmentStatus(
-    data,
-    responseObject.notification.shipmentId,
-    get_sms_shipment,
-    "SMS",
-  );
+    // checking shipment details for the SMS order
+    getShipmentStatus(data, responseObject.notification.shipmentId, get_sms_shipment, "SMS");
 
-  // testing instant SMS notification order request
-  response = postSmsInstantNotificationOrderRequest(data);
-  getShipmentStatus(
-    data,
-    JSON.parse(response).notification.shipmentId,
-    get_sms_instant_shipment,
-    "SMSInstant",
-  );
+    // testing instant SMS notification order request
+    response = postSmsInstantNotificationOrderRequest(data);
+    getShipmentStatus(data, JSON.parse(response).notification.shipmentId, get_sms_instant_shipment, "SMSInstant");
 
-  // testing old instant SMS notification order request
-  response = postSmsInstantNotificationOrderRequestOld(data);
-  getShipmentStatus(
-    data,
-    JSON.parse(response).notification.shipmentId,
-    get_sms_instant_shipment_old,
-    "SMSOldInstant",
-  );
+    // testing old instant SMS notification order request
+    response = postSmsInstantNotificationOrderRequestOld(data);
+    getShipmentStatus(data, JSON.parse(response).notification.shipmentId, get_sms_instant_shipment_old, "SMSOldInstant");
 
-  // testing instant Email notification order request
-  response = postEmailInstantNotificationOrderRequest(data);
-  getShipmentStatus(
-    data,
-    JSON.parse(response).notification.shipmentId,
-    get_email_instant_shipment,
-    "EmailInstant",
-  );
+    // testing instant Email notification order request
+    response = postEmailInstantNotificationOrderRequest(data);
+    getShipmentStatus(data, JSON.parse(response).notification.shipmentId, get_email_instant_shipment, "EmailInstant");
 
-  getStatusFeed(data, get_status_feed);
+    getStatusFeed(data, get_status_feed);
 }

--- a/components/api/test/k6/src/tests/orders-v2.js
+++ b/components/api/test/k6/src/tests/orders-v2.js
@@ -30,106 +30,173 @@ import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 import * as setupToken from "../setup.js";
 import * as futureOrdersApi from "../api/notifications/v2.js";
 import {
-    post_sms_order_v2, post_sms_instant_order_v2, post_email_order_v2,
-    setEmptyThresholds, get_email_shipment, get_sms_shipment,
-    get_sms_instant_shipment, get_email_instant_shipment, get_status_feed,
-    post_email_instant_order_v2
+  post_sms_order_v2,
+  post_sms_instant_order_v2,
+  post_sms_instant_order_old_v2,
+  post_email_order_v2,
+  setEmptyThresholds,
+  get_email_shipment,
+  get_sms_shipment,
+  get_sms_instant_shipment,
+  get_email_instant_shipment,
+  get_status_feed,
+  post_email_instant_order_v2,
 } from "./threshold-labels.js";
 import { scopes } from "../shared/variables.js";
 import { getEmailRecipient, getSmsRecipient } from "../shared/functions.js";
 
-const labels = [post_email_order_v2, post_sms_order_v2, post_sms_instant_order_v2, post_email_instant_order_v2, get_email_shipment, get_sms_shipment, get_status_feed];
+const labels = [
+  post_email_order_v2,
+  post_sms_order_v2,
+  post_sms_instant_order_v2,
+  post_sms_instant_order_old_v2,
+  post_email_instant_order_v2,
+  get_email_shipment,
+  get_sms_shipment,
+  get_status_feed,
+];
 
 const emailOrderRequestJson = JSON.parse(
-    open("../data/orders/order-v2-email.json")
+  open("../data/orders/order-v2-email.json"),
 );
 const smsOrderRequestJson = JSON.parse(
-    open("../data/orders/order-v2-sms.json")
+  open("../data/orders/order-v2-sms.json"),
 );
 const smsOrderInstantRequestJson = JSON.parse(
-    open("../data/orders/order-v2-sms-instant.json")
+  open("../data/orders/order-v2-sms-instant.json"),
 );
+const smsOrderInstantRequestOldJson = JSON.parse(
+  open("../data/orders/order-v2-sms-instant-old.json"),
+);
+
 const emailOrderInstantRequestJson = JSON.parse(
-    open("../data/orders/order-v2-email-instant.json")
+  open("../data/orders/order-v2-email-instant.json"),
 );
 
 export const options = {
-    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(95)', 'p(99)', 'p(99.5)', 'p(99.9)', 'count'],
-    thresholds: {
-        // Checks rate should be 100%. Raise error if any check has failed.
-        checks: ['rate>=1']
-    }
+  summaryTrendStats: [
+    "avg",
+    "min",
+    "med",
+    "max",
+    "p(95)",
+    "p(99)",
+    "p(99.5)",
+    "p(99.9)",
+    "count",
+  ],
+  thresholds: {
+    // Checks rate should be 100%. Raise error if any check has failed.
+    checks: ["rate>=1"],
+  },
 };
 setEmptyThresholds(labels, options);
 
 /**
  * Initialize test data.
  * @returns {Object} The data object containing token, sendersReference, and emailOrderRequest.
-*/
+ */
 export function setup() {
-    const emailRecipient = getEmailRecipient();
-    const smsRecipient = getSmsRecipient();
+  const emailRecipient = getEmailRecipient();
+  const smsRecipient = getSmsRecipient();
 
-    // used with notification email orders if applicable
-    const ninRecipient = __ENV.ninRecipient ? __ENV.ninRecipient.toLowerCase() : null;
+  // used with notification email orders if applicable
+  const ninRecipient = __ENV.ninRecipient
+    ? __ENV.ninRecipient.toLowerCase()
+    : null;
 
-    const token = setupToken.getAltinnTokenForOrg(scopes);
-    const idempotencyIdEmail = uuidv4();
-    const idempotencyIdSms = uuidv4();
-    const sendersReference = uuidv4();
+  const token = setupToken.getAltinnTokenForOrg(scopes);
+  const idempotencyIdEmail = uuidv4();
+  const idempotencyIdSms = uuidv4();
+  const sendersReference = uuidv4();
 
-    if (emailRecipient == null) {
-        // unset recipientEmail object when no email recipient is provided
-        emailOrderRequestJson.recipient["recipientEmail"] = undefined;
-    }
-    else {
-        emailOrderRequestJson.recipient.recipientEmail.emailAddress = emailRecipient;
-    }
+  if (emailRecipient == null) {
+    // unset recipientEmail object when no email recipient is provided
+    emailOrderRequestJson.recipient["recipientEmail"] = undefined;
+  } else {
+    emailOrderRequestJson.recipient.recipientEmail.emailAddress =
+      emailRecipient;
+  }
 
-    if (ninRecipient == null) {
-        // unset recipientPerson object when no national identity number is provided
-        emailOrderRequestJson.recipient["recipientPerson"] = undefined;
-    }
-    else {
-        emailOrderRequestJson.recipient.recipientPerson.nationalIdentityNumber = ninRecipient;
-    }
+  if (ninRecipient == null) {
+    // unset recipientPerson object when no national identity number is provided
+    emailOrderRequestJson.recipient["recipientPerson"] = undefined;
+  } else {
+    emailOrderRequestJson.recipient.recipientPerson.nationalIdentityNumber =
+      ninRecipient;
+  }
 
-    if (smsRecipient != null) {
-        smsOrderRequestJson.recipient.recipientSms.phoneNumber = smsRecipient;
-    }
+  if (smsRecipient != null) {
+    smsOrderRequestJson.recipient.recipientSms.phoneNumber = smsRecipient;
+  }
 
-    const emailOrderRequest = { ...emailOrderRequestJson, idempotencyId: idempotencyIdEmail };
+  // needed for instant notifications
+  if (!smsRecipient) {
+    stopIterationOnFail(
+      "smsRecipient is required for SMS instant orders — set the 'smsRecipient' env var",
+      false,
+    );
+  }
 
-    const smsOrderRequest = { ...smsOrderRequestJson, idempotencyId: idempotencyIdSms, sendersReference };
+  if (!emailRecipient) {
+    stopIterationOnFail(
+      "emailRecipient is required for email instant orders — set the 'emailRecipient' env var",
+      false,
+    );
+  }
 
-    const smsOrderInstantRequest = {
-        ...smsOrderInstantRequestJson,
-        idempotencyId: uuidv4(),
-        sendersReference,
-        recipientSms: {
-            ...smsOrderInstantRequestJson.recipientSms,
-            phoneNumber: smsRecipient
-        }
-    };
+  const emailOrderRequest = {
+    ...emailOrderRequestJson,
+    idempotencyId: idempotencyIdEmail,
+  };
 
-    const emailOrderInstantRequest = {
-        ...emailOrderInstantRequestJson,
-        idempotencyId: uuidv4(),
-        sendersReference,
-        recipientEmail: {
-            ...emailOrderInstantRequestJson.recipientEmail,
-            emailAddress: emailRecipient
-        }
-    };
+  const smsOrderRequest = {
+    ...smsOrderRequestJson,
+    idempotencyId: idempotencyIdSms,
+    sendersReference,
+  };
 
-    return {
-        token,
-        sendersReference,
-        emailOrderRequest,
-        smsOrderRequest,
-        smsOrderInstantRequest,
-        emailOrderInstantRequest
-    };
+  const smsOrderInstantOldRequest = {
+    ...smsOrderInstantRequestOldJson,
+    idempotencyId: uuidv4(),
+    sendersReference,
+    recipient: {
+      ...smsOrderInstantRequestOldJson.recipient,
+      recipientSms: {
+        ...smsOrderInstantRequestOldJson.recipient.recipientSms,
+        phoneNumber: smsRecipient,
+      },
+    },
+  };
+
+  const smsOrderInstantRequest = {
+    ...smsOrderInstantRequestJson,
+    idempotencyId: uuidv4(),
+    sendersReference,
+    recipientSms: {
+      ...smsOrderInstantRequestJson.recipientSms,
+      phoneNumber: smsRecipient,
+    },
+  };
+  const emailOrderInstantRequest = {
+    ...emailOrderInstantRequestJson,
+    idempotencyId: uuidv4(),
+    sendersReference,
+    recipientEmail: {
+      ...emailOrderInstantRequestJson.recipientEmail,
+      emailAddress: emailRecipient,
+    },
+  };
+
+  return {
+    token,
+    sendersReference,
+    emailOrderRequest,
+    smsOrderRequest,
+    smsOrderInstantRequest,
+    smsOrderInstantOldRequest,
+    emailOrderInstantRequest,
+  };
 }
 
 /**
@@ -138,25 +205,27 @@ export function setup() {
  * @returns {string} The response body of the created order.
  */
 function postEmailNotificationOrderRequest(data) {
-    const response = futureOrdersApi.postNotificationOrderV2(
-        JSON.stringify(data.emailOrderRequest),
-        data.token,
-        post_email_order_v2
-    );
+  const response = futureOrdersApi.postNotificationOrderV2(
+    JSON.stringify(data.emailOrderRequest),
+    data.token,
+    post_email_order_v2,
+  );
 
-    const success = check(response, {
-        "POST email notification order request. Status is 201 Created": (r) => r.status === 201
-    });
+  const success = check(response, {
+    "POST email notification order request. Status is 201 Created": (r) =>
+      r.status === 201,
+  });
 
-    stopIterationOnFail("POST email notification order request failed", success);
+  stopIterationOnFail("POST email notification order request failed", success);
 
-    const selfLink = response.headers["Location"];
+  const selfLink = response.headers["Location"];
 
-    check(response, {
-        "POST email notification order request. Location header provided": (_) => selfLink,
-    });
+  check(response, {
+    "POST email notification order request. Location header provided": (_) =>
+      selfLink,
+  });
 
-    return response.body;
+  return response.body;
 }
 
 /**
@@ -165,28 +234,30 @@ function postEmailNotificationOrderRequest(data) {
  * @returns {string} The response body of the created order.
  */
 function postSmsNotificationOrderRequest(data) {
-    const response = futureOrdersApi.postNotificationOrderV2(
-        JSON.stringify(data.smsOrderRequest),
-        data.token,
-        post_sms_order_v2
-    );
+  const response = futureOrdersApi.postNotificationOrderV2(
+    JSON.stringify(data.smsOrderRequest),
+    data.token,
+    post_sms_order_v2,
+  );
 
-    const success = check(response, {
-        "POST SMS notification order request. Status is 201 Created": (r) => r.status === 201
-    });
+  const success = check(response, {
+    "POST SMS notification order request. Status is 201 Created": (r) =>
+      r.status === 201,
+  });
 
-    stopIterationOnFail("POST SMS notification order request failed", success);
+  stopIterationOnFail("POST SMS notification order request failed", success);
 
-    const selfLink = response.headers["Location"];
+  const selfLink = response.headers["Location"];
 
-    check(response, {
-        "POST SMS notification order request. Location header provided": (_) => selfLink,
-        "POST SMS notification order request. Response body is not an empty string": (r) => r.body
-    });
+  check(response, {
+    "POST SMS notification order request. Location header provided": (_) =>
+      selfLink,
+    "POST SMS notification order request. Response body is not an empty string":
+      (r) => r.body,
+  });
 
-    return response.body;
+  return response.body;
 }
-
 
 /**
  * Post instant SMS notification order request using the v2 API.
@@ -194,22 +265,48 @@ function postSmsNotificationOrderRequest(data) {
  * @returns
  */
 function postSmsInstantNotificationOrderRequest(data) {
-    const response = futureOrdersApi.postSmsInstantNotificationOrderRequest(
-        JSON.stringify(data.smsOrderInstantRequest),
-        data.token,
-        post_sms_instant_order_v2
-    );
+  const response = futureOrdersApi.postSmsInstantNotificationOrderRequest(
+    JSON.stringify(data.smsOrderInstantRequest),
+    data.token,
+    post_sms_instant_order_v2,
+  );
 
-    const success = check(response, {
-        "POST SMS instant notification order request. Status is 201 Created": (r) => r.status === 201,
-        "POST SMS instant notification order request. Response body contains shipmentId": (r) => JSON.parse(r.body).notification.shipmentId !== undefined
-    });
+  const success = check(response, {
+    "POST SMS instant notification order request. Status is 201 Created": (r) =>
+      r.status === 201,
+    "POST SMS instant notification order request. Response body contains shipmentId":
+      (r) => JSON.parse(r.body).notification.shipmentId !== undefined,
+  });
 
-    stopIterationOnFail("POST SMS instant notification order request failed", success);
+  stopIterationOnFail(
+    "POST SMS instant notification order request failed",
+    success,
+  );
 
-    return response.body;
+  return response.body;
 }
+function postSmsInstantNotificationOrderRequestOld(data) {
+  const response = futureOrdersApi.postSmsInstantNotificationOrderRequestOld(
+    JSON.stringify(data.smsOrderInstantOldRequest),
+    data.token,
+    post_sms_instant_order_v2,
+  );
 
+  const success = check(response, {
+    "POST old SMS instant notification order request. Status is 201 Created": (
+      r,
+    ) => r.status === 201,
+    "POST old SMS instant notification order request. Response body contains shipmentId":
+      (r) => JSON.parse(r.body).notification.shipmentId !== undefined,
+  });
+
+  stopIterationOnFail(
+    "POST old SMS instant notification order request failed",
+    success,
+  );
+
+  return response.body;
+}
 
 /**
  * Post instant Email notification order request using the v2 API.
@@ -217,22 +314,27 @@ function postSmsInstantNotificationOrderRequest(data) {
  * @returns
  */
 function postEmailInstantNotificationOrderRequest(data) {
-    const response = futureOrdersApi.postEmailInstantNotificationOrderRequest(
-        JSON.stringify(data.emailOrderInstantRequest),
-        data.token,
-        post_email_instant_order_v2
-    );
+  const response = futureOrdersApi.postEmailInstantNotificationOrderRequest(
+    JSON.stringify(data.emailOrderInstantRequest),
+    data.token,
+    post_email_instant_order_v2,
+  );
 
-    const success = check(response, {
-        "POST Email instant notification order request. Status is 201 Created": (r) => r.status === 201,
-        "POST Email instant notification order request. Response body contains shipmentId": (r) => JSON.parse(r.body).notification.shipmentId !== undefined
-    });
+  const success = check(response, {
+    "POST Email instant notification order request. Status is 201 Created": (
+      r,
+    ) => r.status === 201,
+    "POST Email instant notification order request. Response body contains shipmentId":
+      (r) => JSON.parse(r.body).notification.shipmentId !== undefined,
+  });
 
-    stopIterationOnFail("POST Email instant notification order request failed", success);
+  stopIterationOnFail(
+    "POST Email instant notification order request failed",
+    success,
+  );
 
-    return response.body;
+  return response.body;
 }
-
 
 /**
  * Gets the notification shipment status for email or SMS.
@@ -242,46 +344,75 @@ function postEmailInstantNotificationOrderRequest(data) {
  * @param {string} type - The type of notification (e.g., "Email" or "SMS").
  */
 export function getShipmentStatus(data, shipmentId, label, type) {
-    const response = futureOrdersApi.getShipment(shipmentId, data.token, label);
+  const response = futureOrdersApi.getShipment(shipmentId, data.token, label);
 
-    switch (type) {
-        case "Email":
-            check(response, {
-                "GET shipment details for Email. Status is 200 OK": (r) => r.status === 200
-            });
-            check(JSON.parse(response.body), {
-                "GET shipment details for Email. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId
-            });
-            break;
-        case "SMS":
-            check(response, {
-                "GET SMS shipment details for SMS. Status is 200 OK": (r) => r.status === 200,
-            });
-            check(JSON.parse(response.body), {
-                "GET SMS shipment details for SMS. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId
-            });
-            break;
-        case "SMSInstant":
-            check(response, {
-                "GET SMS instant shipment details for SMS. Status is 200 OK": (r) => r.status === 200
-            });
-            check(JSON.parse(response.body), {
-                "GET SMS instant shipment details for SMS. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
-                "Get SMS instant shipment details for SMS. Type is Instant": (shipmentResponse) => shipmentResponse.type === "Instant"
-            });
-            break;
-        case "EmailInstant":
-            check(response, {
-                "GET Email instant shipment details. Status is 200 OK": (r) => r.status === 200
-            });
-            check(JSON.parse(response.body), {
-                "GET Email instant shipment details. ShipmentId property is a match": (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
-                "GET Email instant shipment details. Type is Instant": (shipmentResponse) => shipmentResponse.type === "Instant"
-            });
-            break;
-        default:
-            throw new Error(`Unknown notification type: ${type}`);
-    }
+  switch (type) {
+    case "Email":
+      check(response, {
+        "GET shipment details for Email. Status is 200 OK": (r) =>
+          r.status === 200,
+      });
+      check(JSON.parse(response.body), {
+        "GET shipment details for Email. ShipmentId property is a match": (
+          shipmentResponse,
+        ) => shipmentResponse.shipmentId === shipmentId,
+      });
+      break;
+    case "SMS":
+      check(response, {
+        "GET SMS shipment details for SMS. Status is 200 OK": (r) =>
+          r.status === 200,
+      });
+      check(JSON.parse(response.body), {
+        "GET SMS shipment details for SMS. ShipmentId property is a match": (
+          shipmentResponse,
+        ) => shipmentResponse.shipmentId === shipmentId,
+      });
+      break;
+    case "SMSOldInstant":
+      check(response, {
+        "GET old SMS instant shipment details for SMS. Status is 200 OK": (r) =>
+          r.status === 200,
+      });
+      check(JSON.parse(response.body), {
+        "GET old SMS instant shipment details for SMS. ShipmentId property is a match":
+          (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
+        "Get old SMS instant shipment details for SMS. Type is Instant": (
+          shipmentResponse,
+        ) => shipmentResponse.type === "Instant",
+      });
+      break;
+
+    case "SMSInstant":
+      check(response, {
+        "GET SMS instant shipment details for SMS. Status is 200 OK": (r) =>
+          r.status === 200,
+      });
+      check(JSON.parse(response.body), {
+        "GET SMS instant shipment details for SMS. ShipmentId property is a match":
+          (shipmentResponse) => shipmentResponse.shipmentId === shipmentId,
+        "Get SMS instant shipment details for SMS. Type is Instant": (
+          shipmentResponse,
+        ) => shipmentResponse.type === "Instant",
+      });
+      break;
+    case "EmailInstant":
+      check(response, {
+        "GET Email instant shipment details. Status is 200 OK": (r) =>
+          r.status === 200,
+      });
+      check(JSON.parse(response.body), {
+        "GET Email instant shipment details. ShipmentId property is a match": (
+          shipmentResponse,
+        ) => shipmentResponse.shipmentId === shipmentId,
+        "GET Email instant shipment details. Type is Instant": (
+          shipmentResponse,
+        ) => shipmentResponse.type === "Instant",
+      });
+      break;
+    default:
+      throw new Error(`Unknown notification type: ${type}`);
+  }
 }
 
 /**
@@ -291,18 +422,23 @@ export function getShipmentStatus(data, shipmentId, label, type) {
  * @description This function retrieves the status feed for notifications using the sequence number query string start position.
  */
 function getStatusFeed(data, label) {
-    const sequenceNumber = 0; // starting position for the status feed
-    const response = futureOrdersApi.getStatusFeed(sequenceNumber, data.token, label);
+  const sequenceNumber = 0; // starting position for the status feed
+  const response = futureOrdersApi.getStatusFeed(
+    sequenceNumber,
+    data.token,
+    label,
+  );
 
-    check(response, {
-        "GET status feed. Status is 200 OK": (r) => r.status === 200,
-    });
+  check(response, {
+    "GET status feed. Status is 200 OK": (r) => r.status === 200,
+  });
 
-    const body = JSON.parse(response.body);
+  const body = JSON.parse(response.body);
 
-    check(body, {
-        "GET status feed. Response body is not empty": (r) => Object.keys(r).length > 0,
-    });
+  check(body, {
+    "GET status feed. Response body is not empty": (r) =>
+      Object.keys(r).length > 0,
+  });
 }
 
 /**
@@ -310,25 +446,54 @@ function getStatusFeed(data, label) {
  * @param {Object} data - The data object containing test data.
  */
 export default function runTests(data) {
-    let response = postEmailNotificationOrderRequest(data);
-    let responseObject = JSON.parse(response);
+  let response = postEmailNotificationOrderRequest(data);
+  let responseObject = JSON.parse(response);
 
-    // checking shipment details for the email order
-    getShipmentStatus(data, responseObject.notification.shipmentId, get_email_shipment, "Email");
+  // checking shipment details for the email order
+  getShipmentStatus(
+    data,
+    responseObject.notification.shipmentId,
+    get_email_shipment,
+    "Email",
+  );
 
-    response = postSmsNotificationOrderRequest(data);
-    responseObject = JSON.parse(response);
+  response = postSmsNotificationOrderRequest(data);
+  responseObject = JSON.parse(response);
 
-    // checking shipment details for the SMS order
-    getShipmentStatus(data, responseObject.notification.shipmentId, get_sms_shipment, "SMS");
+  // checking shipment details for the SMS order
+  getShipmentStatus(
+    data,
+    responseObject.notification.shipmentId,
+    get_sms_shipment,
+    "SMS",
+  );
 
-    // testing instant SMS notification order request
-    response = postSmsInstantNotificationOrderRequest(data);
-    getShipmentStatus(data, JSON.parse(response).notification.shipmentId, get_sms_instant_shipment, "SMSInstant");
+  // testing instant SMS notification order request
+  response = postSmsInstantNotificationOrderRequest(data);
+  getShipmentStatus(
+    data,
+    JSON.parse(response).notification.shipmentId,
+    get_sms_instant_shipment,
+    "SMSInstant",
+  );
 
-    // testing instant Email notification order request
-    response = postEmailInstantNotificationOrderRequest(data);
-    getShipmentStatus(data, JSON.parse(response).notification.shipmentId, get_email_instant_shipment, "EmailInstant");
+  // testing old instant SMS notification order request
+  response = postSmsInstantNotificationOrderRequestOld(data);
+  getShipmentStatus(
+    data,
+    JSON.parse(response).notification.shipmentId,
+    get_sms_instant_shipment,
+    "SMSOldInstant",
+  );
 
-    getStatusFeed(data, get_status_feed);
+  // testing instant Email notification order request
+  response = postEmailInstantNotificationOrderRequest(data);
+  getShipmentStatus(
+    data,
+    JSON.parse(response).notification.shipmentId,
+    get_email_instant_shipment,
+    "EmailInstant",
+  );
+
+  getStatusFeed(data, get_status_feed);
 }

--- a/components/api/test/k6/src/tests/orders-v2.js
+++ b/components/api/test/k6/src/tests/orders-v2.js
@@ -97,11 +97,12 @@ export function setup() {
 
 
 
-    //can only have one active recipient
-    if (ninRecipient != null && !emailRecipient) {
+    // non-instant supports NIN lookup; prefer it over direct email when provided
+    if (ninRecipient != null) {
         emailOrderRequestJson.recipient.recipientPerson.nationalIdentityNumber = ninRecipient;
-    } else {
-          // unset recipientPerson object when no national identity number is provided
+        emailOrderRequestJson.recipient["recipientEmail"] = undefined;
+    }
+    else {
         emailOrderRequestJson.recipient["recipientPerson"] = undefined;
     }
 

--- a/components/api/test/k6/src/tests/threshold-labels.js
+++ b/components/api/test/k6/src/tests/threshold-labels.js
@@ -13,6 +13,10 @@ export const get_email_shipment = "get_email_shipment";
 export const get_sms_instant_shipment = "get_sms_instant_shipment";
 export const post_sms_instant_order_v2 = "post_sms_instant_order_v2";
 
+export const get_email_instant_shipment = "get_email_instant_shipment";
+export const post_email_instant_order_v2 = "post_email_instant_order_v2";
+
+
 export const get_status_feed = "get_status_feed";
 
 export const post_valid_order = "post_valid_order";
@@ -26,8 +30,8 @@ export const post_order_without_resource_id = "post_order_without_resource_id";
  * @param {object} options - Options object containing thresholds configuration
  */
 export function setEmptyThresholds(labels, options) {
-    for (const label of labels) {
-        options.thresholds[`http_reqs{name:${label}}`] = [];
-        options.thresholds[`http_req_duration{name:${label}}`] = [];
-    }
+  for (const label of labels) {
+    options.thresholds[`http_reqs{name:${label}}`] = [];
+    options.thresholds[`http_req_duration{name:${label}}`] = [];
+  }
 }

--- a/components/api/test/k6/src/tests/threshold-labels.js
+++ b/components/api/test/k6/src/tests/threshold-labels.js
@@ -13,6 +13,9 @@ export const get_email_shipment = "get_email_shipment";
 export const get_sms_instant_shipment = "get_sms_instant_shipment";
 export const post_sms_instant_order_v2 = "post_sms_instant_order_v2";
 
+export const get_sms_instant_shipment_old = "get_sms_instant_shipment";
+export const post_sms_instant_order_old_v2 = "post_sms_instant_order_old_v2";
+
 export const get_email_instant_shipment = "get_email_instant_shipment";
 export const post_email_instant_order_v2 = "post_email_instant_order_v2";
 
@@ -29,8 +32,8 @@ export const post_order_without_resource_id = "post_order_without_resource_id";
  * @param {object} options - Options object containing thresholds configuration
  */
 export function setEmptyThresholds(labels, options) {
-    for (const label of labels) {
-        options.thresholds[`http_reqs{name:${label}}`] = [];
-        options.thresholds[`http_req_duration{name:${label}}`] = [];
-    }
+  for (const label of labels) {
+    options.thresholds[`http_reqs{name:${label}}`] = [];
+    options.thresholds[`http_req_duration{name:${label}}`] = [];
+  }
 }

--- a/components/api/test/k6/src/tests/threshold-labels.js
+++ b/components/api/test/k6/src/tests/threshold-labels.js
@@ -16,7 +16,6 @@ export const post_sms_instant_order_v2 = "post_sms_instant_order_v2";
 export const get_email_instant_shipment = "get_email_instant_shipment";
 export const post_email_instant_order_v2 = "post_email_instant_order_v2";
 
-
 export const get_status_feed = "get_status_feed";
 
 export const post_valid_order = "post_valid_order";
@@ -30,8 +29,8 @@ export const post_order_without_resource_id = "post_order_without_resource_id";
  * @param {object} options - Options object containing thresholds configuration
  */
 export function setEmptyThresholds(labels, options) {
-  for (const label of labels) {
-    options.thresholds[`http_reqs{name:${label}}`] = [];
-    options.thresholds[`http_req_duration{name:${label}}`] = [];
-  }
+    for (const label of labels) {
+        options.thresholds[`http_reqs{name:${label}}`] = [];
+        options.thresholds[`http_req_duration{name:${label}}`] = [];
+    }
 }

--- a/components/api/test/k6/src/tests/threshold-labels.js
+++ b/components/api/test/k6/src/tests/threshold-labels.js
@@ -13,7 +13,7 @@ export const get_email_shipment = "get_email_shipment";
 export const get_sms_instant_shipment = "get_sms_instant_shipment";
 export const post_sms_instant_order_v2 = "post_sms_instant_order_v2";
 
-export const get_sms_instant_shipment_old = "get_sms_instant_shipment";
+export const get_sms_instant_shipment_old = "get_sms_instant_shipment_old";
 export const post_sms_instant_order_old_v2 = "post_sms_instant_order_old_v2";
 
 export const get_email_instant_shipment = "get_email_instant_shipment";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
  - Fixed the SMS instant notification endpoint to use the channel-specific     
  route (/instant/sms)
  - Added support for email instant notification orders, including test data,   
  API client function, threshold labels
  - Updated the SMS instant order payload structure




## Related Issue(s)
- #1439 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded API test coverage to include instant email and an older instant-SMS flow, with new scenarios, labels and stronger posting and shipment-status validations.
* **Chores**
  * Added new test fixtures and updated test data shapes to support the new instant variants.
* **Chores**
  * CI workflows updated to pass an email-recipient environment flag to the API test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->