### PR TITLE
fix: add test data cleanup to OrderLifecycleStageIntegrationTests

### DIFF
--- a/components/api/test/Altinn.Notifications.IntegrationTests/Notifications/OrderPhase/OrderLifecycleStageIntegrationTests.cs
+++ b/components/api/test/Altinn.Notifications.IntegrationTests/Notifications/OrderPhase/OrderLifecycleStageIntegrationTests.cs
@@ -216,11 +216,15 @@ public class OrderLifecycleStageIntegrationTests(SpyContactPointServiceFactory f
 
     public async ValueTask DisposeAsync()
     {
-        await PostgreUtil.DeleteOrdersByAlternateIds(_orderIdsToDelete);
-
-        _client?.Dispose();
-
-        GC.SuppressFinalize(this);
+        try
+        {
+            await PostgreUtil.DeleteOrdersByAlternateIds(_orderIdsToDelete);
+        }
+        finally
+        {
+            _client?.Dispose();
+            GC.SuppressFinalize(this);
+        }
     }
 
     private async Task<HttpResponseMessage> SendPostRequest(NotificationOrderChainRequestExt request)
@@ -232,7 +236,7 @@ public class OrderLifecycleStageIntegrationTests(SpyContactPointServiceFactory f
         {
             var body = await response.Content.ReadAsStringAsync();
             var result = JsonSerializer.Deserialize<NotificationOrderChainResponseExt>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            if (result is not null)
+            if (result?.OrderChainReceipt is not null)
             {
                 _orderIdsToDelete.Add(result.OrderChainReceipt.ShipmentId);
 

--- a/components/api/test/Altinn.Notifications.IntegrationTests/Notifications/OrderPhase/OrderLifecycleStageIntegrationTests.cs
+++ b/components/api/test/Altinn.Notifications.IntegrationTests/Notifications/OrderPhase/OrderLifecycleStageIntegrationTests.cs
@@ -23,6 +23,7 @@ public class OrderLifecycleStageIntegrationTests(SpyContactPointServiceFactory f
 {
     private const string _basePath = "/notifications/api/v1/future/orders";
     private readonly SpyContactPointServiceFactory _factory = factory;
+    private readonly List<Guid> _orderIdsToDelete = [];
     private HttpClient _client = null!;
 
     [Fact]
@@ -213,17 +214,35 @@ public class OrderLifecycleStageIntegrationTests(SpyContactPointServiceFactory f
         return ValueTask.CompletedTask;
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
+        await PostgreUtil.DeleteOrdersByAlternateIds(_orderIdsToDelete);
+
         _client?.Dispose();
 
         GC.SuppressFinalize(this);
-        return ValueTask.CompletedTask;
     }
 
     private async Task<HttpResponseMessage> SendPostRequest(NotificationOrderChainRequestExt request)
     {
         using var content = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
-        return await _client.PostAsync(_basePath, content);
+        var response = await _client.PostAsync(_basePath, content);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            var result = JsonSerializer.Deserialize<NotificationOrderChainResponseExt>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            if (result is not null)
+            {
+                _orderIdsToDelete.Add(result.OrderChainReceipt.ShipmentId);
+
+                if (result.OrderChainReceipt.Reminders is not null)
+                {
+                    _orderIdsToDelete.AddRange(result.OrderChainReceipt.Reminders.Select(r => r.ShipmentId));
+                }
+            }
+        }
+
+        return response;
     }
 }


### PR DESCRIPTION
## Description
Each test in `OrderLifecycleStageIntegrationTests` creates notification orders in the database via the API, but `DisposeAsync` was not deleting them after each test run.

## Related Issue(s)
- #904

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test cleanup to ensure proper resource management and data removal after test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->