### PR TITLE
Add configurable listener counts per ASB queue

### DIFF
--- a/components/api/src/Altinn.Notifications.Integrations/Configuration/WolverineSettings.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Configuration/WolverineSettings.cs
@@ -52,6 +52,11 @@ public class WolverineSettings : WolverineSettingsBase
     public QueueRetryPolicy EmailDeliveryReportQueuePolicy { get; set; } = new();
 
     /// <summary>
+    /// Number of concurrent listeners for the email delivery report queue per pod.
+    /// </summary>
+    public int EmailDeliveryReportListenerCount { get; set; } = 10;
+
+    /// <summary>
     /// Maximum number of SMS send commands published concurrently during a batch publish operation.
     /// </summary>
     public int SmsPublishConcurrency { get; set; } = 10;
@@ -78,6 +83,11 @@ public class WolverineSettings : WolverineSettingsBase
     public QueueRetryPolicy SmsDeliveryReportQueuePolicy { get; set; } = new();
 
     /// <summary>
+    /// Number of concurrent listeners for the SMS delivery report queue per pod.
+    /// </summary>
+    public int SmsDeliveryReportListenerCount { get; set; } = 10;
+
+    /// <summary>
     /// Determines whether to consume email send results via Wolverine and Azure Service Bus or via Kafka.
     /// </summary>
     public bool EnableEmailSendResultListener { get; set; } = false;
@@ -92,6 +102,11 @@ public class WolverineSettings : WolverineSettingsBase
     /// Retry policy for the email send result queue.
     /// </summary>
     public QueueRetryPolicy EmailSendResultQueuePolicy { get; set; } = new();
+
+    /// <summary>
+    /// Number of concurrent listeners for the email send result queue per pod.
+    /// </summary>
+    public int EmailSendResultListenerCount { get; set; } = 10;
 
     /// <summary>
     /// Determines whether to consume SMS send results via Wolverine and Azure Service Bus or via Kafka.
@@ -110,6 +125,11 @@ public class WolverineSettings : WolverineSettingsBase
     public QueueRetryPolicy SmsSendResultQueuePolicy { get; set; } = new();
 
     /// <summary>
+    /// Number of concurrent listeners for the SMS send result queue per pod.
+    /// </summary>
+    public int SmsSendResultListenerCount { get; set; } = 10;
+
+    /// <summary>
     /// Whether to enable the email service rate limit queue listener.
     /// Consumes messages published by the email service when ACS returns HTTP 429.
     /// </summary>
@@ -125,6 +145,11 @@ public class WolverineSettings : WolverineSettingsBase
     /// Retry policy for the email service rate limit queue.
     /// </summary>
     public QueueRetryPolicy EmailServiceRateLimitQueuePolicy { get; set; } = new();
+
+    /// <summary>
+    /// Number of concurrent listeners for the email service rate limit queue per pod.
+    /// </summary>
+    public int EmailServiceRateLimitListenerCount { get; set; } = 10;
 
     /// <summary>
     /// Determines whether to publish past-due order commands via Wolverine and Azure Service Bus or via Kafka.
@@ -146,6 +171,11 @@ public class WolverineSettings : WolverineSettingsBase
     /// Retry policy for the past-due orders queue.
     /// </summary>
     public QueueRetryPolicy PastDueOrdersQueuePolicy { get; set; } = new();
+
+    /// <summary>
+    /// Number of concurrent listeners for the past-due orders queue per pod.
+    /// </summary>
+    public int PastDueOrdersListenerCount { get; set; } = 10;
 
     /// <summary>
     /// Delay in milliseconds before the single scheduled retry for inconclusive send conditions

--- a/components/api/src/Altinn.Notifications.Integrations/Configuration/WolverineSettings.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Configuration/WolverineSettings.cs
@@ -149,7 +149,7 @@ public class WolverineSettings : WolverineSettingsBase
     /// <summary>
     /// Number of concurrent listeners for the email service rate limit queue per pod.
     /// </summary>
-    public int EmailServiceRateLimitListenerCount { get; set; } = 10;
+    public int EmailServiceRateLimitListenerCount { get; set; } = 1;
 
     /// <summary>
     /// Determines whether to publish past-due order commands via Wolverine and Azure Service Bus or via Kafka.

