### PR TITLE
fix(config): replace invalid Renovate preset with direct prHourlyLimit config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>Altinn/renovate-config",
-    ":prHourlyLimit6"
+    "local>Altinn/renovate-config"
   ],
+  "prHourlyLimit": 6,
   "packageRules": [
     {
       "matchFileNames": [


### PR DESCRIPTION
## Description
Replacing `:prHourlyLimit6` with the equivalent direct config option `"prHourlyLimit": 6` achieves the same intent without breaking the configuration.

## Related Issue(s)
- #1632

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable
