### PR TITLE
OpenAPI changes for altinn-studio-docs

### DIFF
--- a/docs/swagger_transforms/transform.jq
+++ b/docs/swagger_transforms/transform.jq
@@ -7,7 +7,7 @@
 | .servers |= map(select(.url | contains("localhost") | not))
 | .servers |= map(.url |= sub("altinn.no/"; "altinn.no/notifications/api/v1"))
 | del(.paths."/tests/sendcondition")
-| del(.paths."/metrics")
+| del(.paths."/metrics", .paths."/metrics/sms", .paths."/metrics/email")
 | del(.tags)
 | .tags += [{"name": "Deprecated", "description": "Legacy endpoints. Still supported, but going forward please use '/future/*' endpoints instead."}]
 | .tags += [{"name": "Order", "description": "Create notifications (queued processing)"}]


### PR DESCRIPTION
- Clarify resourceId URN-format in the property description
 - Extend transform.jq to delete new/upcoming operations on "metrics/sms"  and "../email"

Related Issue(s)
- #1466
- #1479