--- a/components/api/src/Altinn.Notifications.Integrations/Configuration/WolverineSettings.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Configuration/WolverineSettings.cs
@@ -25,11 +25,6 @@ public class WolverineSettings : WolverineSettingsBase
     public string EmailSendQueueName { get; set; } = string.Empty;
 
     /// <summary>
-    /// Retry policy for the email send queue.
-    /// </summary>
-    public QueueRetryPolicy EmailSendQueuePolicy { get; set; } = new();
-
-    /// <summary>
     /// ASB queue name used for publishing sms messages.
     /// Produced by the API and consumed by the SMS Service and service provider.
     /// </summary>

--- a/components/api/src/Altinn.Notifications.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
@@ -78,6 +78,12 @@ public static class WolverineServiceCollectionExtensions
             return;
         }
 
+        if (wolverineSettings.EmailSendResultListenerCount <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(WolverineSettings.EmailSendResultListenerCount)} must be greater than 0 when {nameof(WolverineSettings.EnableEmailSendResultListener)} is enabled.");
+        }
+
         if (string.IsNullOrWhiteSpace(wolverineSettings.EmailSendResultQueueName))
         {
             throw new InvalidOperationException(
@@ -100,6 +106,12 @@ public static class WolverineServiceCollectionExtensions
         if (!wolverineSettings.EnableSmsSendResultListener)
         {
             return;
+        }
+
+        if (wolverineSettings.SmsSendResultListenerCount <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(WolverineSettings.SmsSendResultListenerCount)} must be greater than 0 when {nameof(WolverineSettings.EnableSmsSendResultListener)} is enabled.");
         }
 
         if (string.IsNullOrWhiteSpace(wolverineSettings.SmsSendResultQueueName))
@@ -125,6 +137,12 @@ public static class WolverineServiceCollectionExtensions
             return;
         }
 
+        if (wolverineSettings.EmailDeliveryReportListenerCount <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(WolverineSettings.EmailDeliveryReportListenerCount)} must be greater than 0 when {nameof(WolverineSettings.EnableEmailDeliveryReportListener)} is enabled.");
+        }
+
         if (string.IsNullOrWhiteSpace(wolverineSettings.EmailDeliveryReportQueueName))
         {
             throw new InvalidOperationException(
@@ -148,6 +166,12 @@ public static class WolverineServiceCollectionExtensions
             return;
         }
 
+        if (wolverineSettings.SmsDeliveryReportListenerCount <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(WolverineSettings.SmsDeliveryReportListenerCount)} must be greater than 0 when {nameof(WolverineSettings.EnableSmsDeliveryReportListener)} is enabled.");
+        }
+
         if (string.IsNullOrWhiteSpace(wolverineSettings.SmsDeliveryReportQueueName))
         {
             throw new InvalidOperationException(
@@ -169,6 +193,12 @@ public static class WolverineServiceCollectionExtensions
         if (!wolverineSettings.EnableEmailServiceRateLimitListener)
         {
             return;
+        }
+
+        if (wolverineSettings.EmailServiceRateLimitListenerCount <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(WolverineSettings.EmailServiceRateLimitListenerCount)} must be greater than 0 when {nameof(WolverineSettings.EnableEmailServiceRateLimitListener)} is enabled.");
         }
 
         if (string.IsNullOrWhiteSpace(wolverineSettings.EmailServiceRateLimitQueueName))
@@ -239,6 +269,12 @@ public static class WolverineServiceCollectionExtensions
         if (!wolverineSettings.EnablePastDueOrderListener)
         {
             return;
+        }
+
+        if (wolverineSettings.PastDueOrdersListenerCount <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(WolverineSettings.PastDueOrdersListenerCount)} must be greater than 0 when {nameof(WolverineSettings.EnablePastDueOrderListener)} is enabled.");
         }
 
         if (string.IsNullOrWhiteSpace(wolverineSettings.PastDueOrdersQueueName))

--- a/components/api/src/Altinn.Notifications.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
@@ -85,7 +85,7 @@ public static class WolverineServiceCollectionExtensions
         }
 
         wolverineOptions.ListenToAzureServiceBusQueue(wolverineSettings.EmailSendResultQueueName)
