### PR TITLE
Enhance retry ploicies

### DIFF
--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Handlers/SendEmailCommandHandler.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Handlers/SendEmailCommandHandler.cs
@@ -57,7 +57,7 @@ public static class SendEmailCommandHandler
     }
 
     /// <summary>
-    /// Logs a send-email failure at error level.
+    /// Logs a send-email failure at warning level.
     /// </summary>
     /// <param name="logger">The logger to write to.</param>
     /// <param name="notificationId">The notification ID associated with the failed send attempt.</param>

--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Handlers/SendEmailCommandHandler.cs
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Wolverine/Handlers/SendEmailCommandHandler.cs
@@ -48,13 +48,9 @@ public static class SendEmailCommandHandler
                 "Successfully dispatched email for NotificationId: {NotificationId}",
                 command.NotificationId);
         }
-        catch (OperationCanceledException)
+        catch (Exception)
         {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            LogOnSendEmailFailed(logger, ex, command.NotificationId);
+            LogOnSendEmailFailed(logger, command.NotificationId);
 
             throw;
         }
@@ -64,12 +60,10 @@ public static class SendEmailCommandHandler
     /// Logs a send-email failure at error level.
     /// </summary>
     /// <param name="logger">The logger to write to.</param>
-    /// <param name="exception">The exception that caused the failure.</param>
     /// <param name="notificationId">The notification ID associated with the failed send attempt.</param>
-    private static void LogOnSendEmailFailed(ILogger logger, Exception exception, Guid notificationId)
+    private static void LogOnSendEmailFailed(ILogger logger, Guid notificationId)
     {
-        logger.LogError(
-            exception,
+        logger.LogWarning(
             "SendEmailCommandHandler failed to send email for NotificationId: {NotificationId}.",
             notificationId);
     }

--- a/components/email-service/test/Altinn.Notifications.Email.Tests/Email.Integrations/Wolverine/SendEmailCommandHandlerTests.cs
+++ b/components/email-service/test/Altinn.Notifications.Email.Tests/Email.Integrations/Wolverine/SendEmailCommandHandlerTests.cs
@@ -22,12 +22,8 @@ public class SendEmailCommandHandlerTests
         ToAddress = "recipient@example.com"
     };
 
-    /// <summary>
-    /// Verifies that a general <see cref="Exception"/> thrown by
-    /// <see cref="ISendingService.SendAsync"/> is logged at error level and then rethrown.
-    /// </summary>
     [Fact]
-    public async Task HandleAsync_GeneralException_LogsErrorAndRethrows()
+    public async Task HandleAsync_GeneralException_LogsWarningAndRethrows()
     {
         // Arrange
         var exception = new InvalidOperationException("SMTP connection failed");
@@ -48,18 +44,14 @@ public class SendEmailCommandHandlerTests
 
         loggerMock.Verify(
             l => l.Log(
-                LogLevel.Error,
+                LogLevel.Warning,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("failed to send email") && v.ToString()!.Contains(_validSendEmailCommand.NotificationId.ToString())),
-                exception,
+                (Exception?)null,
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }
 
-    /// <summary>
-    /// Verifies that an unknown <see cref="SendEmailCommand.ContentType"/> value is
-    /// logged at error level and the email is sent with <see cref="EmailContentType.Plain"/> as the fallback.
-    /// </summary>
     [Fact]
     public async Task HandleAsync_UnknownContentType_LogsErrorAndDefaultsToPlain()
     {
@@ -94,17 +86,16 @@ public class SendEmailCommandHandlerTests
         Assert.Equal(EmailContentType.Plain, capturedEmail!.ContentType);
     }
 
-    /// <summary>
-    /// Verifies that an <see cref="OperationCanceledException"/> thrown by <see cref="ISendingService.SendAsync"/> is rethrown directly without invoking the send-failure error logger.
-    /// </summary>
     [Fact]
-    public async Task HandleAsync_OperationCanceledException_RethrowsWithoutLoggingException()
+    public async Task HandleAsync_OperationCanceledException_LogsWarningAndRethrows()
     {
         // Arrange
+        var exception = new OperationCanceledException();
+
         var sendingServiceMock = new Mock<ISendingService>();
         sendingServiceMock
             .Setup(s => s.SendAsync(It.IsAny<Notifications.Email.Core.Sending.Email>()))
-            .ThrowsAsync(new OperationCanceledException());
+            .ThrowsAsync(exception);
 
         var loggerMock = new Mock<ILogger>();
         loggerMock.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
@@ -115,11 +106,11 @@ public class SendEmailCommandHandlerTests
 
         loggerMock.Verify(
             l => l.Log(
-                LogLevel.Error,
+                LogLevel.Warning,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("failed to send email")),
-                It.IsAny<Exception>(),
+                (Exception?)null,
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Never);
+            Times.Once);
     }
 }

