### PR TITLE
🔧 Replace references to test data from secrets->vars in workflows

### DIFF
--- a/.github/workflows/regression-test-ATX.yml
+++ b/.github/workflows/regression-test-ATX.yml
@@ -37,21 +37,21 @@ jobs:
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-email.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT }} -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e emailRecipient=${{ vars.AUTOMATEDTEST_EMAILRECIPIENT }} -e ninRecipient=${{ vars.AUTOMATEDTEST_NINRECIPIENT }}
           inspect-flags: -e altinn_env=${{ inputs.environment }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
 
       - name: Run contact(s) lookup by organization number regression tests with generating an email notification
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-org-no.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ secrets.AUTOMATEDTEST_ORG_NO_RECIPIENT}} -e resourceId=${{ secrets.AUTOMATEDTEST_RESOURCE_ID}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ vars.AUTOMATEDTEST_ORG_NO_RECIPIENT }} -e resourceId=${{ vars.AUTOMATEDTEST_RESOURCE_ID }}
           inspect-flags: -e altinn_env=${{ inputs.environment }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
 
       - name: Run sms notification order regression tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-sms.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT }}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e smsRecipient=${{ vars.AUTOMATEDTEST_SMSRECIPIENT }}
           inspect-flags: -e altinn_env=${{ inputs.environment }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
 
       - name: Run API v2 notification order regression tests
@@ -59,15 +59,15 @@ jobs:
         with:
           path: components/api/test/k6/src/tests/orders-v2.js
           flags: >-
-            --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT }}
-            -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}}
+            --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e ninRecipient=${{ vars.AUTOMATEDTEST_NINRECIPIENT }} -e emailRecipient=${{ vars.AUTOMATEDTEST_EMAILRECIPIENT }}
+            -e smsRecipient=${{ vars.AUTOMATEDTEST_SMSRECIPIENT }}
           inspect-flags: -e altinn_env=${{ inputs.environment }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
 
       - name: Run API v2 org lookup regression tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-org-no-v2.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ secrets.AUTOMATEDTEST_ORG_NO_RECIPIENT}} -e resourceId=urn:altinn:resource:${{ secrets.AUTOMATEDTEST_RESOURCE_ID}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ vars.AUTOMATEDTEST_ORG_NO_RECIPIENT }} -e resourceId=${{ vars.AUTOMATEDTEST_URN_RESOURCE_ID }}
           inspect-flags: -e altinn_env=${{ inputs.environment }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
   slack-notify:
     if: failure()

--- a/.github/workflows/regression-test-PROD.yaml
+++ b/.github/workflows/regression-test-PROD.yaml
@@ -37,33 +37,33 @@ jobs:
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-email.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT }} -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e emailRecipient=${{ vars.AUTOMATEDTEST_EMAILRECIPIENT }} -e ninRecipient=${{ vars.AUTOMATEDTEST_NINRECIPIENT }}
           inspect-flags: -e altinn_env=Prod # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run contact(s) lookup by organization number regression tests with generating an email notification
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-org-no.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ secrets.AUTOMATEDTEST_ORG_NO_RECIPIENT}} -e resourceId=${{ secrets.AUTOMATEDTEST_RESOURCE_ID}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ vars.AUTOMATEDTEST_ORG_NO_RECIPIENT }} -e resourceId=${{ vars.AUTOMATEDTEST_RESOURCE_ID }}
           inspect-flags: -e altinn_env=Prod # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run sms notification order use case tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-sms.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT }}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e smsRecipient=${{ vars.AUTOMATEDTEST_SMSRECIPIENT }}
           inspect-flags: -e altinn_env=Prod # Supplies the value for pre-run validation, when env vars / flags are not yet defined
 
       - name: Run API v2 notification order regression tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-v2.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e ninRecipient=${{ vars.AUTOMATEDTEST_NINRECIPIENT }} -e emailRecipient=${{ vars.AUTOMATEDTEST_EMAILRECIPIENT }} -e smsRecipient=${{ vars.AUTOMATEDTEST_SMSRECIPIENT }}
           inspect-flags: -e altinn_env=Prod # Supplies the value for pre-run validation, when env vars / flags are not yet defined
 
       - name: Run API v2 org lookup regression tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-org-no-v2.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ secrets.AUTOMATEDTEST_ORG_NO_RECIPIENT}} -e resourceId=urn:altinn:resource:${{ secrets.AUTOMATEDTEST_RESOURCE_ID}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ vars.AUTOMATEDTEST_ORG_NO_RECIPIENT }} -e resourceId=${{ vars.AUTOMATEDTEST_URN_RESOURCE_ID }}
           inspect-flags: -e altinn_env=Prod # Supplies the value for pre-run validation, when env vars / flags are not yet defined
   slack-notify:
     if: failure()