-                        .ListenerCount(wolverineSettings.ListenerCount);
+                        .ListenerCount(wolverineSettings.EmailSendResultListenerCount);
 
         wolverineOptions.Policies.Add(new EmailSendResultHandlerPolicy(wolverineSettings));
     }
@@ -109,7 +109,7 @@ public static class WolverineServiceCollectionExtensions
         }
 
         wolverineOptions.ListenToAzureServiceBusQueue(wolverineSettings.SmsSendResultQueueName)
-                        .ListenerCount(wolverineSettings.ListenerCount);
+                        .ListenerCount(wolverineSettings.SmsSendResultListenerCount);
 
         wolverineOptions.Policies.Add(new SmsSendResultHandlerPolicy(wolverineSettings));
     }
@@ -133,7 +133,7 @@ public static class WolverineServiceCollectionExtensions
 
         wolverineOptions.ListenToAzureServiceBusQueue(wolverineSettings.EmailDeliveryReportQueueName)
                         .InteropWith(new EventGridEnvelopeMapper())
-                        .ListenerCount(wolverineSettings.ListenerCount);
+                        .ListenerCount(wolverineSettings.EmailDeliveryReportListenerCount);
 
         wolverineOptions.Policies.Add(new EmailDeliveryReportHandlerPolicy(wolverineSettings));
     }
@@ -155,7 +155,7 @@ public static class WolverineServiceCollectionExtensions
         }
 
         wolverineOptions.ListenToAzureServiceBusQueue(wolverineSettings.SmsDeliveryReportQueueName)
-                        .ListenerCount(wolverineSettings.ListenerCount);
+                        .ListenerCount(wolverineSettings.SmsDeliveryReportListenerCount);
 
         wolverineOptions.Policies.Add(new SmsDeliveryReportHandlerPolicy(wolverineSettings));
     }
@@ -178,7 +178,7 @@ public static class WolverineServiceCollectionExtensions
         }
 
         wolverineOptions.ListenToAzureServiceBusQueue(wolverineSettings.EmailServiceRateLimitQueueName)
-                        .ListenerCount(wolverineSettings.ListenerCount);
+                        .ListenerCount(wolverineSettings.EmailServiceRateLimitListenerCount);
 
         wolverineOptions.Policies.Add(new EmailServiceRateLimitHandlerPolicy(wolverineSettings));
     }
@@ -248,7 +248,7 @@ public static class WolverineServiceCollectionExtensions
         }
 
         wolverineOptions.ListenToAzureServiceBusQueue(wolverineSettings.PastDueOrdersQueueName)
-                        .ListenerCount(wolverineSettings.ListenerCount);
+                        .ListenerCount(wolverineSettings.PastDueOrdersListenerCount);
 
         wolverineOptions.Policies.Add(new ProcessPastDueOrderHandlerPolicy(wolverineSettings));
     }

--- a/components/api/src/Altinn.Notifications/appsettings.json
+++ b/components/api/src/Altinn.Notifications/appsettings.json
@@ -80,41 +80,46 @@
     "EmailPublishConcurrency": 10,
     "SmsPublishConcurrency": 10,
     "ServiceBusConnectionString": "",
-    "ListenerCount": 10,
     "EnableSendEmailPublisher": false,
     "EmailSendQueueName": "altinn.notifications.email.send",
     "EnableSendSmsPublisher": false,
     "SendSmsQueueName": "altinn.notifications.sms.send",
+    "EmailDeliveryReportListenerCount": 10,
     "EnableEmailDeliveryReportListener": false,
     "EmailDeliveryReportQueueName": "altinn.notifications.email.deliveryreports",
     "EmailDeliveryReportQueuePolicy": {
       "CooldownDelaysMs": [ 1000, 5000, 10000 ],
       "ScheduleDelaysMs": [ 60000, 120000, 120000 ]
     },
+    "SmsDeliveryReportListenerCount": 10,
     "EnableSmsDeliveryReportListener": false,
     "SmsDeliveryReportQueueName": "altinn.notifications.sms.deliveryreports",
     "SmsDeliveryReportQueuePolicy": {
       "CooldownDelaysMs": [ 1000, 5000, 10000 ],
       "ScheduleDelaysMs": [ 60000, 120000, 120000 ]
     },
