### PR TITLE
resourceId - tighten validation and show URN format as OpenAPI 'pattern'

### DIFF
--- a/components/api/src/Altinn.Notifications/Models/Recipient/RecipientBaseExt.cs
+++ b/components/api/src/Altinn.Notifications/Models/Recipient/RecipientBaseExt.cs
@@ -56,6 +56,7 @@ public abstract class RecipientBaseExt
     /// </summary>
     /// <example>urn:altinn:resource:org_example_app</example>
     [JsonPropertyName("resourceId")]
+    [RegularExpression("^urn:altinn:resource.+$")]
     public string? ResourceId { get; set; }
 
     /// <summary>

--- a/components/api/src/Altinn.Notifications/Models/Recipient/RecipientBaseExt.cs
+++ b/components/api/src/Altinn.Notifications/Models/Recipient/RecipientBaseExt.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 
 using Altinn.Notifications.Models.Email;
 using Altinn.Notifications.Models.Sms;
+using Altinn.Notifications.Swagger;
 
 namespace Altinn.Notifications.Models.Recipient;
 
@@ -56,7 +57,7 @@ public abstract class RecipientBaseExt
     /// </summary>
     /// <example>urn:altinn:resource:org_example_app</example>
     [JsonPropertyName("resourceId")]
-    [RegularExpression("^urn:altinn:resource.+$")]
+    [OpenApiPattern("^urn:altinn:resource:.+$")]
     public string? ResourceId { get; set; }
 
     /// <summary>

--- a/components/api/src/Altinn.Notifications/Program.cs
+++ b/components/api/src/Altinn.Notifications/Program.cs
@@ -70,14 +70,14 @@ builder.Services.AddSwaggerGen(options =>
     });
 
     IncludeXmlComments(options);
-    
+
     options.EnableAnnotations();
     options.UseInlineDefinitionsForEnums();
-    options.SchemaFilter<SwaggerDefaultValues>();
+    options.SchemaFilter<OpenApiSchemaEnrichmentFilter>();
     options.OperationFilter<AddResponseHeadersFilter>();
-    
+
     options.ExampleFilters();
-    
+
     options.AddServer(new OpenApiServer()
     {
         Url = "https://platform.tt02.altinn.no/",
@@ -229,7 +229,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration config)
     services.AddAuthorizationService(config);
     services.AddKafkaServices(config);
     services.AddWolverineServices(config, builder.Environment);
-    
+
     services.AddAltinnClients(config);
     services.AddPostgresRepositories(config);
 }

--- a/components/api/src/Altinn.Notifications/Swagger/OpenApiPatternAttribute.cs
+++ b/components/api/src/Altinn.Notifications/Swagger/OpenApiPatternAttribute.cs
@@ -3,14 +3,14 @@ using System.Diagnostics.CodeAnalysis;
 namespace Altinn.Notifications.Swagger;
 
 /// <summary>
-/// A non-validating attribute that communicates a pattern constraint  
+/// A non-validating attribute that communicates the pattern constraint for a OpenAPI schema property
 /// </summary>
 [ExcludeFromCodeCoverage]
 [AttributeUsage(AttributeTargets.Property)]
 public class OpenApiPatternAttribute(string pattern) : Attribute
 {
     /// <summary>
-    /// The property's pattern attribute
+    /// The regex pattern of the property
     /// </summary>
     public string Pattern { get; } = pattern;
 }

--- a/components/api/src/Altinn.Notifications/Swagger/OpenApiPatternAttribute.cs
+++ b/components/api/src/Altinn.Notifications/Swagger/OpenApiPatternAttribute.cs
@@ -1,0 +1,16 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Altinn.Notifications.Swagger;
+
+/// <summary>
+/// A non-validating attribute that communicates a pattern constraint  
+/// </summary>
+[ExcludeFromCodeCoverage]
+[AttributeUsage(AttributeTargets.Property)]
+public class OpenApiPatternAttribute(string pattern) : Attribute
+{
+    /// <summary>
+    /// The property's pattern attribute
+    /// </summary>
+    public string Pattern { get; } = pattern;
+}