--- a/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Wolverine/Handlers/SendSmsCommandHandler.cs
+++ b/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Wolverine/Handlers/SendSmsCommandHandler.cs
@@ -25,7 +25,7 @@ public static class SendSmsCommandHandler
         if (command.NotificationId == Guid.Empty)
         {
             logger.LogError("Received SendSmsCommand with missing NotificationId.");
-            throw new InvalidOperationException("Received SendSmsCommand with missing NotificationId.");
+            return;
         }
 
         logger.LogInformation(
@@ -48,10 +48,6 @@ public static class SendSmsCommandHandler
                 "Successfully dispatched SMS for NotificationId: {NotificationId}",
                 command.NotificationId);
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
         catch (Exception ex)
         {
             LogOnSendSmsFailed(logger, ex, command.NotificationId);
@@ -62,7 +58,7 @@ public static class SendSmsCommandHandler
 
     private static void LogOnSendSmsFailed(ILogger logger, Exception exception, Guid notificationId)
     {
-        logger.LogError(
+        logger.LogWarning(
             exception,
             "SendSmsCommandHandler failed to send SMS for NotificationId: {NotificationId}.",
             notificationId);

--- a/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Wolverine/Handlers/SendSmsCommandHandler.cs
+++ b/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Wolverine/Handlers/SendSmsCommandHandler.cs
@@ -56,6 +56,11 @@ public static class SendSmsCommandHandler
         }
     }
 
+    /// <summary>
+    /// Logs a send-sms failure at warning level.
+    /// </summary>
+    /// <param name="logger">The logger to write to.</param>
+    /// <param name="notificationId">The notification ID associated with the failed send attempt.</param>
     private static void LogOnSendSmsFailed(ILogger logger, Guid notificationId)
     {
         logger.LogWarning(

--- a/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Wolverine/Handlers/SendSmsCommandHandler.cs
+++ b/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Wolverine/Handlers/SendSmsCommandHandler.cs
@@ -48,18 +48,17 @@ public static class SendSmsCommandHandler
                 "Successfully dispatched SMS for NotificationId: {NotificationId}",
                 command.NotificationId);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            LogOnSendSmsFailed(logger, ex, command.NotificationId);
+            LogOnSendSmsFailed(logger, command.NotificationId);
 
             throw;
         }
     }
 
-    private static void LogOnSendSmsFailed(ILogger logger, Exception exception, Guid notificationId)
+    private static void LogOnSendSmsFailed(ILogger logger, Guid notificationId)
     {
         logger.LogWarning(
-            exception,
             "SendSmsCommandHandler failed to send SMS for NotificationId: {NotificationId}.",
             notificationId);
     }

--- a/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Wolverine/Policies/SendSmsCommandHandlerPolicy.cs
+++ b/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Wolverine/Policies/SendSmsCommandHandlerPolicy.cs
@@ -4,8 +4,12 @@ using Altinn.Notifications.Shared.Commands;
 using Altinn.Notifications.Sms.Integrations.Configuration;
 
 using Azure.Messaging.ServiceBus;
+
 using JasperFx;
 using JasperFx.CodeGeneration;
+
+using LinkMobility.PSWin.Client;
+
 using Wolverine.Configuration;
 using Wolverine.ErrorHandling;
 using Wolverine.Runtime.Handlers;