+    "EmailSendResultListenerCount": 10,
     "EnableEmailSendResultListener": false,
     "EmailSendResultQueueName": "altinn.notifications.email.send.result",
     "EmailSendResultQueuePolicy": {
       "CooldownDelaysMs": [ 1000, 5000, 10000 ],
       "ScheduleDelaysMs": [ 60000, 120000, 120000 ]
     },
+    "SmsSendResultListenerCount": 10,
     "EnableSmsSendResultListener": false,
     "SmsSendResultQueueName": "altinn.notifications.sms.send.result",
     "SmsSendResultQueuePolicy": {
       "CooldownDelaysMs": [ 1000, 5000, 10000 ],
       "ScheduleDelaysMs": [ 60000, 120000, 120000 ]
     },
+    "EmailServiceRateLimitListenerCount": 10,
     "EnableEmailServiceRateLimitListener": false,
     "EmailServiceRateLimitQueueName": "altinn.notifications.email.send.ratelimit",
     "EmailServiceRateLimitQueuePolicy": {
       "CooldownDelaysMs": [ 1000, 5000, 10000 ],
       "ScheduleDelaysMs": [ 60000, 120000, 120000 ]
     },
+    "PastDueOrdersListenerCount": 10,
     "EnablePastDueOrderPublisher": false,
     "EnablePastDueOrderListener": false,
     "PastDueOrdersQueueName": "altinn.notifications.orders.pastdue",

--- a/components/api/src/Altinn.Notifications/appsettings.json
+++ b/components/api/src/Altinn.Notifications/appsettings.json
@@ -112,7 +112,7 @@
       "CooldownDelaysMs": [ 1000, 5000, 10000 ],
       "ScheduleDelaysMs": [ 60000, 120000, 120000 ]
     },
-    "EmailServiceRateLimitListenerCount": 10,
+    "EmailServiceRateLimitListenerCount": 1,
     "EnableEmailServiceRateLimitListener": false,
     "EmailServiceRateLimitQueueName": "altinn.notifications.email.send.ratelimit",
     "EmailServiceRateLimitQueuePolicy": {

--- a/components/api/test/Altinn.Notifications.IntegrationTestsASB/appsettings.integrationtest.json
+++ b/components/api/test/Altinn.Notifications.IntegrationTestsASB/appsettings.integrationtest.json
@@ -52,7 +52,12 @@
       "ScheduleDelaysMs": [ 500, 500, 500, 500, 500 ]
     },
     "PastDueOrdersRetryDelayMs": 500,
-    "ListenerCount": 1
+    "EmailDeliveryReportListenerCount": 1,
+    "SmsDeliveryReportListenerCount": 1,
+    "EmailSendResultListenerCount": 1,
+    "SmsSendResultListenerCount": 1,
+    "EmailServiceRateLimitListenerCount": 1,
+    "PastDueOrdersListenerCount": 1
   },
   "GeneralSettings": {
     "BaseUri": "http://localhost:0",

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Wolverine/WolverineSettingsTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Wolverine/WolverineSettingsTests.cs
@@ -18,15 +18,19 @@ public class WolverineSettingsTests
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["WolverineSettings:EnableWolverine"] = "true",
-
-                ["WolverineSettings:EmailSendQueuePolicy:CooldownDelaysMs:0"] = "1000",
-                ["WolverineSettings:EmailSendQueuePolicy:ScheduleDelaysMs:0"] = "60000",
                 ["WolverineSettings:EmailSendQueueName"] = "altinn.notifications.email.send",
 
                 ["WolverineSettings:EnableEmailDeliveryReportListener"] = "true",
                 ["WolverineSettings:EmailDeliveryReportQueuePolicy:CooldownDelaysMs:0"] = "1000",
                 ["WolverineSettings:EmailDeliveryReportQueuePolicy:ScheduleDelaysMs:0"] = "60000",
                 ["WolverineSettings:EmailDeliveryReportQueueName"] = "altinn.notifications.email.deliveryreports",
+                ["WolverineSettings:EmailDeliveryReportListenerCount"] = "3",
+
+                ["WolverineSettings:SmsDeliveryReportListenerCount"] = "4",
+                ["WolverineSettings:EmailSendResultListenerCount"] = "5",
+                ["WolverineSettings:SmsSendResultListenerCount"] = "6",
+                ["WolverineSettings:EmailServiceRateLimitListenerCount"] = "2",
+                ["WolverineSettings:PastDueOrdersListenerCount"] = "7",
             })
             .Build();
 
