### PR TITLE
Roll back temporary email send result nullguard removal

### DIFF
--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Publishers/EmailSendResultPublisher.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Publishers/EmailSendResultPublisher.cs
@@ -38,9 +38,19 @@ public class EmailSendResultPublisher : IEmailSendResultDispatcher
             throw new ArgumentException("SendResult must be set before dispatching.", nameof(result));
         }
 
+        if (result.NotificationId is null)
+        {
+            throw new ArgumentException("NotificationId must be set before dispatching.", nameof(result));
+        }
+
+        if (result.NotificationId == Guid.Empty)
+        {
+            throw new ArgumentException("NotificationId must not be empty.", nameof(result));
+        }
+
         var command = new EmailSendResultCommand
         {
-            NotificationId = result.NotificationId.GetValueOrDefault(),
+            NotificationId = result.NotificationId.Value,
             
             // SendResult.ToString() is the wire format; EmailNotificationResultType on the API side
             // must have matching member names — any divergence will be treated as an unrecognized result.

--- a/components/email-service/test/Altinn.Notifications.Email.Tests/Email.Integrations/EmailSendResultPublisherTests.cs
+++ b/components/email-service/test/Altinn.Notifications.Email.Tests/Email.Integrations/EmailSendResultPublisherTests.cs
@@ -97,67 +97,41 @@ public class EmailSendResultPublisherTests
     }
 
     [Fact]
-    public async Task DispatchAsync_WhenNotificationIdIsNull_SendsCommandWithEmptyNotificationIdAndOperationId()
+    public async Task DispatchAsync_WhenNotificationIdIsNull_ThrowsArgumentException()
     {
         // Arrange
-        const string operationId = "acs-op-delivery-123";
-
         var result = new SendOperationResult
         {
             NotificationId = null,
-            OperationId = operationId,
+            OperationId = "op-123",
             SendResult = EmailSendResult.Delivered
         };
 
-        EmailSendResultCommand? capturedCommand = null;
         var messageBusMock = new Mock<IMessageBus>();
-        messageBusMock
-            .Setup(b => b.SendAsync(It.IsAny<EmailSendResultCommand>(), It.IsAny<DeliveryOptions?>()))
-            .Callback<EmailSendResultCommand, DeliveryOptions?>((cmd, _) => capturedCommand = cmd)
-            .Returns(ValueTask.CompletedTask);
-
         var emailSendResultPublisher = new EmailSendResultPublisher(CreateServiceProvider(messageBusMock.Object));
 
-        // Act
-        await emailSendResultPublisher.DispatchAsync(result);
-
-        // Assert
-        Assert.NotNull(capturedCommand);
-        Assert.Equal(Guid.Empty, capturedCommand.NotificationId);
-        Assert.Equal(operationId, capturedCommand.OperationId);
-        messageBusMock.Verify(b => b.SendAsync(It.IsAny<EmailSendResultCommand>(), It.IsAny<DeliveryOptions?>()), Times.Once);
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => emailSendResultPublisher.DispatchAsync(result));
+        messageBusMock.Verify(b => b.SendAsync(It.IsAny<EmailSendResultCommand>(), It.IsAny<DeliveryOptions?>()), Times.Never);
     }
 
     [Fact]
-    public async Task DispatchAsync_WhenNotificationIdIsEmpty_SendsCommandWithEmptyNotificationIdAndOperationId()
+    public async Task DispatchAsync_WhenNotificationIdIsEmpty_ThrowsArgumentException()
     {
         // Arrange
-        const string operationId = "acs-op-delivery-456";
-
         var result = new SendOperationResult
         {
             NotificationId = Guid.Empty,
-            OperationId = operationId,
+            OperationId = "op-123",
             SendResult = EmailSendResult.Delivered
         };
 
-        EmailSendResultCommand? capturedCommand = null;
         var messageBusMock = new Mock<IMessageBus>();
-        messageBusMock
-            .Setup(b => b.SendAsync(It.IsAny<EmailSendResultCommand>(), It.IsAny<DeliveryOptions?>()))
-            .Callback<EmailSendResultCommand, DeliveryOptions?>((cmd, _) => capturedCommand = cmd)
-            .Returns(ValueTask.CompletedTask);
-
         var emailSendResultPublisher = new EmailSendResultPublisher(CreateServiceProvider(messageBusMock.Object));
 
-        // Act
-        await emailSendResultPublisher.DispatchAsync(result);
-
-        // Assert
-        Assert.NotNull(capturedCommand);
-        Assert.Equal(Guid.Empty, capturedCommand.NotificationId);
-        Assert.Equal(operationId, capturedCommand.OperationId);
-        messageBusMock.Verify(b => b.SendAsync(It.IsAny<EmailSendResultCommand>(), It.IsAny<DeliveryOptions?>()), Times.Once);
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => emailSendResultPublisher.DispatchAsync(result));
+        messageBusMock.Verify(b => b.SendAsync(It.IsAny<EmailSendResultCommand>(), It.IsAny<DeliveryOptions?>()), Times.Never);
     }
 
     private static ServiceProvider CreateServiceProvider(IMessageBus messageBus)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR reinstates the nullguards for notificationId in the `EmailSendResultPublisher`. We keep the improvements made to change `InvalidOperationException` -> `ArgumentException` to avoid unnecessary retries, and the         `ArgumentNullException.ThrowIfNull(result)` statement at the top of the dispatch method.

## Related Issue(s)
- #1496

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