@@ -38,8 +42,9 @@ internal sealed class SendSmsCommandHandlerPolicy(WolverineSettings wolverineSet
         chain
            .OnException<TimeoutException>()
            .Or<ServiceBusException>()
+           .Or<HttpRequestException>()
+           .Or<SendMessageException>()
            .Or<TaskCanceledException>()
-           .Or<InvalidOperationException>()
            .RetryWithCooldown(policy.GetCooldownDelays())
            .Then.ScheduleRetry(policy.GetScheduleDelays())
            .Then.MoveToErrorQueue();

--- a/components/sms-service/test/Altinn.Notifications.Sms.IntegrationTestsASB/Tests/SendSmsCommandHandlerTests.cs
+++ b/components/sms-service/test/Altinn.Notifications.Sms.IntegrationTestsASB/Tests/SendSmsCommandHandlerTests.cs
@@ -127,12 +127,11 @@ public class SendSmsCommandHandlerTests(IntegrationTestContainersFixture fixture
     }
 
     /// <summary>
-    /// Verifies that when a SendSmsCommand has an empty NotificationId, the handler throws
-    /// an <see cref="InvalidOperationException"/> which is not covered by the retry policy,
-    /// causing the message to go directly to the dead letter queue without any retries.
+    /// Verifies that when a SendSmsCommand has an empty NotificationId, the handler discards
+    /// the message silently without invoking the sending service or dead-lettering the message.
     /// </summary>
     [Fact]
-    public async Task HandleAsync_WhenNotificationIdIsEmpty_GoesToDeadLetterQueueWithoutRetry()
+    public async Task HandleAsync_WhenNotificationIdIsEmpty_DiscardsMessageWithoutCallingService()
     {
         // Arrange
         var mockService = new Mock<ISendingService>();
@@ -145,7 +144,7 @@ public class SendSmsCommandHandlerTests(IntegrationTestContainersFixture fixture
         {
             string queueName = GetQueueName(factory);
 
-            // Act - NotificationId = Guid.Empty triggers InvalidOperationException in the handler guard clause
+            // Act - NotificationId = Guid.Empty triggers the guard clause which logs and returns early
             await factory.SendToQueueAsync(queueName, new SendSmsCommand
             {
                 NotificationId = Guid.Empty,
@@ -154,15 +153,18 @@ public class SendSmsCommandHandlerTests(IntegrationTestContainersFixture fixture
                 SenderNumber = "Altinn"
             });
 
-            // Assert - Message should appear in DLQ quickly as InvalidOperationException is not retried by the policy
+            // Allow time for the message to be processed
+            await Task.Delay(TimeSpan.FromSeconds(5));
+
+            // Assert - Message should NOT appear in the DLQ as it is discarded, not failed
             var deadLetterMessage = await ServiceBusTestUtils.WaitForDeadLetterMessageAsync(
                 _fixture.ServiceBusConnectionString,
                 queueName,
-                TimeSpan.FromSeconds(10));
+                TimeSpan.FromSeconds(2));
 
-            Assert.NotNull(deadLetterMessage);
+            Assert.Null(deadLetterMessage);
 
-            // Assert - The sending service should never have been called since the guard throws before it
+            // Assert - The sending service should never have been called
             mockService.Verify(s => s.SendAsync(It.IsAny<Core.Sending.Sms>()), Times.Never);
         }
     }

--- a/components/sms-service/test/Altinn.Notifications.Sms.Tests/Sms.Integrations/Wolverine/SendSmsCommandHandlerTests.cs
+++ b/components/sms-service/test/Altinn.Notifications.Sms.Tests/Sms.Integrations/Wolverine/SendSmsCommandHandlerTests.cs
@@ -44,7 +44,7 @@ public class SendSmsCommandHandlerTests
                 LogLevel.Warning,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("failed to send SMS") && v.ToString()!.Contains(_validSendSmsCommand.NotificationId.ToString())),
-                exception,
+                (Exception?)null,
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }
@@ -99,7 +99,7 @@ public class SendSmsCommandHandlerTests
                 LogLevel.Warning,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("failed to send SMS")),
-                exception,
+                (Exception?)null,
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }

--- a/components/sms-service/test/Altinn.Notifications.Sms.Tests/Sms.Integrations/Wolverine/SendSmsCommandHandlerTests.cs
+++ b/components/sms-service/test/Altinn.Notifications.Sms.Tests/Sms.Integrations/Wolverine/SendSmsCommandHandlerTests.cs
@@ -1,12 +1,11 @@
 using Altinn.Notifications.Shared.Commands;
+
+using Altinn.Notifications.Sms.Core.Sending;
 using Altinn.Notifications.Sms.Integrations.Wolverine.Handlers;
 
 using Microsoft.Extensions.Logging;
 
 using Moq;
-
-using ISendingService = Altinn.Notifications.Sms.Core.Sending.ISendingService;
-using SmsMessage = Altinn.Notifications.Sms.Core.Sending.Sms;
 
 namespace Altinn.Notifications.Sms.Tests.Sms.Integrations.Wolverine;
 