@@ -37,13 +41,18 @@ public class WolverineSettingsTests
         Assert.True(settings.EnableWolverine);
 
         Assert.Equal("altinn.notifications.email.send", settings.EmailSendQueueName);
-        Assert.Contains(TimeSpan.FromMilliseconds(1000), settings.EmailSendQueuePolicy.GetCooldownDelays());
-        Assert.Contains(TimeSpan.FromMilliseconds(60000), settings.EmailSendQueuePolicy.GetScheduleDelays());
 
         Assert.True(settings.EnableEmailDeliveryReportListener);
         Assert.Equal("altinn.notifications.email.deliveryreports", settings.EmailDeliveryReportQueueName);
         Assert.Contains(TimeSpan.FromMilliseconds(1000), settings.EmailDeliveryReportQueuePolicy.GetCooldownDelays());
         Assert.Contains(TimeSpan.FromMilliseconds(60000), settings.EmailDeliveryReportQueuePolicy.GetScheduleDelays());
+        Assert.Equal(3, settings.EmailDeliveryReportListenerCount);
+
+        Assert.Equal(4, settings.SmsDeliveryReportListenerCount);
+        Assert.Equal(5, settings.EmailSendResultListenerCount);
+        Assert.Equal(6, settings.SmsSendResultListenerCount);
+        Assert.Equal(2, settings.EmailServiceRateLimitListenerCount);
+        Assert.Equal(7, settings.PastDueOrdersListenerCount);
     }
 
     [Fact]
@@ -53,7 +62,6 @@ public class WolverineSettingsTests
 
         Assert.False(settings.EnableWolverine);
 
-        Assert.NotNull(settings.EmailSendQueuePolicy);
         Assert.Equal(string.Empty, settings.EmailSendQueueName);
 
         Assert.NotNull(settings.EmailDeliveryReportQueuePolicy);

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Wolverine/WolverineSettingsTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Wolverine/WolverineSettingsTests.cs
@@ -59,5 +59,12 @@ public class WolverineSettingsTests
         Assert.NotNull(settings.EmailDeliveryReportQueuePolicy);
         Assert.False(settings.EnableEmailDeliveryReportListener);
         Assert.Equal(string.Empty, settings.EmailDeliveryReportQueueName);
+
+        Assert.Equal(10, settings.EmailSendResultListenerCount);
+        Assert.Equal(10, settings.SmsSendResultListenerCount);
+        Assert.Equal(10, settings.EmailDeliveryReportListenerCount);
+        Assert.Equal(10, settings.SmsDeliveryReportListenerCount);
+        Assert.Equal(10, settings.EmailServiceRateLimitListenerCount);
+        Assert.Equal(10, settings.PastDueOrdersListenerCount);
     }
 }

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Wolverine/WolverineSettingsTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Wolverine/WolverineSettingsTests.cs
@@ -64,7 +64,7 @@ public class WolverineSettingsTests
         Assert.Equal(10, settings.SmsSendResultListenerCount);
         Assert.Equal(10, settings.EmailDeliveryReportListenerCount);
         Assert.Equal(10, settings.SmsDeliveryReportListenerCount);
-        Assert.Equal(10, settings.EmailServiceRateLimitListenerCount);
         Assert.Equal(10, settings.PastDueOrdersListenerCount);
+        Assert.Equal(1, settings.EmailServiceRateLimitListenerCount);
     }
 }

--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Configuration/WolverineSettings.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Configuration/WolverineSettings.cs
@@ -25,6 +25,11 @@ public class WolverineSettings : WolverineSettingsBase
     public QueueRetryPolicy EmailSendQueuePolicy { get; set; } = new();
 
     /// <summary>
+    /// Number of concurrent listeners for the email send queue per pod.
+    /// </summary>
+    public int EmailSendListenerCount { get; set; } = 10;
+
+    /// <summary>
     /// Determines whether to consume email status check commands via Wolverine and Azure Service Bus or via Kafka.
     /// </summary>
     public bool EnableEmailStatusCheckListener { get; set; } = false;