--- a/.github/workflows/regression-test-TT02.yaml
+++ b/.github/workflows/regression-test-TT02.yaml
@@ -37,33 +37,33 @@ jobs:
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-email.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT }} -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e emailRecipient=${{ vars.AUTOMATEDTEST_EMAILRECIPIENT }} -e ninRecipient=${{ vars.AUTOMATEDTEST_NINRECIPIENT }}
           inspect-flags: -e altinn_env=TT02 # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run contact(s) lookup by organization number regression tests with generating an email notification
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-org-no.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ secrets.AUTOMATEDTEST_ORG_NO_RECIPIENT}} -e resourceId=${{ secrets.AUTOMATEDTEST_RESOURCE_ID}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ vars.AUTOMATEDTEST_ORG_NO_RECIPIENT }} -e resourceId=${{ vars.AUTOMATEDTEST_RESOURCE_ID }}
           inspect-flags: -e altinn_env=TT02 # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run sms notification order regression tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-sms.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT }}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e smsRecipient=${{ vars.AUTOMATEDTEST_SMSRECIPIENT }}
           inspect-flags: -e altinn_env=TT02 # Supplies the value for pre-run validation, when env vars / flags are not yet defined
 
       - name: Run API v2 notification order regression tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-v2.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e ninRecipient=${{ vars.AUTOMATEDTEST_NINRECIPIENT }} -e emailRecipient=${{ vars.AUTOMATEDTEST_EMAILRECIPIENT }} -e smsRecipient=${{ vars.AUTOMATEDTEST_SMSRECIPIENT }}
           inspect-flags: -e altinn_env=TT02 # Supplies the value for pre-run validation, when env vars / flags are not yet defined
 
       - name: Run API v2 org lookup regression tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-org-no-v2.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ secrets.AUTOMATEDTEST_ORG_NO_RECIPIENT}} -e resourceId=urn:altinn:resource:${{ secrets.AUTOMATEDTEST_RESOURCE_ID}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ vars.AUTOMATEDTEST_ORG_NO_RECIPIENT }} -e resourceId=${{ vars.AUTOMATEDTEST_URN_RESOURCE_ID }}
           inspect-flags: -e altinn_env=TT02 # Supplies the value for pre-run validation, when env vars / flags are not yet defined
   slack-notify:
     if: failure()

--- a/.github/workflows/use-case-ATX.yaml
+++ b/.github/workflows/use-case-ATX.yaml
@@ -43,32 +43,32 @@ jobs:
         with:
           path: components/api/test/k6/src/tests/orders-v2.js
           flags: >-