--- a/components/api/src/Altinn.Notifications/Swagger/OpenApiSchemaEnrichmentFilter.cs
+++ b/components/api/src/Altinn.Notifications/Swagger/OpenApiSchemaEnrichmentFilter.cs
@@ -61,7 +61,7 @@ public class OpenApiSchemaEnrichmentFilter : ISchemaFilter
         }
     }
 
-    private T? GetAttribute<T>(SchemaFilterContext context)
+    private static T? GetAttribute<T>(SchemaFilterContext context)
     {
         return context.MemberInfo.GetCustomAttributes(typeof(T), true)
             .OfType<T>()

--- a/components/api/src/Altinn.Notifications/Swagger/OpenApiSchemaEnrichmentFilter.cs
+++ b/components/api/src/Altinn.Notifications/Swagger/OpenApiSchemaEnrichmentFilter.cs
@@ -29,20 +29,14 @@ public class OpenApiSchemaEnrichmentFilter : ISchemaFilter
             return;
         }
 
-        var patternAttr = context.MemberInfo
-            .GetCustomAttributes(typeof(OpenApiPatternAttribute), true)
-            .OfType<OpenApiPatternAttribute>()
-            .FirstOrDefault();
+        var patternAttr = GetAttribute<OpenApiPatternAttribute>(context);
 
         if (patternAttr != null)
         {
             openApiSchema.Pattern = patternAttr.Pattern;
         }
 
-        var defaultValue = context.MemberInfo
-            .GetCustomAttributes(typeof(DefaultValueAttribute), true)
-            .OfType<DefaultValueAttribute>()
-            .FirstOrDefault();
+        var defaultValue = GetAttribute<DefaultValueAttribute>(context);
 
         if (defaultValue == null || schema.Default != null)
         {
@@ -65,5 +59,12 @@ public class OpenApiSchemaEnrichmentFilter : ISchemaFilter
         {
             openApiSchema.Default = stringValue;
         }
+    }
+
+    private T? GetAttribute<T>(SchemaFilterContext context)
+    {
+        return context.MemberInfo.GetCustomAttributes(typeof(T), true)
+            .OfType<T>()
+            .FirstOrDefault();
     }
 }

--- a/components/api/src/Altinn.Notifications/Swagger/OpenApiSchemaEnrichmentFilter.cs
+++ b/components/api/src/Altinn.Notifications/Swagger/OpenApiSchemaEnrichmentFilter.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.OpenApi;
@@ -8,13 +8,13 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 namespace Altinn.Notifications.Swagger;
 
 /// <summary>
-/// Schema filter to properly handle default values in Swagger.
+/// Schema filter that enriches OpenAPI schemas with pattern constraints and default values.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class SwaggerDefaultValues : ISchemaFilter
+public class OpenApiSchemaEnrichmentFilter : ISchemaFilter
 {
     /// <summary>
-    /// Applies default value handling to the schema
+    /// Applies pattern constraints and default value handling to the schema.
     /// </summary>
     public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {

--- a/components/api/src/Altinn.Notifications/Swagger/SwaggerDefaultValues.cs
+++ b/components/api/src/Altinn.Notifications/Swagger/SwaggerDefaultValues.cs
@@ -23,18 +23,28 @@ public class SwaggerDefaultValues : ISchemaFilter
             return;
         }
 
+        // Cast to concrete OpenApiSchema to access settable properties
+        if (schema is not OpenApiSchema openApiSchema)
+        {
+            return;
+        }
+
+        var patternAttr = context.MemberInfo
+            .GetCustomAttributes(typeof(OpenApiPatternAttribute), true)
+            .OfType<OpenApiPatternAttribute>()
+            .FirstOrDefault();
+
+        if (patternAttr != null)
+        {
+            openApiSchema.Pattern = patternAttr.Pattern;
+        }
+
         var defaultValue = context.MemberInfo
             .GetCustomAttributes(typeof(DefaultValueAttribute), true)
             .OfType<DefaultValueAttribute>()
             .FirstOrDefault();
 
         if (defaultValue == null || schema.Default != null)
-        {
-            return;
-        }
-
-        // Cast to concrete OpenApiSchema to access the settable Default property
-        if (schema is not OpenApiSchema openApiSchema)
         {
             return;
         }

--- a/components/api/src/Altinn.Notifications/Validators/Rules/RecipientRules.cs
+++ b/components/api/src/Altinn.Notifications/Validators/Rules/RecipientRules.cs
@@ -250,12 +250,12 @@ public static class RecipientRules
     }
 
     /// <summary>