@@ -44,6 +49,11 @@ public class WolverineSettings : WolverineSettingsBase
     /// Retry policy for the email status check queue.
     /// </summary>
     public QueueRetryPolicy EmailStatusCheckQueuePolicy { get; set; } = new();
+
+    /// <summary>
+    /// Number of concurrent listeners for the email status check queue per pod.
+    /// </summary>
+    public int EmailStatusCheckListenerCount { get; set; } = 10;
 
     /// <summary>
     /// Determines whether to publish email send results via Wolverine and Azure Service Bus or via Kafka.

--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
@@ -78,7 +78,7 @@ public static class WolverineServiceCollectionExtensions
         }
 
         wolverineOptions.ListenToAzureServiceBusQueue(wolverineSettings.EmailSendQueueName)
-                        .ListenerCount(wolverineSettings.ListenerCount);
+                        .ListenerCount(wolverineSettings.EmailSendListenerCount);
 
         wolverineOptions.Policies.Add(new SendEmailCommandHandlerPolicy(wolverineSettings));
     }
@@ -129,7 +129,7 @@ public static class WolverineServiceCollectionExtensions
         }
 
         wolverineOptions.ListenToAzureServiceBusQueue(wolverineSettings.EmailStatusCheckQueueName)
-                        .ListenerCount(wolverineSettings.ListenerCount);
+                        .ListenerCount(wolverineSettings.EmailStatusCheckListenerCount);
 
         wolverineOptions.Policies.Add(new CheckEmailSendStatusHandlerPolicy(wolverineSettings));
     }

--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
@@ -71,6 +71,12 @@ public static class WolverineServiceCollectionExtensions
             return;
         }
 