@@ -20,19 +19,15 @@ public class SendSmsCommandHandlerTests
         SenderNumber = "Altinn"
     };
 
-    /// <summary>
-    /// Verifies that a general <see cref="Exception"/> thrown by the sending service
-    /// is logged at error level and then rethrown.
-    /// </summary>
     [Fact]
-    public async Task HandleAsync_GeneralException_LogsErrorAndRethrows()
+    public async Task HandleAsync_GeneralException_LogsWarningAndRethrows()
     {
         // Arrange
         var exception = new InvalidOperationException("SMS gateway unavailable");
 
         var sendingServiceMock = new Mock<ISendingService>();
         sendingServiceMock
-            .Setup(s => s.SendAsync(It.IsAny<SmsMessage>()))
+            .Setup(s => s.SendAsync(It.IsAny<Notifications.Sms.Core.Sending.Sms>()))
             .ThrowsAsync(exception);
 
         var loggerMock = new Mock<ILogger>();
@@ -46,7 +41,7 @@ public class SendSmsCommandHandlerTests
 
         loggerMock.Verify(
             l => l.Log(
-                LogLevel.Error,
+                LogLevel.Warning,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("failed to send SMS") && v.ToString()!.Contains(_validSendSmsCommand.NotificationId.ToString())),
                 exception,
@@ -54,18 +49,43 @@ public class SendSmsCommandHandlerTests
             Times.Once);
     }
 
-    /// <summary>
-    /// Verifies that an <see cref="OperationCanceledException"/> thrown by the sending service
-    /// is rethrown directly without invoking the send-failure error logger.
-    /// </summary>
     [Fact]
-    public async Task HandleAsync_OperationCanceledException_RethrowsWithoutLoggingException()
+    public async Task HandleAsync_EmptyNotificationId_LogsErrorAndDiscardsMessage()
     {
         // Arrange
+        var command = new SendSmsCommand { NotificationId = Guid.Empty };
+
+        var sendingServiceMock = new Mock<ISendingService>();
+
+        var loggerMock = new Mock<ILogger>();
+        loggerMock.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
+
+        // Act
+        await SendSmsCommandHandler.HandleAsync(command, sendingServiceMock.Object, loggerMock.Object);
+
+        // Assert
+        sendingServiceMock.Verify(s => s.SendAsync(It.IsAny<Notifications.Sms.Core.Sending.Sms>()), Times.Never);
+
+        loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("missing NotificationId")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_OperationCanceledException_LogsWarningAndRethrows()
+    {
+        // Arrange
+        var exception = new OperationCanceledException();
+
         var sendingServiceMock = new Mock<ISendingService>();
         sendingServiceMock
-            .Setup(s => s.SendAsync(It.IsAny<SmsMessage>()))
-            .ThrowsAsync(new OperationCanceledException());
+            .Setup(s => s.SendAsync(It.IsAny<Notifications.Sms.Core.Sending.Sms>()))
+            .ThrowsAsync(exception);
 
         var loggerMock = new Mock<ILogger>();
         loggerMock.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
@@ -76,11 +96,11 @@ public class SendSmsCommandHandlerTests
 
         loggerMock.Verify(
             l => l.Log(
-                LogLevel.Error,
+                LogLevel.Warning,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("failed to send SMS")),
-                It.IsAny<Exception>(),
+                exception,
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Never);
+            Times.Once);
     }
 }


### PR DESCRIPTION
## Description
When the SMS gateway returned transient HTTP errors (503, 504) or the network failed, the `SendSmsCommandHandlerPolicy` did not recognize those exceptions and moved messages to the error queue immediately instead of retrying them.

Additionally, both `SendSmsCommandHandler` and `SendEmailCommandHandler` were double-logging exceptions: once explicitly via `LogError(exception, ...)` in the handler, and again automatically by Wolverine. This produced redundant noise in Application
Insights with no adde no added context.

## Related Issue(s)
- #1580

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SMS messages with missing/empty notification IDs are now discarded (no dead-lettering) and prevent unnecessary send attempts.
  * Sending failures now log warnings instead of errors to reduce noise while still surfacing issues.

* **Refactor**
  * Standardized error handling and logging behavior across email and SMS delivery services for consistent observability.

* **Tests**
  * Updated tests to reflect new discard behavior and warning-level logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-notifications/pull/1582)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->