### PR TITLE
Add retry policies

### DIFF
--- a/components/api/src/Altinn.Notifications.Integrations/Wolverine/Policies/SmsSendResultHandlerPolicy.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Wolverine/Policies/SmsSendResultHandlerPolicy.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 
 using Altinn.Notifications.Core.Enums;
+using Altinn.Notifications.Core.Exceptions;
 using Altinn.Notifications.Integrations.Configuration;
 using Altinn.Notifications.Shared.Commands;
 
@@ -24,6 +25,8 @@ namespace Altinn.Notifications.Integrations.Wolverine.Policies;
 internal sealed class SmsSendResultHandlerPolicy(WolverineSettings settings) : IHandlerPolicy
 {
     private const string _unrecognizedSendResultReason = "UNRECOGNIZED_SEND_RESULT";
+    private const string _retryExceededReason = "RETRY_THRESHOLD_EXCEEDED";
+    private const string _notificationExpiredReason = "NOTIFICATION_EXPIRED";
 
     /// <inheritdoc/>
     public void Apply(IReadOnlyList<HandlerChain> chains, GenerationRules rules, IServiceContainer container)
@@ -42,6 +45,16 @@ internal sealed class SmsSendResultHandlerPolicy(WolverineSettings settings) : I
             .RetryWithCooldown(policy.GetCooldownDelays())
             .Then.ScheduleRetry(policy.GetScheduleDelays())
             .Then.MoveToErrorQueue();
+
+        chain
+            .OnException<NotificationNotFoundException>()
+            .RetryWithCooldown(policy.GetCooldownDelays())
+            .Then.ScheduleRetry(policy.GetScheduleDelays())
+            .Then.SaveDeadDeliveryReport(_retryExceededReason, DeliveryReportChannel.LinkMobility);
+
+        chain
+            .OnException<NotificationExpiredException>()
+            .SaveDeadDeliveryReport(_notificationExpiredReason, DeliveryReportChannel.LinkMobility);
 
         chain
             .OnException<ArgumentException>()

--- a/components/api/test/Altinn.Notifications.IntegrationTestsASB/Tests/SmsSendResultHandlerTests.cs
+++ b/components/api/test/Altinn.Notifications.IntegrationTestsASB/Tests/SmsSendResultHandlerTests.cs
@@ -1,4 +1,5 @@
 using Altinn.Notifications.Core.Enums;
+using Altinn.Notifications.Core.Exceptions;
 using Altinn.Notifications.Core.Models.Notification;
 using Altinn.Notifications.Core.Services.Interfaces;
 using Altinn.Notifications.IntegrationTestsASB.Infrastructure;
@@ -6,6 +7,9 @@ using Altinn.Notifications.IntegrationTestsASB.Utils;
 using Altinn.Notifications.Shared.Commands;
 using Altinn.Notifications.Shared.TestInfrastructure.Infrastructure;
 using Altinn.Notifications.Shared.TestInfrastructure.Utils;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 using Moq;
 
@@ -103,6 +107,145 @@ public class SmsSendResultHandlerTests(IntegrationTestContainersFixture fixture)
             // Assert - Verify the handler was called exactly as many times as the policy dictates
             Console.WriteLine($"[Test] Handler was called {attemptCount} times (expected {expectedAttempts})");
             Assert.Equal(expectedAttempts, attemptCount);
+        }
+    }
+
+    [Fact]
+    public async Task SmsSendResult_WhenNotificationNotFound_RetriesAndSavesDeadDeliveryReport()
+    {
+        // Arrange - Capture logs to count handler attempts via NotificationNotFoundException
+        var logCapture = new LogCapture(nameof(NotificationNotFoundException));
+
+        var factory = new IntegrationTestWebApplicationFactory(_fixture)
+            .ConfigureTestServices(services =>
+                services.AddSingleton<ILoggerProvider>(logCapture))
+            .Initialize();
+
+        await using (factory)
+        {
+            var policy = factory.WolverineSettings!.SmsSendResultQueuePolicy;
+            int expectedAttempts = 1 + policy.CooldownDelaysMs.Length + policy.ScheduleDelaysMs.Length;
+            string queueName = factory.WolverineSettings!.SmsSendResultQueueName;
+            string gatewayReference = Guid.NewGuid().ToString();
+
+            // Act - Send a command with a notificationId that doesn't exist in the database
+            var command = new SmsSendResultCommand
+            {
+                NotificationId = Guid.NewGuid(),
+                GatewayReference = gatewayReference,
+                SendResult = SmsNotificationResultType.Accepted.ToString()
+            };
+            await factory.SendToQueueAsync(queueName, command);
+
+            // Assert - Poll the dead delivery reports table until the report appears after retries exhaust
+            DeadDeliveryReportRow? deadReport = null;
+            var deadReportFound = await WaitForUtils.WaitForAsync(
+                async () =>
+                {
+                    deadReport = await PostgreUtil.GetDeadDeliveryReportByGatewayReference(
+                        _fixture.PostgresConnectionString,
+                        gatewayReference);
+                    return deadReport is not null;
+                },
+                maxAttempts: 40,
+                delayMs: 500);
+            Assert.True(deadReportFound, "Dead delivery report should be saved after retries are exhausted");
+            Assert.Equal("RETRY_THRESHOLD_EXCEEDED", deadReport!.Reason);
+            Assert.Equal(DeliveryReportChannel.LinkMobility, deadReport.Channel);
+            Assert.Equal(expectedAttempts, deadReport.AttemptCount);
+            Assert.False(deadReport.Resolved);
+
+            // Assert - Queue should be empty (message was handled, not moved to DLQ)
+            var queueEmpty = await ServiceBusTestUtils.WaitForEmptyAsync(
+                _fixture.ServiceBusConnectionString,
+                queueName,
+                TimeSpan.FromSeconds(5));
+            Assert.True(queueEmpty, "Queue should be empty — report is saved to dead delivery reports, not DLQ");
+
+            // Assert - DLQ is empty
+            var dlqEmpty = await ServiceBusTestUtils.WaitForDeadLetterEmptyAsync(
+                _fixture.ServiceBusConnectionString,
+                queueName,
+                TimeSpan.FromSeconds(5));
+            Assert.True(dlqEmpty, "Dead letter queue should be empty — NotificationNotFoundException should not trigger DLQ");
+
+            // Assert - Verify the handler was called exactly as many times as the policy dictates
+            Console.WriteLine($"[Test] NotificationNotFoundException logged {logCapture.Count} times (expected {expectedAttempts})");
+            Assert.Equal(expectedAttempts, logCapture.Count);
+        }
+    }
+
+    [Fact]
+    public async Task SmsSendResult_WhenNotificationExpired_SavesDeadDeliveryReportWithoutRetry()
+    {
+        // Arrange - Capture logs to verify the handler only runs once (no retries for expired)
+        var logCapture = new LogCapture(nameof(NotificationExpiredException));
+
+        var factory = new IntegrationTestWebApplicationFactory(_fixture)
+            .ConfigureTestServices(services =>
+                services.AddSingleton<ILoggerProvider>(logCapture))
+            .Initialize();
+
+        await using (factory)
+        {
+            // Arrange - Create notification, set gatewayReference via Accepted status,
+            // then expire it. Must set gatewayReference before expiring — the SQL function
+            // blocks updates on expired notifications.
+            string gatewayReference = Guid.NewGuid().ToString();
+            string queueName = factory.WolverineSettings!.SmsSendResultQueueName;
+            var (_, notification) = await PostgreUtil.PopulateDBWithOrderAndSmsNotification(factory);
+            await PostgreUtil.UpdateSmsSendStatus(factory, notification.Id, SmsNotificationResultType.Accepted, gatewayReference);
+
+            // Now expire the notification by backdating its expiry time
+            await PostgreUtil.RunSql(
+                _fixture.PostgresConnectionString,
+                "UPDATE notifications.smsnotifications SET expirytime = now() - interval '1 minute' WHERE alternateid = $1",
+                new NpgsqlParameter { Value = notification.Id });
+
+            // Act - Send send-result command for the expired notification
+            var command = new SmsSendResultCommand
+            {
+                NotificationId = notification.Id,
+                GatewayReference = gatewayReference,
+                SendResult = SmsNotificationResultType.Accepted.ToString()
+            };
+            await factory.SendToQueueAsync(queueName, command);
+
+            // Assert - Poll the dead delivery reports table until the report appears
+            DeadDeliveryReportRow? deadReport = null;
+            var deadReportFound = await WaitForUtils.WaitForAsync(
+                async () =>
+                {
+                    deadReport = await PostgreUtil.GetDeadDeliveryReportByGatewayReference(
+                        _fixture.PostgresConnectionString,
+                        gatewayReference);
+                    return deadReport is not null;
+                },
+                maxAttempts: 20,
+                delayMs: 500);
+            Assert.True(deadReportFound, "Dead delivery report should be saved for expired notifications");
+            Assert.Equal("NOTIFICATION_EXPIRED", deadReport!.Reason);
+            Assert.Equal(DeliveryReportChannel.LinkMobility, deadReport.Channel);
+            Assert.Equal(1, deadReport.AttemptCount);
+            Assert.False(deadReport.Resolved);
+
+            // Assert - Queue should be empty (message was handled, no retry)
+            var queueEmpty = await ServiceBusTestUtils.WaitForEmptyAsync(
+                _fixture.ServiceBusConnectionString,
+                queueName,
+                TimeSpan.FromSeconds(5));
+            Assert.True(queueEmpty, "Queue should be empty — expired notifications are not retried");
+
+            // Assert - DLQ is empty
+            var dlqEmpty = await ServiceBusTestUtils.WaitForDeadLetterEmptyAsync(
+                _fixture.ServiceBusConnectionString,
+                queueName,
+                TimeSpan.FromSeconds(5));
+            Assert.True(dlqEmpty, "Dead letter queue should be empty — NotificationExpiredException should not trigger DLQ");
+
+            // Assert - Verify the handler encountered the exception exactly once (no retries)
+            Console.WriteLine($"[Test] NotificationExpiredException logged {logCapture.Count} times");
+            Assert.Equal(1, logCapture.Count);
         }
     }
 


### PR DESCRIPTION
## Description
Add retry policies for when reading SMS send result

## Related Issue(s)
- #1578

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMS notification error handling for cases where notifications cannot be found or have expired. The system now properly logs these failures and prevents delivery retries for expired notifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-notifications/pull/1579)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->