+        if (wolverineSettings.EmailSendListenerCount <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(WolverineSettings.EmailSendListenerCount)} must be greater than 0 when {nameof(WolverineSettings.EnableSendEmailListener)} is enabled.");
+        }
+
         if (string.IsNullOrWhiteSpace(wolverineSettings.EmailSendQueueName))
         {
             throw new InvalidOperationException(
@@ -120,6 +126,12 @@ public static class WolverineServiceCollectionExtensions
         if (!wolverineSettings.EnableEmailStatusCheckListener)
         {
             return;
+        }
+
+        if (wolverineSettings.EmailStatusCheckListenerCount <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(WolverineSettings.EmailStatusCheckListenerCount)} must be greater than 0 when {nameof(WolverineSettings.EnableEmailStatusCheckListener)} is enabled.");
         }
 
         if (string.IsNullOrWhiteSpace(wolverineSettings.EmailStatusCheckQueueName))

--- a/components/email-service/src/Altinn.Notifications.Email/appsettings.json
+++ b/components/email-service/src/Altinn.Notifications.Email/appsettings.json
@@ -43,13 +43,14 @@
   "WolverineSettings": {
     "EnableWolverine": false,
     "ServiceBusConnectionString": "",
-    "ListenerCount": 10,
+    "EmailSendListenerCount": 10,
     "EnableSendEmailListener": false,
     "EmailSendQueueName": "altinn.notifications.email.send",
     "EmailSendQueuePolicy": {
       "CooldownDelaysMs": [ 1000, 5000, 10000 ],
       "ScheduleDelaysMs": [ 60000, 120000, 120000 ]
     },
+    "EmailStatusCheckListenerCount": 10,
     "EnableEmailStatusCheckListener": false,
     "EnableEmailStatusCheckPublisher": false,
     "EmailStatusCheckQueueName": "altinn.notifications.email.check.send.status",

--- a/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/appsettings.integrationtest.json
+++ b/components/email-service/test/Altinn.Notifications.Email.IntegrationTestsASB/appsettings.integrationtest.json
@@ -16,7 +16,8 @@
     }
   },
   "WolverineSettings": {
-    "ListenerCount": 1,
+    "EmailSendListenerCount": 1,
+    "EmailStatusCheckListenerCount": 1,
     "EnableWolverine": true,
     "EnableSendEmailListener": true,
     "EnableEmailSendResultPublisher": true,

--- a/components/email-service/test/Altinn.Notifications.Email.Tests/Email.Integrations/Wolverine/WolverineSettingsTests.cs
+++ b/components/email-service/test/Altinn.Notifications.Email.Tests/Email.Integrations/Wolverine/WolverineSettingsTests.cs
@@ -14,8 +14,9 @@ public class WolverineSettingsTests
         var settings = new WolverineSettings();
 
         Assert.False(settings.EnableWolverine);
-        Assert.Equal(10, settings.ListenerCount);
-        
+        Assert.Equal(10, settings.EmailSendListenerCount);
+        Assert.Equal(10, settings.EmailStatusCheckListenerCount);
+
         Assert.NotNull(settings.EmailSendQueuePolicy);
         Assert.False(settings.EnableSendEmailListener);
         Assert.Equal(string.Empty, settings.EmailSendQueueName);
@@ -34,7 +35,8 @@ public class WolverineSettingsTests
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["WolverineSettings:ListenerCount"] = "5",
+                ["WolverineSettings:EmailSendListenerCount"] = "5",
+                ["WolverineSettings:EmailStatusCheckListenerCount"] = "3",
                 ["WolverineSettings:EnableWolverine"] = "true",
                 ["WolverineSettings:EnableSendEmailListener"] = "true",
                 ["WolverineSettings:EnableEmailStatusCheckListener"] = "true",
@@ -55,7 +57,8 @@ public class WolverineSettingsTests
         Assert.NotNull(settings);
         Assert.True(settings.EnableWolverine);
 
-        Assert.Equal(5, settings.ListenerCount);
+        Assert.Equal(5, settings.EmailSendListenerCount);
+        Assert.Equal(3, settings.EmailStatusCheckListenerCount);
 
         Assert.True(settings.EnableSendEmailListener);
         Assert.Equal("altinn.notifications.email.send", settings.EmailSendQueueName);

--- a/components/shared/src/Altinn.Notifications.Shared/Configuration/WolverineSettingsBase.cs
+++ b/components/shared/src/Altinn.Notifications.Shared/Configuration/WolverineSettingsBase.cs
@@ -16,9 +16,4 @@ public class WolverineSettingsBase
     /// Connection string for Azure Service Bus.
     /// </summary>
     public string ServiceBusConnectionString { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Number of listeners per queue per pod.
-    /// </summary>
-    public int ListenerCount { get; set; } = 10;
 }

--- a/components/shared/test/Altinn.Notifications.Shared.Tests/Configuration/WolverineSettingsTests.cs
+++ b/components/shared/test/Altinn.Notifications.Shared.Tests/Configuration/WolverineSettingsTests.cs
@@ -12,7 +12,6 @@ public class WolverineSettingsTests
 
         Assert.False(settings.EnableWolverine);
         Assert.Equal(string.Empty, settings.ServiceBusConnectionString);
-        Assert.Equal(10, settings.ListenerCount);
     }
 
     [Fact]

--- a/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Configuration/WolverineSettings.cs
+++ b/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Configuration/WolverineSettings.cs
@@ -19,6 +19,11 @@ public class WolverineSettings : WolverineSettingsBase
     public QueueRetryPolicy SendSmsQueuePolicy { get; set; } = new();
 
     /// <summary>
+    /// Number of concurrent listeners for the SMS send queue per pod.
+    /// </summary>
+    public int SendSmsListenerCount { get; set; } = 10;
+
+    /// <summary>
     /// Determines whether to accept sms notifications via Wolverine and Azure Service Bus or via Kafka.
     /// </summary>
     public bool EnableSendSmsListener { get; set; } = false;

--- a/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
+++ b/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
@@ -71,7 +71,7 @@ public static class WolverineServiceCollectionExtensions
         }
 
         wolverineOptions.ListenToAzureServiceBusQueue(wolverineSettings.SendSmsQueueName)
-                        .ListenerCount(wolverineSettings.ListenerCount);
+                        .ListenerCount(wolverineSettings.SendSmsListenerCount);
 
         wolverineOptions.Policies.Add(new SendSmsCommandHandlerPolicy(wolverineSettings));
     }

--- a/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
+++ b/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Extensions/WolverineServiceCollectionExtensions.cs
@@ -64,6 +64,12 @@ public static class WolverineServiceCollectionExtensions
             return;
         }
 
