### PR TITLE
Update dependencies to patch vulnerabilities

### DIFF
--- a/components/api/src/Altinn.Notifications.Core/Altinn.Notifications.Core.csproj
+++ b/components/api/src/Altinn.Notifications.Core/Altinn.Notifications.Core.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Altinn.Authorization.ProblemDetails.Abstractions" Version="5.4.0" />
-    <PackageReference Include="Parquet.Net" Version="5.6.0" />
+    <PackageReference Include="Parquet.Net" Version="5.6.1" />
     <PackageReference Include="libphonenumber-csharp" Version="9.0.29" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />

--- a/components/api/src/Altinn.Notifications.Integrations/Altinn.Notifications.Integrations.csproj
+++ b/components/api/src/Altinn.Notifications.Integrations/Altinn.Notifications.Integrations.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Azure.Messaging.EventGrid" Version="5.0.0" />
     <PackageReference Include="Confluent.Kafka" Version="2.14.0" />
     <PackageReference Include="Confluent.Kafka.Extensions.OpenTelemetry" Version="0.4.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.15.3"/>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.7" />
     <PackageReference Include="Npgsql" Version="10.0.2" />
     <PackageReference Include="WolverineFx" Version="5.32.1" />


### PR DESCRIPTION
Patching Parquet.Net
Adding explicit OpenTelemetry.Api dependency to force the patched version in Confluent.Kafka.Extensions.OpenTelemetry (v0.4.0). OpenTelemetry.Api can be removed when Confluent.Kafka.Extensions.OpenTelemetry is removed 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Parquet.Net dependency to version 5.6.1
  * Added OpenTelemetry.Api dependency (version 1.15.3)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->