### PR TITLE
Fix shared test infra test discovery error

### DIFF
--- a/components/shared/test/Altinn.Notifications.Shared.TestInfrastructure/Altinn.Notifications.Shared.TestInfrastructure.csproj
+++ b/components/shared/test/Altinn.Notifications.Shared.TestInfrastructure/Altinn.Notifications.Shared.TestInfrastructure.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTestProject>false</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>

--- a/components/shared/test/Altinn.Notifications.Shared.TestInfrastructure/Altinn.Notifications.Shared.TestInfrastructure.csproj
+++ b/components/shared/test/Altinn.Notifications.Shared.TestInfrastructure/Altinn.Notifications.Shared.TestInfrastructure.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <IsTestProject>false</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
@@ -17,6 +16,7 @@
     <PackageReference Include="Npgsql" Version="10.0.2" />
     <PackageReference Include="Testcontainers" Version="4.11.0" />
     <PackageReference Include="WolverineFx" Version="5.27.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In VS Code we currently get a popup "[error] Test discovery was aborted" when the C# extensions start up. The root cause is that the `Altinn.Notifications.Shared.TestInfrastructure` project has test infrastruture files that import `Xunit`, despite not having any defined tests in itself. This leads to a misclassification and ultimately an error message when there are no tests to be discovered. 

This PR fixes this problem by including the `Microsoft.NET.Test.Sdk` package reference in the csproj of this namespace. This will provide the `testhost.dll` needed to stop test discovery from crashing.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal infrastructure configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->