### PR TITLE
Chore 1569 mask private information status message details

### DIFF
--- a/components/api/src/Altinn.Notifications.Integrations/Telemetry/DeliveryReportMetrics.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Telemetry/DeliveryReportMetrics.cs
@@ -56,7 +56,7 @@ public sealed class DeliveryReportMetrics : IDisposable
         {
             { "channel",                          "email" },
             { "email.status",                     status ?? string.Empty },
-            { "email.status_message",             statusMessage ?? string.Empty },
+            { "email.status_message",             EmailMaskingHelper.RedactEmailAddressesFromMessage(statusMessage, recipient, sender) },
             { "email.recipient_mail_server",      recipientMailServerHostName ?? string.Empty },
             { "email.sender",                     EmailMaskingHelper.MaskEmailAddress(sender) },
             { "email.recipient",                  EmailMaskingHelper.MaskEmailAddress(recipient) },

--- a/components/api/src/Altinn.Notifications.Integrations/Telemetry/DeliveryReportMetrics.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Telemetry/DeliveryReportMetrics.cs
@@ -56,7 +56,7 @@ public sealed class DeliveryReportMetrics : IDisposable
         {
             { "channel",                          "email" },
             { "email.status",                     status ?? string.Empty },
-            { "email.status_message",             EmailMaskingHelper.RedactEmailAddressesFromMessage(statusMessage, recipient, sender) },
+            { "email.status_message",             EmailMaskingHelper.RedactEmailAddressesFromMessage(statusMessage, recipient ?? string.Empty, sender ?? string.Empty) },
             { "email.recipient_mail_server",      recipientMailServerHostName ?? string.Empty },
             { "email.sender",                     EmailMaskingHelper.MaskEmailAddress(sender) },
             { "email.recipient",                  EmailMaskingHelper.MaskEmailAddress(recipient) },

--- a/components/api/src/Altinn.Notifications.Integrations/Telemetry/EmailMaskingHelper.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Telemetry/EmailMaskingHelper.cs
@@ -57,7 +57,7 @@ internal static class EmailMaskingHelper
         var redacted = message;
         foreach (var address in knownAddresses.Where(address => !string.IsNullOrWhiteSpace(address)))
         {
-            redacted = redacted.Replace(address, "[redacted]", StringComparison.OrdinalIgnoreCase);
+            redacted = redacted.Replace(address, MaskEmailAddress(address), StringComparison.OrdinalIgnoreCase);
         }
 
         return redacted;

--- a/components/api/src/Altinn.Notifications.Integrations/Telemetry/EmailMaskingHelper.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Telemetry/EmailMaskingHelper.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace Altinn.Notifications.Integrations.Telemetry;
 
 /// <summary>
@@ -35,5 +37,29 @@ internal static class EmailMaskingHelper
         }
 
         return $"{localPart[..2]}***@{domain}";
+    }
+
+    /// <summary>
+    /// Redacts known email addresses from a free-form status message string,
+    /// replacing each occurrence with the literal text "[redacted]".
+    /// Returns an empty string if <paramref name="message"/> is null or whitespace.
+    /// </summary>
+    /// <param name="message">The status message that may contain email addresses.</param>
+    /// <param name="knownAddresses">The email addresses to redact from the message.</param>
+    /// <returns>The message with known addresses redacted.</returns>
+    internal static string RedactEmailAddressesFromMessage(string? message, params string[] knownAddresses)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return string.Empty;
+        }
+
+        var redacted = message;
+        foreach (var address in knownAddresses.Where(address => !string.IsNullOrWhiteSpace(address)))
+        {
+            redacted = redacted.Replace(address, "[redacted]", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return redacted;
     }
 }

--- a/components/api/src/Altinn.Notifications.Integrations/Telemetry/EmailMaskingHelper.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Telemetry/EmailMaskingHelper.cs
@@ -41,7 +41,7 @@ internal static class EmailMaskingHelper
 
     /// <summary>
     /// Redacts known email addresses from a free-form status message string,