-    /// Validates that the resource ID starts with "urn:altinn:resource".
+    /// Validates that the resource ID starts with "urn:altinn:resource:".
     /// </summary>
     /// <param name="resourceId">A string representation of a valid resource id</param>
     /// <returns>true if the resource id is a valid full resource id</returns>
     internal static bool BeValidResourceId(string resourceId)
     {
-        return resourceId.StartsWith("urn:altinn:resource");
+        return resourceId.StartsWith("urn:altinn:resource:");
     }
 }

--- a/components/api/src/Altinn.Notifications/Validators/Rules/RecipientRules.cs
+++ b/components/api/src/Altinn.Notifications/Validators/Rules/RecipientRules.cs
@@ -250,12 +250,13 @@ public static class RecipientRules
     }
 
     /// <summary>
-    /// Validates that the resource ID starts with "urn:altinn:resource:".
+    /// Validates that the resource ID matches the pattern "urn:altinn:resource:" followed by at least one character.
     /// </summary>
     /// <param name="resourceId">A string representation of a valid resource id</param>
     /// <returns>true if the resource id is a valid full resource id</returns>
     internal static bool BeValidResourceId(string resourceId)
     {
-        return resourceId.StartsWith("urn:altinn:resource:");
+        const string prefix = "urn:altinn:resource:";
+        return resourceId.StartsWith(prefix) && resourceId.Length > prefix.Length;
     }
 }

--- a/components/api/test/Altinn.Notifications.Tests/Notifications/TestingValidators/RecipientExternalIdentityValidatorTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications/TestingValidators/RecipientExternalIdentityValidatorTests.cs
@@ -139,6 +139,29 @@ public class RecipientExternalIdentityValidatorTests
     }
 
     [Fact]
+    public void Validate_PrefixOnlyResourceId_ReturnsError()
+    {
+        // Arrange
+        var recipient = new RecipientExternalIdentityExt
+        {
+            ChannelSchema = NotificationChannelExt.Email,
+            ResourceId = "urn:altinn:resource:",
+            ExternalIdentity = "urn:altinn:person:idporten-email:user@example.com",
+            EmailSettings = new EmailSendingOptionsExt
+            {
+                Body = "Test body",
+                Subject = "Test subject"
+            }
+        };
+
+        // Act
+        var actual = _validator.TestValidate(recipient);
+
+        // Assert
+        actual.ShouldHaveValidationErrorFor(r => r.ResourceId).WithErrorMessage("ResourceId must have a valid syntax.");
+    }
+
+    [Fact]
     public void Validate_NullResourceId_NoError()
     {
         // Arrange

--- a/components/api/test/Altinn.Notifications.Tests/Notifications/TestingValidators/RecipientOrganizationValidatorTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications/TestingValidators/RecipientOrganizationValidatorTests.cs
@@ -62,7 +62,7 @@ public class RecipientOrganizationValidatorTests
 
         // act
         var actual = _recipientOrganizationValidator.TestValidate(recipientOrganization);
-        
+
         // assert
         actual.ShouldHaveValidationErrorFor(recipient => recipient.EmailSettings).WithErrorMessage("EmailSettings must be set when ChannelSchema is SmsPreferred or EmailPreferred");
         actual.ShouldHaveValidationErrorFor(recipient => recipient.SmsSettings).WithErrorMessage("SmsSettings must be set when ChannelSchema is SmsPreferred or EmailPreferred");
@@ -166,6 +166,24 @@ public class RecipientOrganizationValidatorTests
 
         // assert
         actual.ShouldNotHaveValidationErrorFor(recipient => recipient.ResourceId);
+    }
+
+    [Fact]
+    public void Should_Not_Validate_ResourceId_When_Only_Prefix()
+    {
+        // arrange
+        var recipientOrganization = new RecipientOrganizationExt
+        {
+            OrgNumber = "123456789",
+            ResourceId = "urn:altinn:resource:",
+            ChannelSchema = NotificationChannelExt.EmailPreferred,
+        };
+
+        // act
+        var actual = _recipientOrganizationValidator.TestValidate(recipientOrganization);
+
+        // assert
+        actual.ShouldHaveValidationErrorFor(recipient => recipient.ResourceId).WithErrorMessage("ResourceId must have a valid syntax.");
     }
 
     [Theory]