-            --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT}}
-            -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}}
+            --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e ninRecipient=${{ vars.AUTOMATEDTEST_NINRECIPIENT }} -e emailRecipient=${{ vars.AUTOMATEDTEST_EMAILRECIPIENT }}
+            -e smsRecipient=${{ vars.AUTOMATEDTEST_SMSRECIPIENT }}
           inspect-flags: -e altinn_env=${{ matrix.environment }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run API v2 recipientOrganization tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-org-no-v2.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ secrets.AUTOMATEDTEST_ORG_NO_RECIPIENT}} -e resourceId=urn:altinn:resource:${{ secrets.AUTOMATEDTEST_RESOURCE_ID}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ vars.AUTOMATEDTEST_ORG_NO_RECIPIENT }} -e resourceId=${{ vars.AUTOMATEDTEST_URN_RESOURCE_ID }}
           inspect-flags: -e altinn_env=${{ matrix.environment }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run email notification order use case tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-email.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT }} -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e emailRecipient=${{ vars.AUTOMATEDTEST_EMAILRECIPIENT }} -e ninRecipient=${{ vars.AUTOMATEDTEST_NINRECIPIENT }}
           inspect-flags: -e altinn_env=${{ matrix.environment }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run contact(s) lookup by organization number use case tests with generating an email notification
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-org-no.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ secrets.AUTOMATEDTEST_ORG_NO_RECIPIENT}} -e resourceId=${{ secrets.AUTOMATEDTEST_RESOURCE_ID}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ vars.AUTOMATEDTEST_ORG_NO_RECIPIENT }} -e resourceId=${{ vars.AUTOMATEDTEST_RESOURCE_ID }}
           inspect-flags: -e altinn_env=${{ matrix.environment }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run sms notification order use case tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-sms.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT }}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e smsRecipient=${{ vars.AUTOMATEDTEST_SMSRECIPIENT }}
           inspect-flags: -e altinn_env=${{ matrix.environment }} # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Set failure output
         id: set-failure

--- a/.github/workflows/use-case-PROD.yaml
+++ b/.github/workflows/use-case-PROD.yaml
@@ -36,31 +36,31 @@ jobs:
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-v2.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e ninRecipient=${{ vars.AUTOMATEDTEST_NINRECIPIENT }} -e emailRecipient=${{ vars.AUTOMATEDTEST_EMAILRECIPIENT }} -e smsRecipient=${{ vars.AUTOMATEDTEST_SMSRECIPIENT }}
           inspect-flags: -e altinn_env=Prod # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run API v2 recipientOrganization tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-org-no-v2.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ secrets.AUTOMATEDTEST_ORG_NO_RECIPIENT}} -e resourceId=urn:altinn:resource:${{ secrets.AUTOMATEDTEST_RESOURCE_ID}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ vars.AUTOMATEDTEST_ORG_NO_RECIPIENT }} -e resourceId=${{ vars.AUTOMATEDTEST_URN_RESOURCE_ID }}
           inspect-flags: -e altinn_env=Prod # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run email notification order use case tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-email.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT }} -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e emailRecipient=${{ vars.AUTOMATEDTEST_EMAILRECIPIENT }} -e ninRecipient=${{ vars.AUTOMATEDTEST_NINRECIPIENT }}
           inspect-flags: -e altinn_env=Prod # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run contact(s) lookup by organization number use case tests with generating an email notification
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-org-no.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ secrets.AUTOMATEDTEST_ORG_NO_RECIPIENT}} -e resourceId=${{ secrets.AUTOMATEDTEST_RESOURCE_ID}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ vars.AUTOMATEDTEST_ORG_NO_RECIPIENT }} -e resourceId=${{ vars.AUTOMATEDTEST_RESOURCE_ID }}
           inspect-flags: -e altinn_env=Prod # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run sms notification order use case tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-sms.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT }}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e smsRecipient=${{ vars.AUTOMATEDTEST_SMSRECIPIENT }}
           inspect-flags: -e altinn_env=Prod # Supplies the value for pre-run validation, when env vars / flags are not yet defined
   slack-notify:
     if: failure()

