### PR TITLE
1523 Added null check to _pdp.GetDecisionForRequest in AuthorizeSingleBatch 

### DIFF
--- a/components/api/src/Altinn.Notifications.Integrations/Authorization/AuthorizationService.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Authorization/AuthorizationService.cs
@@ -82,7 +82,7 @@ public class AuthorizationService : IAuthorizationService
 
         XacmlJsonResponse xacmlJsonResponse = await _pdp.GetDecisionForRequest(jsonRequest);
 
-        if (xacmlJsonResponse is null || xacmlJsonResponse.Response is null)
+        if (xacmlJsonResponse?.Response is null)
         {
             throw new HttpRequestException("Authorization PDP returned a null or empty response.");
         }

--- a/components/api/src/Altinn.Notifications.Integrations/Authorization/AuthorizationService.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Authorization/AuthorizationService.cs
@@ -82,6 +82,11 @@ public class AuthorizationService : IAuthorizationService
 
         XacmlJsonResponse xacmlJsonResponse = await _pdp.GetDecisionForRequest(jsonRequest);
 
+        if (xacmlJsonResponse is null || xacmlJsonResponse.Response is null)
+        {
+            throw new HttpRequestException("Authorization PDP returned a null or empty response.");
+        }
+
         List<OrganizationContactPoints> filtered =
             organizationContactPoints.Select(o => o.CloneWithoutContactPoints()).ToList();
 

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Authorization/AuthorizationServiceTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Authorization/AuthorizationServiceTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;
@@ -520,6 +522,52 @@ public class AuthorizationServiceTests
         result.Should().HaveCount(1);
         result[0].UserContactPoints.Should().HaveCount(4);
         result[0].UserContactPoints.Select(u => u.UserId).Should().BeEquivalentTo([1, 2, 3, 4]);
+    }
+
+    [Fact]
+    public async Task AuthorizeUsersForResource_PdpReturnsNull_ThrowsHttpRequestException()
+    {
+        var target = CreateService();
+
+        List<OrganizationContactPoints> organizationContactPoints =
+        [
+            new OrganizationContactPoints
+            {
+                PartyId = 1001,
+                UserContactPoints = [new() { UserId = 1 }]
+            }
+        ];
+
+        _pdpMock.Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
+            .ReturnsAsync((XacmlJsonResponse)null!);
+
+        Func<Task> act = () => target.AuthorizeUserContactPointsForResource(organizationContactPoints, "app_ttd_apps-test");
+
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .WithMessage("Authorization PDP returned a null or empty response.");
+    }
+
+    [Fact]
+    public async Task AuthorizeUsersForResource_PdpReturnsNullResponse_ThrowsHttpRequestException()
+    {
+        var target = CreateService();
+
+        List<OrganizationContactPoints> organizationContactPoints =
+        [
+            new OrganizationContactPoints
+            {
+                PartyId = 1001,
+                UserContactPoints = [new() { UserId = 1 }]
+            }
+        ];
+
+        _pdpMock.Setup(pdp => pdp.GetDecisionForRequest(It.IsAny<XacmlJsonRequestRoot>()))
+            .ReturnsAsync(new XacmlJsonResponse { Response = null! });
+
+        Func<Task> act = () => target.AuthorizeUserContactPointsForResource(organizationContactPoints, "app_ttd_apps-test");
+
+        await act.Should().ThrowAsync<HttpRequestException>()
+            .WithMessage("Authorization PDP returned a null or empty response.");
     }
 
     private static XacmlJsonResult CreatePermitResult(XacmlJsonRequestRoot request, XacmlJsonRequestReference reference)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added a null check to the PDP-response in `AuthorizationService.AuthorizeSingleBatch` 
- Added 2 new tests that check both null branches 

## Related Issue(s)
- #1523 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization service now properly validates responses from the authorization provider and immediately reports errors when receiving invalid or empty responses, preventing potential failures later in the authorization process.

* **Tests**
  * Added comprehensive test coverage to validate authorization service error handling for edge cases including null or invalid authorization responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->