+        if (wolverineSettings.SendSmsListenerCount <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(WolverineSettings.SendSmsListenerCount)} must be greater than 0 when {nameof(WolverineSettings.EnableSendSmsListener)} is enabled.");
+        }
+
         if (string.IsNullOrWhiteSpace(wolverineSettings.SendSmsQueueName))
         {
             throw new InvalidOperationException(

--- a/components/sms-service/src/Altinn.Notifications.Sms/appsettings.json
+++ b/components/sms-service/src/Altinn.Notifications.Sms/appsettings.json
@@ -40,6 +40,7 @@
   },
   "WolverineSettings": {
     "EnableWolverine": false,
+    "SendSmsListenerCount": 10,
     "EnableSendSmsListener": false,
     "SendSmsQueueName": "altinn.notifications.sms.send",
     "SendSmsQueuePolicy": {
@@ -50,8 +51,7 @@
     "SmsDeliveryReportQueueName": "altinn.notifications.sms.deliveryreports",
     "EnableSmsSendResultPublisher": false,
     "SmsSendResultQueueName": "altinn.notifications.sms.send.result",
-    "ServiceBusConnectionString": "",
-    "ListenerCount": 10
+    "ServiceBusConnectionString": ""
   },
   "Logging": {
     "LogLevel": {

--- a/components/sms-service/test/Altinn.Notifications.Sms.IntegrationTestsASB/appsettings.integrationtest.json
+++ b/components/sms-service/test/Altinn.Notifications.Sms.IntegrationTestsASB/appsettings.integrationtest.json
@@ -23,11 +23,11 @@
     "EnableSmsSendResultPublisher": true,
     "SmsSendResultQueueName": "altinn.notifications.sms.send.result",
     "SendSmsQueueName": "altinn.notifications.sms.send",
+    "SendSmsListenerCount": 1,
     "EnableSendSmsListener": true,
     "SendSmsQueuePolicy": {
       "CooldownDelaysMs": [ 100, 100, 100 ],
       "ScheduleDelaysMs": [ 500, 500, 500, 500, 500 ]
-    },
-    "ListenerCount": 1
+    }
   }
 }

--- a/components/sms-service/test/Altinn.Notifications.Sms.Tests/Sms.Integrations/Wolverine/WolverineSettingsTests.cs
+++ b/components/sms-service/test/Altinn.Notifications.Sms.Tests/Sms.Integrations/Wolverine/WolverineSettingsTests.cs
@@ -14,7 +14,7 @@ public class WolverineSettingsTests
         var settings = new WolverineSettings();
 
         Assert.False(settings.EnableWolverine);
-        Assert.Equal(10, settings.ListenerCount);
+        Assert.Equal(10, settings.SendSmsListenerCount);
         Assert.NotNull(settings.SendSmsQueuePolicy);
         Assert.Equal(string.Empty, settings.SendSmsQueueName);
         Assert.False(settings.EnableSendSmsListener);
@@ -27,7 +27,7 @@ public class WolverineSettingsTests
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["WolverineSettings:ListenerCount"] = "5",
+                ["WolverineSettings:SendSmsListenerCount"] = "5",
                 ["WolverineSettings:EnableWolverine"] = "true",
                 ["WolverineSettings:EnableSendSmsListener"] = "true",
                 ["WolverineSettings:SendSmsQueuePolicy:CooldownDelaysMs:0"] = "1000",
@@ -43,7 +43,7 @@ public class WolverineSettingsTests
         Assert.NotNull(settings);
         Assert.True(settings.EnableWolverine);
 
-        Assert.Equal(5, settings.ListenerCount);
+        Assert.Equal(5, settings.SendSmsListenerCount);
 
         Assert.True(settings.EnableSendSmsListener);
         Assert.Equal("altinn.notifications.sms.send", settings.SendSmsQueueName);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Each of the 9 ASB queue listeners now have configurable listener counts with defaults 10 (for backward compatability). The default fallback `ListenerCount` in the shared `WolverineSettingsBase` is removed (had default 10 as well). We fail fast on all integer values less than 1 listener.

## Related Issue(s)
- #1531

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced a single global listener-concurrency setting with independent per-queue listener counts for email (send/result/status/delivery), SMS (send/result/delivery), email service rate-limit, and past-due orders; sensible defaults applied (mostly 10; some integration defaults set to 1).
* **Bug Fixes**
  * Added validation that enabled listeners must have a positive listener count, surfacing configuration errors early.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->