--- a/.github/workflows/use-case-TT02.yaml
+++ b/.github/workflows/use-case-TT02.yaml
@@ -39,31 +39,31 @@ jobs:
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-v2.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT}} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e ninRecipient=${{ vars.AUTOMATEDTEST_NINRECIPIENT }} -e emailRecipient=${{ vars.AUTOMATEDTEST_EMAILRECIPIENT }} -e smsRecipient=${{ vars.AUTOMATEDTEST_SMSRECIPIENT }}
           inspect-flags: -e altinn_env=TT02 # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run API v2 recipientOrganization tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-org-no-v2.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ secrets.AUTOMATEDTEST_ORG_NO_RECIPIENT}} -e resourceId=urn:altinn:resource:${{ secrets.AUTOMATEDTEST_RESOURCE_ID}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ vars.AUTOMATEDTEST_ORG_NO_RECIPIENT }} -e resourceId=${{ vars.AUTOMATEDTEST_URN_RESOURCE_ID }}
           inspect-flags: -e altinn_env=TT02 # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run email notification order use case tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-email.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e emailRecipient=${{ secrets.AUTOMATEDTEST_EMAILRECIPIENT }} -e ninRecipient=${{ secrets.AUTOMATEDTEST_NINRECIPIENT}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e emailRecipient=${{ vars.AUTOMATEDTEST_EMAILRECIPIENT }} -e ninRecipient=${{ vars.AUTOMATEDTEST_NINRECIPIENT }}
           inspect-flags: -e altinn_env=TT02 # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run contact(s) lookup by organization number use case tests with generating an email notification
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-org-no.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ secrets.AUTOMATEDTEST_ORG_NO_RECIPIENT}} -e resourceId=${{ secrets.AUTOMATEDTEST_RESOURCE_ID}}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e orgNoRecipient=${{ vars.AUTOMATEDTEST_ORG_NO_RECIPIENT }} -e resourceId=${{ vars.AUTOMATEDTEST_RESOURCE_ID }}
           inspect-flags: -e altinn_env=TT02 # Supplies the value for pre-run validation, when env vars / flags are not yet defined
       - name: Run sms notification order use case tests
         uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
         with:
           path: components/api/test/k6/src/tests/orders-sms.js
-          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e smsRecipient=${{ secrets.AUTOMATEDTEST_SMSRECIPIENT }}
+          flags: --secret-source=file=${{ steps.k6-secrets.outputs.file }} -e smsRecipient=${{ vars.AUTOMATEDTEST_SMSRECIPIENT }}
           inspect-flags: -e altinn_env=TT02 # Supplies the value for pre-run validation, when env vars / flags are not yet defined
   slack-notify:
     if: failure()

--- a/components/api/test/k6/src/tests/orders-sms.js
+++ b/components/api/test/k6/src/tests/orders-sms.js
@@ -87,12 +87,8 @@ function postSmsNotificationOrderRequest(data) {
     );
 
     const success = check(response, {
-        "POST SMS notification order request. Status is 202 Accepted": (r) => {
-            console.error("Response status: ", r.status_text, r.body);
-            return r.status === 202
-        }
+        "POST SMS notification order request. Status is 202 Accepted": (r) => r.status === 202
     });
-
 
     stopIterationOnFail("POST SMS notification order request failed", success);
 

--- a/components/api/test/k6/src/tests/orders-sms.js
+++ b/components/api/test/k6/src/tests/orders-sms.js
@@ -4,9 +4,6 @@
     Command:
     podman compose run k6 run /src/tests/orders-sms.js \
         --secret-source=file=/.secrets \
-        -e mpClientId={the id of an integration defined in maskinporten} \
-        -e mpKid={the key id of the JSON web key used to sign the maskinporten token request} \
-        -e encodedJwk={the encoded JSON web key used to sign the maskinporten token request} \
         -e altinn_env={environment: at22, at23, at24, tt02, prod} \
         -e smsRecipient={a mobile number to include as a notification recipient} \
         -e runFullTestSet=true
@@ -90,8 +87,12 @@ function postSmsNotificationOrderRequest(data) {
     );
 
     const success = check(response, {
-        "POST SMS notification order request. Status is 202 Accepted": (r) => r.status === 202
+        "POST SMS notification order request. Status is 202 Accepted": (r) => {
+            console.error("Response status: ", r.status_text, r.body);
+            return r.status === 202
+        }
     });
+
 
     stopIterationOnFail("POST SMS notification order request failed", success);
 


### PR DESCRIPTION
Use the newly added _Environment variables_ for non-sensitive test data.
I have tested some of the workflows (with this branch as target), now running OK:
[Regression Test - AT22](https://github.com/Altinn/altinn-notifications/actions/runs/26565126072)
[Use Case - TT02](https://github.com/Altinn/altinn-notifications/actions/runs/26562283284)
[Regression test - PROD](https://github.com/Altinn/altinn-notifications/actions/runs/26569199809)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD test workflows to use repository variables instead of secrets for test configuration across multiple environments, improving secrets management practices.

**Note:** No user-facing changes in this release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-notifications/pull/1617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->