--- a/components/api/test/Altinn.Notifications.Tests/Notifications/TestingValidators/RecipientPersonValidatorTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications/TestingValidators/RecipientPersonValidatorTests.cs
@@ -26,7 +26,7 @@ public class RecipientPersonValidatorTests
 
         // act
         var actual = _recipientPersonValidator.TestValidate(recipientPerson);
-        
+
         // assert
         actual.ShouldHaveValidationErrorFor(recipient => recipient.NationalIdentityNumber).WithErrorMessage(errorMessage);
     }
@@ -108,7 +108,7 @@ public class RecipientPersonValidatorTests
 
         // act
         var actual = _recipientPersonValidator.TestValidate(recipientPerson);
-        
+
         // assert
         actual.ShouldNotHaveValidationErrorFor(recipient => recipient.ResourceId);
     }
@@ -147,6 +147,24 @@ public class RecipientPersonValidatorTests
 
         // assert
         actual.ShouldNotHaveValidationErrorFor(recipient => recipient.ResourceId);
+    }
+
+    [Fact]
+    public void Should_Not_Validate_ResourceId_When_Only_Prefix()
+    {
+        // arrange
+        var recipientPerson = new RecipientPersonExt
+        {
+            NationalIdentityNumber = "12345678910",
+            ResourceId = "urn:altinn:resource:",
+            ChannelSchema = NotificationChannelExt.Sms,
+        };
+
+        // act
+        var actual = _recipientPersonValidator.TestValidate(recipientPerson);
+
+        // assert
+        actual.ShouldHaveValidationErrorFor(recipient => recipient.ResourceId).WithErrorMessage("ResourceId must have a valid syntax.");
     }
 
     [Theory]


### PR DESCRIPTION
⚠️ Adds a slightly more strict validation of `RecipientBaseExt.ResourceId`
- before: the validation accepts `"resourceId": "urn:altinn:resource"`
- now: an incoming `resourceId` value no longer accepts "bare prefix" values such as `"urn:altinn:resource"` or `"urn:altinn:resource:"` (note final colon). The value must be prefixed with `'urn:altinn:resource:'` AND must have at least 1 additional character
  - functionally equals the regex match "^urn:altinn:resource:.+$", ref. the new `pattern` doc attribute 👇 

✏️ Enriches the OpenAPI spec for the property RecipientBaseExt.ResourceId, with a `pattern` attribute for the URN format
- The OpenAPI schema property `resourceId` now includes `"pattern": "^urn:altinn:resource:.+$"` 
- Having the string format specified as `pattern` should clarify the documentation even further, and the property can also be used by client side automation tools for validation/code-generation
- Aligns with [the format rule specified for ResourceUrn.ResourceId of the Altinn Resource Registry docs](https://github.com/Altinn/altinn-studio-docs/blob/master/static/swagger/altinn-resource-registry-v1.json#L3546)

(The suggestion was recommended [in altinn-studio-docs PR](https://github.com/Altinn/altinn-studio-docs/pull/2848#discussion_r3108786099))

Related issue: #1466 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for ResourceId format to require content after the `urn:altinn:resource:` prefix.

* **Documentation**
  * Enhanced API schema documentation to clearly specify ResourceId format constraints in Swagger/OpenAPI definitions.

* **Tests**
  * Added validation test cases to ensure ResourceId rejects prefix-only values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->