-    /// replacing each occurrence with the literal text "[redacted]".
+    /// replacing each occurrence with the masked version of the email address.
     /// Returns an empty string if <paramref name="message"/> is null or whitespace.
     /// </summary>
     /// <param name="message">The status message that may contain email addresses.</param>
@@ -55,7 +55,7 @@ internal static class EmailMaskingHelper
         }
 
         var redacted = message;
-        foreach (var address in knownAddresses.Where(address => !string.IsNullOrWhiteSpace(address)))
+        foreach (var address in (knownAddresses ?? []).Where(address => !string.IsNullOrWhiteSpace(address)))
         {
             redacted = redacted.Replace(address, MaskEmailAddress(address), StringComparison.OrdinalIgnoreCase);
         }

--- a/components/api/test/Altinn.Notifications.IntegrationTests/Telemetry/DeliveryReportMetricsTests.cs
+++ b/components/api/test/Altinn.Notifications.IntegrationTests/Telemetry/DeliveryReportMetricsTests.cs
@@ -153,6 +153,32 @@ public sealed class DeliveryReportMetricsTests : IDisposable
         Assert.Equal("Delivered", capturedTags["sms.send_result"]);
     }
 
+    [Fact]
+    public void RecordEmailDeliveryReport_StatusMessageContainingRecipient_IsRedactedInTag()
+    {
+        // Arrange
+        var capturedTags = new Dictionary<string, object?>();
+
+        using var listener = CreateListener((_, _, tags) =>
+        {
+            foreach (var tag in tags)
+            {
+                capturedTags[tag.Key] = tag.Value;
+            }
+        });
+
+        // Act
+        _sut.RecordEmailDeliveryReport(
+            status: "Failed",
+            statusMessage: "Delivery failed for recipient@example.com: mailbox full",
+            recipientMailServerHostName: "mail.example.com",
+            sender: "sender@example.com",
+            recipient: "recipient@example.com");
+
+        // Assert
+        Assert.Equal("Delivery failed for [redacted]: mailbox full", capturedTags["email.status_message"]);
+    }
+
     [Theory]
     [InlineData("sender@example.com", "se***@example.com")]
     [InlineData("ab@example.com", "***@example.com")]     // local part <= 2 chars
