### PR TITLE
Increase Renovate `prHourlyLimit` to 6

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>Altinn/renovate-config"
+    "local>Altinn/renovate-config",
+    ":prHourlyLimit6"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Description
Increases `prHourlyLimit` from the default of 2 to 6 so that all six update groups (`github-actions`, `docker-compose`, `api-nuget`, `email-nuget`, `sms-nuget`, `shared-nuget`) can be created within a single Thursday schedule window.

## Related Issue(s)
- #1440

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->