### PR TITLE
docs: Update resourceId docstring with added ':' to prefix requirement

### DIFF
--- a/components/api/src/Altinn.Notifications/Models/Recipient/RecipientBaseExt.cs
+++ b/components/api/src/Altinn.Notifications/Models/Recipient/RecipientBaseExt.cs
@@ -53,7 +53,7 @@ public abstract class RecipientBaseExt
     public SmsSendingOptionsExt? SmsSettings { get; set; }
 
     /// <summary>
-    /// An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource' is required.
+    /// An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource:' is required.
     /// </summary>
     /// <example>urn:altinn:resource:org_example_app</example>
     [JsonPropertyName("resourceId")]


### PR DESCRIPTION
Updates the new prefix requirement (added final colon) in the docstring for `resourceId` after #1488 
## Related Issue(s)
- #1466