@@ -178,6 +204,25 @@ public sealed class DeliveryReportMetricsTests : IDisposable
     public void MaskEmailAddress_InvalidFormat_ReturnsEmptyString(string input)
     {
         Assert.Equal(string.Empty, EmailMaskingHelper.MaskEmailAddress(input));
+    }
+
+    [Theory]
+    [InlineData("Delivery failed for recipient@example.com: mailbox full", "recipient@example.com", "Delivery failed for [redacted]: mailbox full")]
+    [InlineData("Message rejected. Address RECIPIENT@EXAMPLE.COM not found.", "recipient@example.com", "Message rejected. Address [redacted] not found.")] // case-insensitive
+    [InlineData("Permanent failure.", "recipient@example.com", "Permanent failure.")] // no address in message
+    [InlineData("Failed: recipient@example.com and sender@example.com both invalid.", "recipient@example.com", "Failed: [redacted] and sender@example.com both invalid.")] // only redacts the passed address
+    public void RedactEmailAddressesFromMessage_ReplacesKnownAddressWithRedacted(string message, string address, string expected)
+    {
+        Assert.Equal(expected, EmailMaskingHelper.RedactEmailAddressesFromMessage(message, address));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RedactEmailAddressesFromMessage_NullOrWhitespaceMessage_ReturnsEmptyString(string? message)
+    {
+        Assert.Equal(string.Empty, EmailMaskingHelper.RedactEmailAddressesFromMessage(message, "recipient@example.com"));
     }
 
     private static MeterListener CreateListener(

--- a/components/api/test/Altinn.Notifications.IntegrationTests/Telemetry/DeliveryReportMetricsTests.cs
+++ b/components/api/test/Altinn.Notifications.IntegrationTests/Telemetry/DeliveryReportMetricsTests.cs
@@ -161,7 +161,10 @@ public sealed class DeliveryReportMetricsTests : IDisposable
 
         using var listener = CreateListener((_, _, tags) =>
         {
-            foreach (var tag in tags) capturedTags[tag.Key] = tag.Value;
+            foreach (var tag in tags)
+            {
+                capturedTags[tag.Key] = tag.Value;
+            }
         });
 
         // Act

--- a/components/api/test/Altinn.Notifications.IntegrationTests/Telemetry/DeliveryReportMetricsTests.cs
+++ b/components/api/test/Altinn.Notifications.IntegrationTests/Telemetry/DeliveryReportMetricsTests.cs
@@ -154,17 +154,14 @@ public sealed class DeliveryReportMetricsTests : IDisposable
     }
 
     [Fact]
-    public void RecordEmailDeliveryReport_StatusMessageContainingRecipient_IsRedactedInTag()
+    public void RecordEmailDeliveryReport_StatusMessageContainingRecipient_IsMaskedInTag()
     {
         // Arrange
         var capturedTags = new Dictionary<string, object?>();
 
         using var listener = CreateListener((_, _, tags) =>
         {
-            foreach (var tag in tags)
-            {
-                capturedTags[tag.Key] = tag.Value;
-            }
+            foreach (var tag in tags) capturedTags[tag.Key] = tag.Value;
         });
 
         // Act
@@ -176,7 +173,7 @@ public sealed class DeliveryReportMetricsTests : IDisposable
             recipient: "recipient@example.com");
 
         // Assert
-        Assert.Equal("Delivery failed for [redacted]: mailbox full", capturedTags["email.status_message"]);
+        Assert.Equal("Delivery failed for re***@example.com: mailbox full", capturedTags["email.status_message"]);
     }
 
     [Theory]
@@ -207,11 +204,11 @@ public sealed class DeliveryReportMetricsTests : IDisposable
     }
 
     [Theory]
-    [InlineData("Delivery failed for recipient@example.com: mailbox full", "recipient@example.com", "Delivery failed for [redacted]: mailbox full")]
-    [InlineData("Message rejected. Address RECIPIENT@EXAMPLE.COM not found.", "recipient@example.com", "Message rejected. Address [redacted] not found.")] // case-insensitive
+    [InlineData("Delivery failed for recipient@example.com: mailbox full", "recipient@example.com", "Delivery failed for re***@example.com: mailbox full")]
+    [InlineData("Message rejected. Address RECIPIENT@EXAMPLE.COM not found.", "recipient@example.com", "Message rejected. Address re***@example.com not found.")] // case-insensitive
     [InlineData("Permanent failure.", "recipient@example.com", "Permanent failure.")] // no address in message
-    [InlineData("Failed: recipient@example.com and sender@example.com both invalid.", "recipient@example.com", "Failed: [redacted] and sender@example.com both invalid.")] // only redacts the passed address
-    public void RedactEmailAddressesFromMessage_ReplacesKnownAddressWithRedacted(string message, string address, string expected)
+    [InlineData("Failed: recipient@example.com and sender@example.com both invalid.", "recipient@example.com", "Failed: re***@example.com and sender@example.com both invalid.")] // only redacts the passed address
+    public void RedactEmailAddressesFromMessage_ReplacesKnownAddressWithMasked(string message, string address, string expected)
     {
         Assert.Equal(expected, EmailMaskingHelper.RedactEmailAddressesFromMessage(message, address));
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Instead of replacing the recipient/sender private information with the constant "[redacted]", the replacement is now the masked recipient/sender using the same masking helper as the other private tags


## Related Issue(s)
- #1569 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email addresses appearing in delivery status messages are now automatically redacted in telemetry and monitoring data; redaction is case-insensitive and preserves other metric tagging.

* **Tests**
  * Added comprehensive tests verifying redaction behavior (including case variations, multiple addresses, and empty/null messages) and that telemetry metrics record the redacted status message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->