### PR TITLE
Filter outdated KRR contact info with configurable service-owner exemption

### DIFF
--- a/components/api/src/Altinn.Notifications.Core/Configuration/KrrContactInfoRetentionSettings.cs
+++ b/components/api/src/Altinn.Notifications.Core/Configuration/KrrContactInfoRetentionSettings.cs
@@ -1,0 +1,31 @@
+namespace Altinn.Notifications.Core.Configuration;
+
+/// <summary>
+/// Settings controlling whether contact information from the Contact and Reservation Register (KRR)
+/// that has not been updated or confirmed within a retention window may be used for notifications.
+/// </summary>
+/// <remarks>
+/// Reverts to the legacy Altinn 2 behaviour where outdated KRR contact information is not used,
+/// for all service owners except those explicitly exempted in <see cref="ExemptServiceOwners"/>
+/// (i.e. service owners with a deliberate, compensating process around outdated contact information).
+/// </remarks>
+public class KrrContactInfoRetentionSettings
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether outdated KRR contact information should be filtered out.
+    /// Defaults to <c>true</c> (restrictive by default).
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the maximum age, in months, that KRR contact information may have since it was last
+    /// updated or confirmed before it is considered outdated and treated as if it is not present. Defaults to 18.
+    /// </summary>
+    public int MaxAgeMonths { get; set; } = 18;
+
+    /// <summary>
+    /// Gets or sets the list of service owner short names (e.g. "skd") that are exempt from the retention check
+    /// and therefore retain the behaviour of using contact information regardless of its age.
+    /// </summary>
+    public List<string> ExemptServiceOwners { get; set; } = [];
+}

--- a/components/api/src/Altinn.Notifications.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/components/api/src/Altinn.Notifications.Core/Extensions/ServiceCollectionExtensions.cs
@@ -28,6 +28,9 @@ public static class ServiceCollectionExtensions
             .Configure<NotificationConfig>(config.GetSection("NotificationConfig"));
 
         services
+            .Configure<KrrContactInfoRetentionSettings>(config.GetSection("KrrContactInfoRetention"));
+
+        services
             .AddHostedService<SmsPublishBackgroundService>()
             .AddHostedService<EmailPublishBackgroundService>();
 

--- a/components/api/src/Altinn.Notifications.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/components/api/src/Altinn.Notifications.Core/Extensions/ServiceCollectionExtensions.cs
@@ -28,7 +28,12 @@ public static class ServiceCollectionExtensions
             .Configure<NotificationConfig>(config.GetSection("NotificationConfig"));
 
         services
-            .Configure<KrrContactInfoRetentionSettings>(config.GetSection("KrrContactInfoRetention"));
+            .AddOptions<KrrContactInfoRetentionSettings>()
+            .Bind(config.GetSection("KrrContactInfoRetention"))
+            .Validate(
+                settings => settings.MaxAgeMonths >= 0,
+                "KrrContactInfoRetention.MaxAgeMonths must not be negative.")
+            .ValidateOnStart();
 
         services
             .AddHostedService<SmsPublishBackgroundService>()

--- a/components/api/src/Altinn.Notifications.Core/Models/ContactPoints/UserContactPoints.cs
+++ b/components/api/src/Altinn.Notifications.Core/Models/ContactPoints/UserContactPoints.cs
@@ -31,6 +31,16 @@ public class UserContactPoints
     public string Email { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the timestamp for when the mobile number was last updated or confirmed by the user in KRR
+    /// </summary>
+    public DateTime? MobileNumberLastTouched { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp for when the email address was last updated or confirmed by the user in KRR
+    /// </summary>
+    public DateTime? EmailLastTouched { get; set; }
+
+    /// <summary>
     /// Create a new instance with the same values as the existing instance
     /// </summary>
     /// <returns>The new instance with copied values.</returns>
@@ -42,7 +52,9 @@ public class UserContactPoints
             NationalIdentityNumber = NationalIdentityNumber,
             IsReserved = IsReserved,
             MobileNumber = MobileNumber,
-            Email = Email
+            Email = Email,
+            MobileNumberLastTouched = MobileNumberLastTouched,
+            EmailLastTouched = EmailLastTouched
         };
     }
 }

--- a/components/api/src/Altinn.Notifications.Core/Services/ContactPointService.cs
+++ b/components/api/src/Altinn.Notifications.Core/Services/ContactPointService.cs
@@ -1,4 +1,5 @@
-﻿using Altinn.Notifications.Core.Enums;
+﻿using Altinn.Notifications.Core.Configuration;
+using Altinn.Notifications.Core.Enums;
 using Altinn.Notifications.Core.Helpers;
 using Altinn.Notifications.Core.Integrations;
 using Altinn.Notifications.Core.Models;
@@ -6,6 +7,9 @@ using Altinn.Notifications.Core.Models.Address;
 using Altinn.Notifications.Core.Models.ContactPoints;
 using Altinn.Notifications.Core.Services.Interfaces;
 using Altinn.Notifications.Core.Shared;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Altinn.Notifications.Core.Services;
 
@@ -17,16 +21,22 @@ namespace Altinn.Notifications.Core.Services;
 /// </remarks>
 public class ContactPointService(
     IProfileClient profile,
-    IAuthorizationService authorizationService) : IContactPointService
+    IAuthorizationService authorizationService,
+    IDateTimeService dateTimeService,
+    IOptions<KrrContactInfoRetentionSettings> retentionSettings,
+    ILogger<ContactPointService> logger) : IContactPointService
 {
     private const string _profileClientName = "ProfileClient";
     private const string _authorizationServiceName = "AuthorizationService";
 
     private readonly IProfileClient _profileClient = profile;
     private readonly IAuthorizationService _authorizationService = authorizationService;
+    private readonly IDateTimeService _dateTimeService = dateTimeService;
+    private readonly KrrContactInfoRetentionSettings _retentionSettings = retentionSettings.Value;
+    private readonly ILogger<ContactPointService> _logger = logger;
 
     /// <inheritdoc/>
-    public async Task AddEmailContactPoints(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null)
+    public async Task AddEmailContactPoints(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null, string? creatorShortName = null)
     {
         await AugmentRecipients(
             recipients,
@@ -35,11 +45,12 @@ public class ContactPointService(
             ApplyEmailForOrganization,
             ApplyEmailForExternalIdentity,
             orderLifecycleStage,
-            resourceAction);
+            resourceAction,
+            creatorShortName);
     }
 
     /// <inheritdoc/>
-    public async Task AddSmsContactPoints(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null)
+    public async Task AddSmsContactPoints(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null, string? creatorShortName = null)
     {
         await AugmentRecipients(
             recipients,
@@ -48,11 +59,12 @@ public class ContactPointService(
             ApplySmsForOrganization,
             ApplySmsForExternalIdentity,
             orderLifecycleStage,
-            resourceAction);
+            resourceAction,
+            creatorShortName);
     }
 
     /// <inheritdoc/>
-    public async Task AddEmailAndSmsContactPointsAsync(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null)
+    public async Task AddEmailAndSmsContactPointsAsync(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null, string? creatorShortName = null)
     {
         await AugmentRecipients(
             recipients,
@@ -61,11 +73,12 @@ public class ContactPointService(
             ApplyEmailAndSmsForOrganization,
             ApplyEmailAndSmsForExternalIdentity,
             orderLifecycleStage,
-            resourceAction);
+            resourceAction,
+            creatorShortName);
     }
 
     /// <inheritdoc/>
-    public async Task AddPreferredContactPoints(NotificationChannel channel, List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null)
+    public async Task AddPreferredContactPoints(NotificationChannel channel, List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null, string? creatorShortName = null)
     {
         switch (channel)
         {
@@ -77,7 +90,8 @@ public class ContactPointService(
                     ApplyEmailPreferredForOrganization,
                     ApplyEmailPreferredForExternalIdentity,
                     orderLifecycleStage,
-                    resourceAction);
+                    resourceAction,
+                    creatorShortName);
                 break;
             case NotificationChannel.SmsPreferred:
                 await AugmentRecipients(
@@ -87,7 +101,8 @@ public class ContactPointService(
                     ApplySmsPreferredForOrganization,
                     ApplySmsPreferredForExternalIdentity,
                     orderLifecycleStage,
-                    resourceAction);
+                    resourceAction,
+                    creatorShortName);
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(channel), channel, $"Unsupported notification channel: {channel}");
@@ -359,6 +374,9 @@ public class ContactPointService(
     /// <param name="resourceAction">
     /// An optional action to authorize against the resource. Defaults to "read" when not specified.
     /// </param>
+    /// <param name="creatorShortName">
+    /// The short name of the service owner that created the order, used to determine exemption from the KRR contact information retention check.
+    /// </param>
     /// <returns>
     /// A task representing the asynchronous operation. The method augments the provided recipient objects in place.
     /// </returns>
@@ -369,7 +387,8 @@ public class ContactPointService(
         Action<Recipient, OrganizationContactPoints> applyOrganizationContactPoints,
         Action<Recipient, ExternalIdentityContactPoints> applyExternalIdentityContactPoints,
         OrderLifecycleStage orderLifecycleStage,
-        string? resourceAction = null)
+        string? resourceAction = null,
+        string? creatorShortName = null)
     {
         var personLookupTask = LookupPersonContactPoints(recipients);
         var externalIdentityLookupTask = LookupExternalIdentityContactPoints(recipients);
@@ -380,6 +399,8 @@ public class ContactPointService(
         List<UserContactPoints> personContactPointsList = personLookupTask.Result;
         List<OrganizationContactPoints> organizationContactPointsList = organizationLookupTask.Result;
         List<ExternalIdentityContactPoints> externalIdentityContactPointsList = externalIdentityLookupTask.Result;
+
+        RemoveOutdatedPersonContactInfo(personContactPointsList, creatorShortName);
 
         foreach (Recipient recipient in recipients)
         {
@@ -395,6 +416,67 @@ public class ContactPointService(
             {
                 ApplyExternalIdentityContactPoints(recipient, externalIdentityContactPointsList, applyExternalIdentityContactPoints);
             }
+        }
+    }
+
+    /// <summary>
+    /// Removes contact information retrieved from KRR that has not been updated or confirmed within the configured
+    /// retention window, treating it as if it is not present. The check is skipped entirely when the feature is
+    /// disabled or when the order's service owner is exempt. Contact points without a last-updated timestamp are
+    /// kept (fail-open) and logged so the scope of missing timestamps can be monitored.
+    /// </summary>
+    private void RemoveOutdatedPersonContactInfo(List<UserContactPoints> personContactPointsList, string? creatorShortName)
+    {
+        if (!_retentionSettings.Enabled || personContactPointsList.Count == 0)
+        {
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(creatorShortName)
+            && _retentionSettings.ExemptServiceOwners.Contains(creatorShortName, StringComparer.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        DateTime cutoff = _dateTimeService.UtcNow().AddMonths(-_retentionSettings.MaxAgeMonths);
+
+        int emailsMissingTimestamp = 0;
+        int mobilesMissingTimestamp = 0;
+
+        foreach (UserContactPoints contactPoint in personContactPointsList)
+        {
+            if (!string.IsNullOrWhiteSpace(contactPoint.Email))
+            {
+                if (contactPoint.EmailLastTouched is null)
+                {
+                    emailsMissingTimestamp++;
+                }
+                else if (contactPoint.EmailLastTouched.Value < cutoff)
+                {
+                    contactPoint.Email = string.Empty;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(contactPoint.MobileNumber))
+            {
+                if (contactPoint.MobileNumberLastTouched is null)
+                {
+                    mobilesMissingTimestamp++;
+                }
+                else if (contactPoint.MobileNumberLastTouched.Value < cutoff)
+                {
+                    contactPoint.MobileNumber = string.Empty;
+                }
+            }
+        }
+
+        if (emailsMissingTimestamp > 0 || mobilesMissingTimestamp > 0)
+        {
+            _logger.LogError(
+                "KRR contact info retention: {EmailCount} email and {MobileCount} mobile contact point(s) from Profile were missing a last-updated timestamp for non-exempt service owner '{Creator}'. Treating as valid (fail-open). Investigate if the scope is unexpected.",
+                emailsMissingTimestamp,
+                mobilesMissingTimestamp,
+                creatorShortName ?? "(unknown)");
         }
     }
 

--- a/components/api/src/Altinn.Notifications.Core/Services/EmailAndSmsOrderProcessingService.cs
+++ b/components/api/src/Altinn.Notifications.Core/Services/EmailAndSmsOrderProcessingService.cs
@@ -52,7 +52,7 @@ public class EmailAndSmsOrderProcessingService : IEmailAndSmsOrderProcessingServ
 
         if (recipientsWithoutContactPoint.Count > 0)
         {
-            await _contactPointService.AddEmailAndSmsContactPointsAsync(recipientsWithoutContactPoint, order.ResourceId, OrderLifecycleStage.Processing, order.ResourceAction);
+            await _contactPointService.AddEmailAndSmsContactPointsAsync(recipientsWithoutContactPoint, order.ResourceId, OrderLifecycleStage.Processing, order.ResourceAction, order.Creator.ShortName);
         }
 
         var (smsRecipients, emailRecipients) = OrganizeRecipientsByChannel(recipients);

--- a/components/api/src/Altinn.Notifications.Core/Services/EmailOrderProcessingService.cs
+++ b/components/api/src/Altinn.Notifications.Core/Services/EmailOrderProcessingService.cs
@@ -176,7 +176,7 @@ public class EmailOrderProcessingService : IEmailOrderProcessingService
 
         if (recipientsWithoutEmail.Count > 0)
         {
-            await _contactPointService.AddEmailContactPoints(recipientsWithoutEmail, order.ResourceId, OrderLifecycleStage.Processing, order.ResourceAction);
+            await _contactPointService.AddEmailContactPoints(recipientsWithoutEmail, order.ResourceId, OrderLifecycleStage.Processing, order.ResourceAction, order.Creator.ShortName);
         }
 
         return order.Recipients;

--- a/components/api/src/Altinn.Notifications.Core/Services/Interfaces/IContactPointService.cs
+++ b/components/api/src/Altinn.Notifications.Core/Services/Interfaces/IContactPointService.cs
@@ -15,9 +15,10 @@ public interface IContactPointService
     /// <param name="resourceId">The resource to find contact points in relation to.</param>
     /// <param name="orderLifecycleStage">The phase of order processing. Defaults to <see cref="OrderLifecycleStage.Processing"/>.</param>
     /// <param name="resourceAction">The action to authorize against the resource. Defaults to "read" when not specified.</param>
+    /// <param name="creatorShortName">The short name of the service owner that created the order, used to determine exemption from the KRR contact information retention check.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <remarks>Implementation alters the recipient reference object directly.</remarks>
-    public Task AddEmailContactPoints(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null);
+    public Task AddEmailContactPoints(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null, string? creatorShortName = null);
 
     /// <summary>
     /// Looks up and adds the SMS contact points for recipients based on their national identity number or organization number.
@@ -26,9 +27,10 @@ public interface IContactPointService
     /// <param name="resourceId">The resource to find contact points in relation to.</param>
     /// <param name="orderLifecycleStage">The phase of order processing. Defaults to <see cref="OrderLifecycleStage.Processing"/>.</param>
     /// <param name="resourceAction">The action to authorize against the resource. Defaults to "read" when not specified.</param>
+    /// <param name="creatorShortName">The short name of the service owner that created the order, used to determine exemption from the KRR contact information retention check.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <remarks>Implementation alters the recipient reference object directly.</remarks>
-    public Task AddSmsContactPoints(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null);
+    public Task AddSmsContactPoints(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null, string? creatorShortName = null);
 
     /// <summary>
     /// Looks up and adds both email and SMS contact points simultaneously for recipients based on their national identity number or organization number.
@@ -37,8 +39,9 @@ public interface IContactPointService
     /// <param name="resourceId">The resource identifier used to determine relevant contact points within the context of a specific resource or service.</param>
     /// <param name="orderLifecycleStage">The phase of order processing. Defaults to <see cref="OrderLifecycleStage.Processing"/>.</param>
     /// <param name="resourceAction">The action to authorize against the resource. Defaults to "read" when not specified.</param>
+    /// <param name="creatorShortName">The short name of the service owner that created the order, used to determine exemption from the KRR contact information retention check.</param>
     /// <returns>Implementation alters the recipient reference objects directly by adding any found email and SMS contact points to their <see cref="Recipient.AddressInfo"/> collection.</returns>
-    public Task AddEmailAndSmsContactPointsAsync(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null);
+    public Task AddEmailAndSmsContactPointsAsync(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null, string? creatorShortName = null);
 
     /// <summary>
     /// Looks up and adds the preferred contact points for recipients based on their national identity number or organization number.
@@ -48,7 +51,8 @@ public interface IContactPointService
     /// <param name="resourceId">The resource to find contact points in relation to.</param>
     /// <param name="orderLifecycleStage">The phase of order processing. Defaults to <see cref="OrderLifecycleStage.Processing"/>.</param>
     /// <param name="resourceAction">The action to authorize against the resource. Defaults to "read" when not specified.</param>
+    /// <param name="creatorShortName">The short name of the service owner that created the order, used to determine exemption from the KRR contact information retention check.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     /// <remarks>Implementation alters the recipient reference object directly.</remarks>
-    public Task AddPreferredContactPoints(NotificationChannel channel, List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null);
+    public Task AddPreferredContactPoints(NotificationChannel channel, List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null, string? creatorShortName = null);
 }

--- a/components/api/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/components/api/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -391,7 +391,7 @@ public class OrderRequestService : IOrderRequestService
     {
         var deliveryDetails = ExtractDeliveryDetails(orderRequest.Recipient);
 
-        var lookupResult = await GetRecipientLookupResult(deliveryDetails.Recipients, deliveryDetails.Channel, deliveryDetails.ResourceId, deliveryDetails.ResourceAction);
+        var lookupResult = await GetRecipientLookupResult(deliveryDetails.Recipients, deliveryDetails.Channel, deliveryDetails.ResourceId, deliveryDetails.ResourceAction, orderRequest.Creator.ShortName);
 
         if (lookupResult?.MissingContact?.Count > 0)
         {
@@ -570,7 +570,7 @@ public class OrderRequestService : IOrderRequestService
 
             var deliveryDetails = ExtractDeliveryDetails(notificationReminder.Recipient);
 
-            var lookupResult = await GetRecipientLookupResult(deliveryDetails.Recipients, deliveryDetails.Channel, deliveryDetails.ResourceId, deliveryDetails.ResourceAction);
+            var lookupResult = await GetRecipientLookupResult(deliveryDetails.Recipients, deliveryDetails.Channel, deliveryDetails.ResourceId, deliveryDetails.ResourceAction, creator.ShortName);
 
             if (lookupResult?.MissingContact?.Count > 0)
             {

--- a/components/api/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
+++ b/components/api/src/Altinn.Notifications.Core/Services/OrderRequestService.cs
@@ -51,7 +51,7 @@ public class OrderRequestService : IOrderRequestService
         Guid orderId = _guid.NewGuid();
         DateTime currentTime = _dateTime.UtcNow();
 
-        var lookupResult = await GetRecipientLookupResult(orderRequest.Recipients, orderRequest.NotificationChannel, orderRequest.ResourceId, orderRequest.ResourceAction);
+        var lookupResult = await GetRecipientLookupResult(orderRequest.Recipients, orderRequest.NotificationChannel, orderRequest.ResourceId, orderRequest.ResourceAction, orderRequest.Creator.ShortName);
 
         var templates = SetSenderIfNotDefined(orderRequest.Templates);
 
@@ -434,11 +434,14 @@ public class OrderRequestService : IOrderRequestService
     /// <param name="resourceAction">
     /// An optional action to authorize against the resource. Defaults to "read" when not specified.
     /// </param>
+    /// <param name="creatorShortName">
+    /// The short name of the service owner that created the order, used to determine exemption from the KRR contact information retention check.
+    /// </param>
     /// <returns>
     /// A <see cref="RecipientLookupResult"/> containing information about reserved recipients and those
     /// with missing contact details, or <c>null</c> if all recipients already have the required contact information.
     /// </returns>
-    private async Task<RecipientLookupResult?> GetRecipientLookupResult(List<Recipient> originalRecipients, NotificationChannel channel, string? resourceId, string? resourceAction = null)
+    private async Task<RecipientLookupResult?> GetRecipientLookupResult(List<Recipient> originalRecipients, NotificationChannel channel, string? resourceId, string? resourceAction = null, string? creatorShortName = null)
     {
         List<Recipient> recipientsWithoutContactPoint = FilterRecipientsWithoutContactPoints(channel, originalRecipients);
         if (recipientsWithoutContactPoint.Count == 0)
@@ -449,20 +452,20 @@ public class OrderRequestService : IOrderRequestService
         switch (channel)
         {
             case NotificationChannel.Email:
-                await _contactPointService.AddEmailContactPoints(recipientsWithoutContactPoint, resourceId, OrderLifecycleStage.Registration, resourceAction);
+                await _contactPointService.AddEmailContactPoints(recipientsWithoutContactPoint, resourceId, OrderLifecycleStage.Registration, resourceAction, creatorShortName);
                 break;
 
             case NotificationChannel.Sms:
-                await _contactPointService.AddSmsContactPoints(recipientsWithoutContactPoint, resourceId, OrderLifecycleStage.Registration, resourceAction);
+                await _contactPointService.AddSmsContactPoints(recipientsWithoutContactPoint, resourceId, OrderLifecycleStage.Registration, resourceAction, creatorShortName);
                 break;
 
             case NotificationChannel.EmailAndSms:
-                await _contactPointService.AddEmailAndSmsContactPointsAsync(recipientsWithoutContactPoint, resourceId, OrderLifecycleStage.Registration, resourceAction);
+                await _contactPointService.AddEmailAndSmsContactPointsAsync(recipientsWithoutContactPoint, resourceId, OrderLifecycleStage.Registration, resourceAction, creatorShortName);
                 break;
 
             case NotificationChannel.SmsPreferred:
             case NotificationChannel.EmailPreferred:
-                await _contactPointService.AddPreferredContactPoints(channel, recipientsWithoutContactPoint, resourceId, OrderLifecycleStage.Registration, resourceAction);
+                await _contactPointService.AddPreferredContactPoints(channel, recipientsWithoutContactPoint, resourceId, OrderLifecycleStage.Registration, resourceAction, creatorShortName);
                 break;
         }
 

--- a/components/api/src/Altinn.Notifications.Core/Services/PreferredChannelProcessingService.cs
+++ b/components/api/src/Altinn.Notifications.Core/Services/PreferredChannelProcessingService.cs
@@ -47,7 +47,7 @@ public class PreferredChannelProcessingService : IPreferredChannelProcessingServ
 
         if (recipientsWithoutContactPoint.Count > 0)
         {
-            await _contactPointService.AddPreferredContactPoints(order.NotificationChannel, recipientsWithoutContactPoint, order.ResourceId, OrderLifecycleStage.Processing, order.ResourceAction);
+            await _contactPointService.AddPreferredContactPoints(order.NotificationChannel, recipientsWithoutContactPoint, order.ResourceId, OrderLifecycleStage.Processing, order.ResourceAction, order.Creator.ShortName);
         }
 
         List<Recipient> preferredChannelRecipients;

--- a/components/api/src/Altinn.Notifications.Core/Services/SmsOrderProcessingService.cs
+++ b/components/api/src/Altinn.Notifications.Core/Services/SmsOrderProcessingService.cs
@@ -225,7 +225,7 @@ public class SmsOrderProcessingService : ISmsOrderProcessingService
 
         if (recipientsMissingSmsContact.Count > 0)
         {
-            await _contactPointService.AddSmsContactPoints(recipientsMissingSmsContact, order.ResourceId, OrderLifecycleStage.Processing, order.ResourceAction);
+            await _contactPointService.AddSmsContactPoints(recipientsMissingSmsContact, order.ResourceId, OrderLifecycleStage.Processing, order.ResourceAction, order.Creator.ShortName);
         }
 
         return order.Recipients;

--- a/components/api/src/Altinn.Notifications.Integrations/Profile/Mappers/UserContactPointsDtoMapperExtension.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Profile/Mappers/UserContactPointsDtoMapperExtension.cs
@@ -21,7 +21,9 @@ public static class UserContactPointsDtoMapperExtension
             NationalIdentityNumber = userContactPointDto.NationalIdentityNumber ?? string.Empty,
             IsReserved = userContactPointDto.IsReserved,
             MobileNumber = userContactPointDto.MobileNumber ?? string.Empty,
-            Email = userContactPointDto.Email ?? string.Empty
+            Email = userContactPointDto.Email ?? string.Empty,
+            MobileNumberLastTouched = userContactPointDto.MobileNumberLastTouched,
+            EmailLastTouched = userContactPointDto.EmailLastTouched
         };
     }
 }

--- a/components/api/src/Altinn.Notifications.Integrations/Profile/Models/UserContactPointsDto.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Profile/Models/UserContactPointsDto.cs
@@ -29,4 +29,14 @@ public class UserContactPointsDto
     /// Gets or sets the email address
     /// </summary>
     public string? Email { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp for when the mobile number was last updated or confirmed by the user in KRR
+    /// </summary>
+    public DateTime? MobileNumberLastTouched { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp for when the email address was last updated or confirmed by the user in KRR
+    /// </summary>
+    public DateTime? EmailLastTouched { get; set; }
 }

--- a/components/api/src/Altinn.Notifications/appsettings.json
+++ b/components/api/src/Altinn.Notifications/appsettings.json
@@ -27,6 +27,11 @@
     "AuthorizationBatchSize": 500,
     "ExpiryOffsetSeconds": 300
   },
+  "KrrContactInfoRetention": {
+    "Enabled": true,
+    "MaxAgeMonths": 18,
+    "ExemptServiceOwners": [ "skd" ]
+  },
   "GeneralSettings": {
     "BaseUri": "http://localhost:5090",
     "OpenIdWellKnownEndpoint": "https://platform.at22.altinn.cloud/authentication/api/v1/openid/",

--- a/components/api/test/Altinn.Notifications.IntegrationTests/Utils/SpyContactPointService.cs
+++ b/components/api/test/Altinn.Notifications.IntegrationTests/Utils/SpyContactPointService.cs
@@ -15,7 +15,7 @@ public class SpyContactPointService : IContactPointService
 {
     public ConcurrentBag<(string Method, OrderLifecycleStage Phase)> RecordedCalls { get; } = new();
 
-    public Task AddEmailContactPoints(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null)
+    public Task AddEmailContactPoints(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null, string? creatorShortName = null)
     {
         RecordedCalls.Add(("AddEmailContactPoints", orderLifecycleStage));
 
@@ -27,7 +27,7 @@ public class SpyContactPointService : IContactPointService
         return Task.CompletedTask;
     }
 
-    public Task AddSmsContactPoints(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null)
+    public Task AddSmsContactPoints(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null, string? creatorShortName = null)
     {
         RecordedCalls.Add(("AddSmsContactPoints", orderLifecycleStage));
 
@@ -39,7 +39,7 @@ public class SpyContactPointService : IContactPointService
         return Task.CompletedTask;
     }
 
-    public Task AddEmailAndSmsContactPointsAsync(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null)
+    public Task AddEmailAndSmsContactPointsAsync(List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null, string? creatorShortName = null)
     {
         RecordedCalls.Add(("AddEmailAndSmsContactPointsAsync", orderLifecycleStage));
 
@@ -52,7 +52,7 @@ public class SpyContactPointService : IContactPointService
         return Task.CompletedTask;
     }
 
-    public Task AddPreferredContactPoints(NotificationChannel channel, List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null)
+    public Task AddPreferredContactPoints(NotificationChannel channel, List<Recipient> recipients, string? resourceId, OrderLifecycleStage orderLifecycleStage, string? resourceAction = null, string? creatorShortName = null)
     {
         RecordedCalls.Add(("AddPreferredContactPoints", orderLifecycleStage));
 

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/ContactPointServiceTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/ContactPointServiceTests.cs
@@ -3,13 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Altinn.Notifications.Core.Configuration;
 using Altinn.Notifications.Core.Enums;
 using Altinn.Notifications.Core.Integrations;
 using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.Address;
 using Altinn.Notifications.Core.Models.ContactPoints;
 using Altinn.Notifications.Core.Services;
+using Altinn.Notifications.Core.Services.Interfaces;
 using Altinn.Notifications.Core.Shared;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 using Moq;
 using Xunit;
@@ -108,6 +113,211 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices
             profileClientMock.Verify(e => e.GetUserContactPoints(It.Is<List<string>>(e => e.Contains(nationalId))), Times.Once);
             profileClientMock.VerifyNoOtherCalls();
             authorizationServiceMock.VerifyNoOtherCalls();
+        }
+
+        private static readonly DateTime _fixedNow = new(2026, 6, 9, 12, 0, 0, DateTimeKind.Utc);
+
+        private static ContactPointService GetRetentionTestService(IProfileClient profileClient, KrrContactInfoRetentionSettings settings)
+        {
+            var dateTimeServiceMock = new Mock<IDateTimeService>();
+            dateTimeServiceMock.Setup(e => e.UtcNow()).Returns(_fixedNow);
+
+            return GetTestService(
+                profileClient: profileClient,
+                retentionSettings: settings,
+                dateTimeService: dateTimeServiceMock.Object);
+        }
+
+        private static IProfileClient GetProfileClientReturning(string nationalId, UserContactPoints contactPoints)
+        {
+            var profileClientMock = new Mock<IProfileClient>();
+            profileClientMock
+                .Setup(e => e.GetUserContactPoints(It.Is<List<string>>(e => e.Contains(nationalId))))
+                .ReturnsAsync([contactPoints]);
+            return profileClientMock.Object;
+        }
+
+        [Fact]
+        public async Task AddEmailAndSmsContactPoints_WhenOutdatedForNonExemptCreator_RemovesBothChannels()
+        {
+            // Arrange
+            string nationalId = "16219001324";
+            var recipients = new List<Recipient> { new() { NationalIdentityNumber = nationalId } };
+
+            var profileClient = GetProfileClientReturning(nationalId, new()
+            {
+                NationalIdentityNumber = nationalId,
+                Email = "recipient@example.com",
+                MobileNumber = "99999999",
+                EmailLastTouched = _fixedNow.AddMonths(-20),
+                MobileNumberLastTouched = _fixedNow.AddMonths(-20)
+            });
+
+            var service = GetRetentionTestService(profileClient, new KrrContactInfoRetentionSettings
+            {
+                Enabled = true,
+                MaxAgeMonths = 18,
+                ExemptServiceOwners = ["skd"]
+            });
+
+            // Act
+            await service.AddEmailAndSmsContactPointsAsync(recipients, null, OrderLifecycleStage.Processing, null, creatorShortName: "nav");
+
+            // Assert
+            Assert.Empty(Assert.Single(recipients).AddressInfo);
+        }
+
+        [Fact]
+        public async Task AddEmailAndSmsContactPoints_WhenOnlySmsOutdatedForNonExemptCreator_KeepsOnlyEmail()
+        {
+            // Arrange
+            string nationalId = "16219001324";
+            string emailAddress = "recipient@example.com";
+            var recipients = new List<Recipient> { new() { NationalIdentityNumber = nationalId } };
+
+            var profileClient = GetProfileClientReturning(nationalId, new()
+            {
+                NationalIdentityNumber = nationalId,
+                Email = emailAddress,
+                MobileNumber = "99999999",
+                EmailLastTouched = _fixedNow.AddMonths(-1),
+                MobileNumberLastTouched = _fixedNow.AddMonths(-20)
+            });
+
+            var service = GetRetentionTestService(profileClient, new KrrContactInfoRetentionSettings
+            {
+                Enabled = true,
+                MaxAgeMonths = 18,
+                ExemptServiceOwners = ["skd"]
+            });
+
+            // Act
+            await service.AddEmailAndSmsContactPointsAsync(recipients, null, OrderLifecycleStage.Processing, null, creatorShortName: "nav");
+
+            // Assert
+            var addressInfo = Assert.Single(Assert.Single(recipients).AddressInfo);
+            var emailAddressPoint = Assert.IsType<EmailAddressPoint>(addressInfo);
+            Assert.Equal(emailAddress, emailAddressPoint.EmailAddress);
+        }
+
+        [Fact]
+        public async Task AddEmailAndSmsContactPoints_WhenOutdatedButCreatorExempt_KeepsBothChannels()
+        {
+            // Arrange
+            string nationalId = "16219001324";
+            var recipients = new List<Recipient> { new() { NationalIdentityNumber = nationalId } };
+
+            var profileClient = GetProfileClientReturning(nationalId, new()
+            {
+                NationalIdentityNumber = nationalId,
+                Email = "recipient@example.com",
+                MobileNumber = "99999999",
+                EmailLastTouched = _fixedNow.AddMonths(-20),
+                MobileNumberLastTouched = _fixedNow.AddMonths(-20)
+            });
+
+            var service = GetRetentionTestService(profileClient, new KrrContactInfoRetentionSettings
+            {
+                Enabled = true,
+                MaxAgeMonths = 18,
+                ExemptServiceOwners = ["skd"]
+            });
+
+            // Act - exemption is case-insensitive
+            await service.AddEmailAndSmsContactPointsAsync(recipients, null, OrderLifecycleStage.Processing, null, creatorShortName: "SKD");
+
+            // Assert
+            Assert.Equal(2, Assert.Single(recipients).AddressInfo.Count);
+        }
+
+        [Fact]
+        public async Task AddEmailAndSmsContactPoints_WhenRetentionDisabled_KeepsOutdatedChannels()
+        {
+            // Arrange
+            string nationalId = "16219001324";
+            var recipients = new List<Recipient> { new() { NationalIdentityNumber = nationalId } };
+
+            var profileClient = GetProfileClientReturning(nationalId, new()
+            {
+                NationalIdentityNumber = nationalId,
+                Email = "recipient@example.com",
+                MobileNumber = "99999999",
+                EmailLastTouched = _fixedNow.AddMonths(-20),
+                MobileNumberLastTouched = _fixedNow.AddMonths(-20)
+            });
+
+            var service = GetRetentionTestService(profileClient, new KrrContactInfoRetentionSettings
+            {
+                Enabled = false,
+                MaxAgeMonths = 18,
+                ExemptServiceOwners = []
+            });
+
+            // Act
+            await service.AddEmailAndSmsContactPointsAsync(recipients, null, OrderLifecycleStage.Processing, null, creatorShortName: "nav");
+
+            // Assert
+            Assert.Equal(2, Assert.Single(recipients).AddressInfo.Count);
+        }
+
+        [Fact]
+        public async Task AddEmailAndSmsContactPoints_WhenLastTouchedIsNull_KeepsChannelsFailOpen()
+        {
+            // Arrange
+            string nationalId = "16219001324";
+            var recipients = new List<Recipient> { new() { NationalIdentityNumber = nationalId } };
+
+            var profileClient = GetProfileClientReturning(nationalId, new()
+            {
+                NationalIdentityNumber = nationalId,
+                Email = "recipient@example.com",
+                MobileNumber = "99999999",
+                EmailLastTouched = null,
+                MobileNumberLastTouched = null
+            });
+
+            var service = GetRetentionTestService(profileClient, new KrrContactInfoRetentionSettings
+            {
+                Enabled = true,
+                MaxAgeMonths = 18,
+                ExemptServiceOwners = []
+            });
+
+            // Act
+            await service.AddEmailAndSmsContactPointsAsync(recipients, null, OrderLifecycleStage.Processing, null, creatorShortName: "nav");
+
+            // Assert
+            Assert.Equal(2, Assert.Single(recipients).AddressInfo.Count);
+        }
+
+        [Fact]
+        public async Task AddEmailContactPoints_WhenContactInfoIsWithinRetentionWindow_KeepsChannel()
+        {
+            // Arrange
+            string nationalId = "16219001324";
+            string emailAddress = "recipient@example.com";
+            var recipients = new List<Recipient> { new() { NationalIdentityNumber = nationalId } };
+
+            var profileClient = GetProfileClientReturning(nationalId, new()
+            {
+                NationalIdentityNumber = nationalId,
+                Email = emailAddress,
+                EmailLastTouched = _fixedNow.AddMonths(-17)
+            });
+
+            var service = GetRetentionTestService(profileClient, new KrrContactInfoRetentionSettings
+            {
+                Enabled = true,
+                MaxAgeMonths = 18,
+                ExemptServiceOwners = []
+            });
+
+            // Act
+            await service.AddEmailContactPoints(recipients, null, OrderLifecycleStage.Processing, null, creatorShortName: "nav");
+
+            // Assert
+            var emailAddressPoint = Assert.IsType<EmailAddressPoint>(Assert.Single(Assert.Single(recipients).AddressInfo));
+            Assert.Equal(emailAddress, emailAddressPoint.EmailAddress);
         }
 
         [Fact]
@@ -2148,7 +2358,9 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices
 
         private static ContactPointService GetTestService(
             IProfileClient? profileClient = null,
-            IAuthorizationService? authorizationService = null)
+            IAuthorizationService? authorizationService = null,
+            KrrContactInfoRetentionSettings? retentionSettings = null,
+            IDateTimeService? dateTimeService = null)
         {
             if (profileClient == null)
             {
@@ -2162,7 +2374,18 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices
                 authorizationService = authorizationServiceMock.Object;
             }
 
-            return new ContactPointService(profileClient, authorizationService);
+            // The retention check is disabled by default so existing tests are unaffected; tests that
+            // exercise the feature pass an explicit settings instance.
+            retentionSettings ??= new KrrContactInfoRetentionSettings { Enabled = false };
+
+            dateTimeService ??= new DateTimeService();
+
+            return new ContactPointService(
+                profileClient,
+                authorizationService,
+                dateTimeService,
+                Options.Create(retentionSettings),
+                NullLogger<ContactPointService>.Instance);
         }
     }
 }

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailAndSmsOrderProcessingServiceTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailAndSmsOrderProcessingServiceTests.cs
@@ -35,8 +35,9 @@ public class EmailAndSmsOrderProcessingServiceTests
                 It.Is<List<Recipient>>(recipients => recipients.Count == 1 && recipients[0].NationalIdentityNumber == nationalIdentityNumber),
                 It.Is<string>(resourceId => resourceId == order.ResourceId),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 recipients[0].AddressInfo.Add(new SmsAddressPoint(mobileNumber));
                 recipients[0].AddressInfo.Add(new EmailAddressPoint(emailAddress));
@@ -59,6 +60,7 @@ public class EmailAndSmsOrderProcessingServiceTests
                     recipients[0].NationalIdentityNumber == nationalIdentityNumber),
                 order.ResourceId,
                 OrderLifecycleStage.Processing,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -99,8 +101,9 @@ public class EmailAndSmsOrderProcessingServiceTests
                 It.Is<List<Recipient>>(recipients => recipients.Count == 1 && recipients[0].ExternalIdentity == externalIdentifier),
                 It.Is<string>(resourceId => resourceId == order.ResourceId),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 recipients[0].AddressInfo.Add(new SmsAddressPoint(mobileNumber));
                 recipients[0].AddressInfo.Add(new EmailAddressPoint(emailAddress));
@@ -121,6 +124,7 @@ public class EmailAndSmsOrderProcessingServiceTests
                 It.Is<List<Recipient>>(recipients => recipients.Count == 1 && recipients[0].ExternalIdentity == externalIdentifier),
                 order.ResourceId,
                 OrderLifecycleStage.Processing,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -160,8 +164,9 @@ public class EmailAndSmsOrderProcessingServiceTests
                 It.Is<List<Recipient>>(recipients => recipients.Count == 1 && recipients[0].OrganizationNumber == organizationNumber),
                 It.Is<string>(resourceId => resourceId == order.ResourceId),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 recipients[0].AddressInfo.Add(new SmsAddressPoint(mobileNumber));
                 recipients[0].AddressInfo.Add(new EmailAddressPoint(emailAddress));
@@ -184,6 +189,7 @@ public class EmailAndSmsOrderProcessingServiceTests
                     recipients[0].OrganizationNumber == organizationNumber),
                 order.ResourceId,
                 OrderLifecycleStage.Processing,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -228,6 +234,7 @@ public class EmailAndSmsOrderProcessingServiceTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string>(),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
             .Returns(Task.CompletedTask);
 
@@ -256,8 +263,9 @@ public class EmailAndSmsOrderProcessingServiceTests
                 It.Is<List<Recipient>>(recipients => recipients.Count == 1 && recipients[0].NationalIdentityNumber == nationalIdentityNumber),
                 It.Is<string>(resourceId => resourceId == order.ResourceId),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 recipients[0].AddressInfo.Add(new SmsAddressPoint(mobileNumber));
                 recipients[0].AddressInfo.Add(new EmailAddressPoint(emailAddress));
@@ -280,6 +288,7 @@ public class EmailAndSmsOrderProcessingServiceTests
                     recipients[0].NationalIdentityNumber == nationalIdentityNumber),
                 order.ResourceId,
                 OrderLifecycleStage.Processing,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -319,8 +328,9 @@ public class EmailAndSmsOrderProcessingServiceTests
                 It.Is<List<Recipient>>(recipients => recipients.Count == 1 && recipients[0].OrganizationNumber == organizationNumber),
                 It.Is<string>(resourceId => resourceId == order.ResourceId),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 recipients[0].AddressInfo.Add(new SmsAddressPoint(mobileNumber));
                 recipients[0].AddressInfo.Add(new EmailAddressPoint(emailAddress));
@@ -343,6 +353,7 @@ public class EmailAndSmsOrderProcessingServiceTests
                     recipients[0].OrganizationNumber == organizationNumber),
                 order.ResourceId,
                 OrderLifecycleStage.Processing,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -383,8 +394,9 @@ public class EmailAndSmsOrderProcessingServiceTests
                 It.Is<List<Recipient>>(recipients => recipients.Count == 1 && recipients[0].ExternalIdentity == externalIdentifier),
                 It.Is<string>(resourceId => resourceId == order.ResourceId),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 recipients[0].AddressInfo.Add(new SmsAddressPoint(mobileNumber));
                 recipients[0].AddressInfo.Add(new EmailAddressPoint(emailAddress));
@@ -405,6 +417,7 @@ public class EmailAndSmsOrderProcessingServiceTests
                 It.Is<List<Recipient>>(recipients => recipients.Count == 1 && recipients[0].ExternalIdentity == externalIdentifier),
                 order.ResourceId,
                 OrderLifecycleStage.Processing,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -456,6 +469,7 @@ public class EmailAndSmsOrderProcessingServiceTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string>(),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
             .Returns(Task.CompletedTask);
 
@@ -526,6 +540,7 @@ public class EmailAndSmsOrderProcessingServiceTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string>(),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
             .Returns(Task.CompletedTask);
 
@@ -596,6 +611,7 @@ public class EmailAndSmsOrderProcessingServiceTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string>(),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
             .Returns(Task.CompletedTask);
 
@@ -663,6 +679,7 @@ public class EmailAndSmsOrderProcessingServiceTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string>(),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
             .Returns(Task.CompletedTask);
 

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailOrderProcessingServiceTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/EmailOrderProcessingServiceTests.cs
@@ -151,7 +151,7 @@ public class EmailOrderProcessingServiceTests
                 It.IsAny<bool>()));
 
         var contactPointServiceMock = new Mock<IContactPointService>();
-        contactPointServiceMock.Setup(c => c.AddEmailContactPoints(It.Is<List<Recipient>>(r => r.Count == 1), It.IsAny<string?>(), OrderLifecycleStage.Processing, It.IsAny<string?>()));
+        contactPointServiceMock.Setup(c => c.AddEmailContactPoints(It.Is<List<Recipient>>(r => r.Count == 1), It.IsAny<string?>(), OrderLifecycleStage.Processing, It.IsAny<string?>(), It.IsAny<string?>()));
 
         var service = GetTestService(emailService: notificationServiceMock.Object, contactPointService: contactPointServiceMock.Object);
 
@@ -159,7 +159,7 @@ public class EmailOrderProcessingServiceTests
         await service.ProcessOrder(order);
 
         // Assert
-        contactPointServiceMock.Verify(c => c.AddEmailContactPoints(It.Is<List<Recipient>>(r => r.Count == 1), It.IsAny<string?>(), OrderLifecycleStage.Processing, It.IsAny<string?>()), Times.Once);
+        contactPointServiceMock.Verify(c => c.AddEmailContactPoints(It.Is<List<Recipient>>(r => r.Count == 1), It.IsAny<string?>(), OrderLifecycleStage.Processing, It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
         notificationServiceMock.VerifyAll();
     }
 
@@ -222,7 +222,7 @@ public class EmailOrderProcessingServiceTests
         {
             var contactPointServiceMock = new Mock<IContactPointService>();
             contactPointServiceMock
-               .Setup(e => e.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>()));
+               .Setup(e => e.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>(), It.IsAny<string?>()));
             contactPointService = contactPointServiceMock.Object;
         }
 

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderLifecycleStageProcessingTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderLifecycleStageProcessingTests.cs
@@ -39,6 +39,7 @@ public class OrderLifecycleStageProcessingTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string?>(),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
             .Returns(Task.CompletedTask);
 
@@ -53,6 +54,7 @@ public class OrderLifecycleStageProcessingTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string?>(),
                 OrderLifecycleStage.Processing,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
     }
@@ -70,6 +72,7 @@ public class OrderLifecycleStageProcessingTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string?>(),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
             .Returns(Task.CompletedTask);
 
@@ -84,6 +87,7 @@ public class OrderLifecycleStageProcessingTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string?>(),
                 OrderLifecycleStage.Processing,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
     }
@@ -105,6 +109,7 @@ public class OrderLifecycleStageProcessingTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string?>(),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
             .Returns(Task.CompletedTask);
 
@@ -119,6 +124,7 @@ public class OrderLifecycleStageProcessingTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string?>(),
                 OrderLifecycleStage.Processing,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
     }
@@ -141,6 +147,7 @@ public class OrderLifecycleStageProcessingTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string?>(),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
             .Returns(Task.CompletedTask);
 
@@ -156,6 +163,7 @@ public class OrderLifecycleStageProcessingTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string?>(),
                 OrderLifecycleStage.Processing,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
     }
@@ -178,6 +186,7 @@ public class OrderLifecycleStageProcessingTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string?>(),
                 It.IsAny<OrderLifecycleStage>(),
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
             .Returns(Task.CompletedTask);
 
@@ -193,6 +202,7 @@ public class OrderLifecycleStageProcessingTests
                 It.IsAny<List<Recipient>>(),
                 It.IsAny<string?>(),
                 OrderLifecycleStage.Processing,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
     }

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -310,8 +310,8 @@ public class OrderRequestServiceTests
 
         var contactPointServiceMock = new Mock<IContactPointService>();
         contactPointServiceMock
-            .Setup(e => e.AddSmsContactPoints(It.Is<List<Recipient>>(r => r.Any(rec => rec.ExternalIdentity == externalIdentity)), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(e => e.AddSmsContactPoints(It.Is<List<Recipient>>(r => r.Any(rec => rec.ExternalIdentity == externalIdentity)), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -340,6 +340,7 @@ public class OrderRequestServiceTests
                 It.Is<List<Recipient>>(r => r.Any(rec => rec.ExternalIdentity == externalIdentity)),
                 It.Is<string?>(s => s == null),
                 OrderLifecycleStage.Registration,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -433,8 +434,9 @@ public class OrderRequestServiceTests
                 It.Is<List<Recipient>>(r => r.Any(rec => rec.ExternalIdentity == externalIdentity)),
                 It.IsAny<string?>(),
                 OrderLifecycleStage.Registration,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()))
-            .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?>((_, recipients, _, _, _) =>
+            .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?, string?>((_, recipients, _, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -463,6 +465,7 @@ public class OrderRequestServiceTests
                 It.Is<List<Recipient>>(r => r.Any(rec => rec.ExternalIdentity == externalIdentity)),
                 It.Is<string?>(s => s == null),
                 OrderLifecycleStage.Registration,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -514,8 +517,8 @@ public class OrderRequestServiceTests
 
         var contactPointServiceMock = new Mock<IContactPointService>();
         contactPointServiceMock
-            .Setup(cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((_, _, _, _) =>
+            .Setup(cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((_, _, _, _, _) =>
             {
                 // Intentionally don't add contact points to simulate missing contact
             })
@@ -532,7 +535,7 @@ public class OrderRequestServiceTests
         Assert.Equal(422, (int)result.Problem.StatusCode);
         Assert.Equal("NOT-00001", result.Problem.ErrorCode.ToString());
 
-        contactPointServiceMock.Verify(cp => cp.AddEmailContactPoints(It.Is<List<Recipient>>(r => r.Any(rec => rec.ExternalIdentity == externalIdentity)), It.Is<string?>(s => s == null), OrderLifecycleStage.Registration, It.IsAny<string?>()), Times.Once);
+        contactPointServiceMock.Verify(cp => cp.AddEmailContactPoints(It.Is<List<Recipient>>(r => r.Any(rec => rec.ExternalIdentity == externalIdentity)), It.Is<string?>(s => s == null), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
         orderRepositoryMock.Verify(repo => repo.Create(It.IsAny<NotificationOrderChainRequest>(), It.IsAny<NotificationOrder>(), It.IsAny<List<NotificationOrder>>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -602,8 +605,8 @@ public class OrderRequestServiceTests
 
         var contactPointServiceMock = new Mock<IContactPointService>();
         contactPointServiceMock
-            .Setup(cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -631,6 +634,7 @@ public class OrderRequestServiceTests
                 It.Is<List<Recipient>>(r => r.Any(rec => rec.ExternalIdentity == externalIdentity)),
                 It.Is<string?>(s => s == resourceId),
                 OrderLifecycleStage.Registration,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -725,8 +729,8 @@ public class OrderRequestServiceTests
 
         var contactPointServiceMock = new Mock<IContactPointService>();
         contactPointServiceMock
-            .Setup(cp => cp.AddPreferredContactPoints(NotificationChannel.SmsPreferred, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?>((_, recipients, _, _, _) =>
+            .Setup(cp => cp.AddPreferredContactPoints(NotificationChannel.SmsPreferred, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?, string?>((_, recipients, _, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -755,6 +759,7 @@ public class OrderRequestServiceTests
                 It.Is<List<Recipient>>(r => r.Any(rec => rec.ExternalIdentity == externalIdentity)),
                 It.Is<string?>(s => s == resourceId),
                 OrderLifecycleStage.Registration,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -849,8 +854,8 @@ public class OrderRequestServiceTests
 
         var contactPointServiceMock = new Mock<IContactPointService>();
         contactPointServiceMock
-            .Setup(cp => cp.AddEmailAndSmsContactPointsAsync(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(cp => cp.AddEmailAndSmsContactPointsAsync(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -879,6 +884,7 @@ public class OrderRequestServiceTests
                 It.Is<List<Recipient>>(r => r.Any(rec => rec.ExternalIdentity == externalIdentity)),
                 It.Is<string?>(s => s == resourceId),
                 OrderLifecycleStage.Registration,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -955,8 +961,8 @@ public class OrderRequestServiceTests
 
         var contactPointServiceMock = new Mock<IContactPointService>();
         contactPointServiceMock
-            .Setup(cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 // Only add contact for main order, not for reminder
                 foreach (var recipient in recipients)
@@ -1113,8 +1119,8 @@ public class OrderRequestServiceTests
 
         var contactPointServiceMock = new Mock<IContactPointService>();
         contactPointServiceMock
-            .Setup(cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -1128,8 +1134,8 @@ public class OrderRequestServiceTests
             .Returns(Task.CompletedTask);
 
         contactPointServiceMock
-            .Setup(cp => cp.AddSmsContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(cp => cp.AddSmsContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -1163,6 +1169,7 @@ public class OrderRequestServiceTests
                 It.Is<List<Recipient>>(r => r.Any(rec => rec.ExternalIdentity == externalIdentity)),
                 It.Is<string?>(s => s == resourceId),
                 OrderLifecycleStage.Registration,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -1172,6 +1179,7 @@ public class OrderRequestServiceTests
                 It.Is<List<Recipient>>(r => r.Any(rec => rec.ExternalIdentity == externalIdentity)),
                 It.Is<string?>(s => s == resourceId),
                 OrderLifecycleStage.Registration,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -1230,8 +1238,8 @@ public class OrderRequestServiceTests
 
         Mock<IContactPointService> contactPointMock = new();
         contactPointMock
-            .Setup(cp => cp.AddSmsContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(cp => cp.AddSmsContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -1302,8 +1310,8 @@ public class OrderRequestServiceTests
 
         Mock<IContactPointService> contactPointMock = new();
         contactPointMock
-            .Setup(cp => cp.AddSmsContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(cp => cp.AddSmsContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -1398,8 +1406,8 @@ public class OrderRequestServiceTests
 
         Mock<IContactPointService> contactPointMock = new();
         contactPointMock
-            .Setup(cp => cp.AddPreferredContactPoints(input.NotificationChannel, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?>((_, recipients, _, _, _) =>
+            .Setup(cp => cp.AddPreferredContactPoints(input.NotificationChannel, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?, string?>((_, recipients, _, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -1468,8 +1476,8 @@ public class OrderRequestServiceTests
 
         Mock<IContactPointService> contactPointMock = new();
         contactPointMock
-            .Setup(cp => cp.AddPreferredContactPoints(input.NotificationChannel, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?>((_, recipients, _, _, _) =>
+            .Setup(cp => cp.AddPreferredContactPoints(input.NotificationChannel, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?, string?>((_, recipients, _, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -1536,8 +1544,8 @@ public class OrderRequestServiceTests
 
         Mock<IContactPointService> contactPointMock = new();
         contactPointMock
-            .Setup(cp => cp.AddEmailAndSmsContactPointsAsync(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, resourceId, _, _) =>
+            .Setup(cp => cp.AddEmailAndSmsContactPointsAsync(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, resourceId, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -1571,6 +1579,7 @@ public class OrderRequestServiceTests
                     recipients.Any(r => r.NationalIdentityNumber == "30286043298")),
                 It.Is<string?>(resourceId => resourceId == null),
                 OrderLifecycleStage.Registration,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -1613,8 +1622,8 @@ public class OrderRequestServiceTests
         var orderRepositoryMock = new Mock<IOrderRepository>();
         var contactPointServiceMock = new Mock<IContactPointService>();
         contactPointServiceMock
-            .Setup(contactService => contactService.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(contactService => contactService.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 // no contact information
             })
@@ -1703,8 +1712,8 @@ public class OrderRequestServiceTests
         var orderRepositoryMock = new Mock<IOrderRepository>();
         var contactPointServiceMock = new Mock<IContactPointService>();
         contactPointServiceMock
-            .Setup(contactService => contactService.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(contactService => contactService.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 // no recipient info for the reminder organization
                 foreach (var recipient in recipients)
@@ -1937,8 +1946,8 @@ public class OrderRequestServiceTests
             .ReturnsAsync([expectedMainOrder, expectedFirstReminder, expectedFinalReminder]);
 
         contactPointServiceMock
-            .Setup(contactService => contactService.AddPreferredContactPoints(It.IsAny<NotificationChannel>(), It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?>((channel, recipients, _, _, _) =>
+            .Setup(contactService => contactService.AddPreferredContactPoints(It.IsAny<NotificationChannel>(), It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?, string?>((channel, recipients, _, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -2113,8 +2122,8 @@ public class OrderRequestServiceTests
 
         var contactPointServiceMock = new Mock<IContactPointService>();
         contactPointServiceMock
-            .Setup(contactService => contactService.AddEmailAndSmsContactPointsAsync(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(contactService => contactService.AddEmailAndSmsContactPointsAsync(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 foreach (var recipient in recipients)
                 {
@@ -2257,8 +2266,8 @@ public class OrderRequestServiceTests
         var orderRepositoryMock = new Mock<IOrderRepository>();
         var contactPointServiceMock = new Mock<IContactPointService>();
         contactPointServiceMock
-            .Setup(contactService => contactService.AddSmsContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(contactService => contactService.AddSmsContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 // Intentionally don't add SMS contact point to simulate missing contact
             })
@@ -2282,6 +2291,7 @@ public class OrderRequestServiceTests
                 It.Is<List<Recipient>>(r => r.Any(rec => rec.NationalIdentityNumber == "16069412345")),
                 It.Is<string?>(s => s == "urn:altinn:resource:sms-test"),
                 OrderLifecycleStage.Registration,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 
@@ -2363,8 +2373,8 @@ public class OrderRequestServiceTests
 
         var contactPointServiceMock = new Mock<IContactPointService>();
         contactPointServiceMock
-            .Setup(cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 // Mark recipient as reserved and don't add contact info
                 // This simulates a person who is in the reservation registry (KRR)
@@ -2646,8 +2656,8 @@ public class OrderRequestServiceTests
 
         Mock<IContactPointService> contactPointMock = new();
         contactPointMock
-            .Setup(contactService => contactService.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((recipients, _, _, _) =>
+            .Setup(contactService => contactService.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((recipients, _, _, _, _) =>
             {
                 // Intentionally don't add any address info to simulate missing contact
             })
@@ -2682,6 +2692,7 @@ public class OrderRequestServiceTests
                 It.Is<List<Recipient>>(r => r.Any(rec => rec.NationalIdentityNumber == "16069412345")),
                 It.Is<string?>(s => s == "urn:altinn:resource:test"),
                 OrderLifecycleStage.Registration,
+                It.IsAny<string?>(),
                 It.IsAny<string?>()),
             Times.Once);
 

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderRequestServiceTests.cs
@@ -345,15 +345,15 @@ public class OrderRequestServiceTests
             Times.Once);
 
         contactPointServiceMock.Verify(
-            cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()),
+            cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()),
             Times.Never);
 
         contactPointServiceMock.Verify(
-            cp => cp.AddEmailAndSmsContactPointsAsync(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()),
+            cp => cp.AddEmailAndSmsContactPointsAsync(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()),
             Times.Never);
 
         contactPointServiceMock.Verify(
-            cp => cp.AddPreferredContactPoints(It.IsAny<NotificationChannel>(), It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()),
+            cp => cp.AddPreferredContactPoints(It.IsAny<NotificationChannel>(), It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()),
             Times.Never);
 
         orderRepositoryMock.VerifyAll();
@@ -989,19 +989,19 @@ public class OrderRequestServiceTests
         Assert.Equal(422, (int)result.Problem.StatusCode);
 
         contactPointServiceMock.Verify(
-            cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()),
+            cp => cp.AddEmailContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()),
             Times.AtLeastOnce);
 
         contactPointServiceMock.Verify(
-            cp => cp.AddSmsContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()),
+            cp => cp.AddSmsContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()),
             Times.Never);
 
         contactPointServiceMock.Verify(
-            cp => cp.AddEmailAndSmsContactPointsAsync(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()),
+            cp => cp.AddEmailAndSmsContactPointsAsync(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()),
             Times.Never);
 
         contactPointServiceMock.Verify(
-            cp => cp.AddPreferredContactPoints(It.IsAny<NotificationChannel>(), It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>()),
+            cp => cp.AddPreferredContactPoints(It.IsAny<NotificationChannel>(), It.IsAny<List<Recipient>>(), It.IsAny<string?>(), OrderLifecycleStage.Registration, It.IsAny<string?>(), It.IsAny<string?>()),
             Times.Never);
 
         orderRepositoryMock.Verify(
@@ -2033,7 +2033,8 @@ public class OrderRequestServiceTests
                It.Is<List<Recipient>>(r => r.Any(rec => rec.NationalIdentityNumber == "29105573746")),
                It.Is<string?>(s => s == resourceId),
                OrderLifecycleStage.Registration,
-               It.Is<string?>(s => s == resourceAction)),  // Changed from It.IsAny<string?>()
+               It.Is<string?>(s => s == resourceAction),  // Changed from It.IsAny<string?>()
+               It.IsAny<string?>()),
            Times.Exactly(2));
 
         // Verify contact point added the expected SMS contact
@@ -2043,7 +2044,8 @@ public class OrderRequestServiceTests
                It.Is<List<Recipient>>(r => r.Any(rec => rec.NationalIdentityNumber == "29105573746")),
                It.Is<string?>(s => s == resourceId),
                OrderLifecycleStage.Registration,
-               It.Is<string?>(s => s == resourceAction)),  // Changed from It.IsAny<string?>()
+               It.Is<string?>(s => s == resourceAction),  // Changed from It.IsAny<string?>()
+               It.IsAny<string?>()),
            Times.Once);
     }
 
@@ -2170,6 +2172,7 @@ public class OrderRequestServiceTests
             It.Is<List<Recipient>>(r => r.Any(rec => rec.OrganizationNumber == "312508729")),
             It.Is<string?>(s => s == "urn:altinn:resource:email-sms-resource-name"),
             OrderLifecycleStage.Registration,
+            It.IsAny<string?>(),
             It.IsAny<string?>()),
             Times.Once);
     }
@@ -2405,7 +2408,8 @@ public class OrderRequestServiceTests
                 It.Is<List<Recipient>>(r => r.Any(rec => rec.NationalIdentityNumber == nationalIdentityNumber)),
                 It.Is<string?>(s => s == "urn:altinn:resource:test-resource"),
                 OrderLifecycleStage.Registration,
-                It.Is<string?>(s => s == "sign")),
+                It.Is<string?>(s => s == "sign"),
+                It.IsAny<string?>()),
             Times.Once);
 
         orderRepositoryMock.VerifyAll();

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/PreferredChannelProcessingServiceTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/PreferredChannelProcessingServiceTests.cs
@@ -42,8 +42,8 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices
             };
 
             _contactPointMock
-                .Setup(cp => cp.AddPreferredContactPoints(order.NotificationChannel, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>()))
-                .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?>((_, recipients, _, _, _) =>
+                .Setup(cp => cp.AddPreferredContactPoints(order.NotificationChannel, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>(), It.IsAny<string?>()))
+                .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?, string?>((_, recipients, _, _, _, _) =>
                 {
                     foreach (var recipient in recipients)
                     {
@@ -111,8 +111,8 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices
             };
 
             _contactPointMock
-                .Setup(cp => cp.AddPreferredContactPoints(order.NotificationChannel, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>()))
-                .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?>((_, recipients, _, _, _) =>
+                .Setup(cp => cp.AddPreferredContactPoints(order.NotificationChannel, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>(), It.IsAny<string?>()))
+                .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?, string?>((_, recipients, _, _, _, _) =>
                 {
                     foreach (var recipient in recipients)
                     {
@@ -246,8 +246,8 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices
             };
 
             _contactPointMock
-                .Setup(cp => cp.AddPreferredContactPoints(order.NotificationChannel, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>()))
-                .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?>((_, recipients, _, _, _) =>
+                .Setup(cp => cp.AddPreferredContactPoints(order.NotificationChannel, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>(), It.IsAny<string?>()))
+                .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?, string?>((_, recipients, _, _, _, _) =>
                 {
                     foreach (var recipient in recipients)
                     {
@@ -381,8 +381,8 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices
             };
 
             _contactPointMock
-                .Setup(cp => cp.AddPreferredContactPoints(order.NotificationChannel, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>()))
-                .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?>((_, recipients, _, _, _) =>
+                .Setup(cp => cp.AddPreferredContactPoints(order.NotificationChannel, It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>(), It.IsAny<string?>()))
+                .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?, string?>((_, recipients, _, _, _, _) =>
                 {
                     foreach (var recipient in recipients)
                     {
@@ -476,7 +476,7 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices
 
             // Assert
             _contactPointMock.Verify(
-                cp => cp.AddPreferredContactPoints(It.IsAny<NotificationChannel>(), It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>()),
+                cp => cp.AddPreferredContactPoints(It.IsAny<NotificationChannel>(), It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>(), It.IsAny<string?>()),
                 Times.Never);
         }
 
@@ -519,8 +519,9 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices
                     It.IsAny<List<Recipient>>(),
                     "test-resource",
                     It.IsAny<OrderLifecycleStage>(),
+                    It.IsAny<string?>(),
                     It.IsAny<string?>()))
-                .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?>((_, recipients, _, _, _) =>
+                .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?, string?>((_, recipients, _, _, _, _) =>
                 {
                     capturedRecipients = recipients;
                     recipients[0].AddressInfo.Add(new EmailAddressPoint("user2@altinn.xyz"));
@@ -808,8 +809,8 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices
                 .Returns(Task.CompletedTask);
 
             _contactPointMock
-                .Setup(cp => cp.AddPreferredContactPoints(It.IsAny<NotificationChannel>(), It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>()))
-                .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?>((_, recipients, _, _, _) =>
+                .Setup(cp => cp.AddPreferredContactPoints(It.IsAny<NotificationChannel>(), It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>(), It.IsAny<string?>()))
+                .Callback<NotificationChannel, List<Recipient>, string?, OrderLifecycleStage, string?, string?>((_, recipients, _, _, _, _) =>
                 {
                     recipients[0].IsReserved = true;
                 })
@@ -855,7 +856,7 @@ namespace Altinn.Notifications.Tests.Notifications.Core.TestingServices
             // Assert
             Assert.Null(exception);
             _contactPointMock.Verify(
-                cp => cp.AddPreferredContactPoints(It.IsAny<NotificationChannel>(), It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>()),
+                cp => cp.AddPreferredContactPoints(It.IsAny<NotificationChannel>(), It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>(), It.IsAny<string?>()),
                 Times.Never);
         }
 

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsOrderProcessingServiceTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/SmsOrderProcessingServiceTests.cs
@@ -181,8 +181,8 @@ public class SmsOrderProcessingServiceTests
                 It.IsAny<bool>()));
 
         var contactPointServiceMock = new Mock<IContactPointService>();
-        contactPointServiceMock.Setup(c => c.AddSmsContactPoints(It.Is<List<Recipient>>(r => r.Count == 1), It.IsAny<string?>(), OrderLifecycleStage.Processing, It.IsAny<string?>()))
-            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?>((r, _, _, resourceAction) =>
+        contactPointServiceMock.Setup(c => c.AddSmsContactPoints(It.Is<List<Recipient>>(r => r.Count == 1), It.IsAny<string?>(), OrderLifecycleStage.Processing, It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<List<Recipient>, string?, OrderLifecycleStage, string?, string?>((r, _, _, resourceAction, _) =>
             {
                 Recipient augumentedRecipient = new() { AddressInfo = [new SmsAddressPoint("+4712345678")], NationalIdentityNumber = r[0].NationalIdentityNumber };
                 r.Clear();
@@ -195,7 +195,7 @@ public class SmsOrderProcessingServiceTests
         await service.ProcessOrder(order);
 
         // Assert
-        contactPointServiceMock.Verify(c => c.AddSmsContactPoints(It.Is<List<Recipient>>(r => r.Count == 1), It.IsAny<string?>(), OrderLifecycleStage.Processing, It.IsAny<string?>()), Times.Once);
+        contactPointServiceMock.Verify(c => c.AddSmsContactPoints(It.Is<List<Recipient>>(r => r.Count == 1), It.IsAny<string?>(), OrderLifecycleStage.Processing, It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
         notificationServiceMock.VerifyAll();
     }
 
@@ -413,7 +413,7 @@ public class SmsOrderProcessingServiceTests
         if (contactPointService == null)
         {
             var contactPointServiceMock = new Mock<IContactPointService>();
-            contactPointServiceMock.Setup(e => e.AddSmsContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>()));
+            contactPointServiceMock.Setup(e => e.AddSmsContactPoints(It.IsAny<List<Recipient>>(), It.IsAny<string?>(), It.IsAny<OrderLifecycleStage>(), It.IsAny<string?>(), It.IsAny<string?>()));
 
             contactPointService = contactPointServiceMock.Object;
         }


### PR DESCRIPTION
## Summary

Contact information from KRR that has not been updated or confirmed within a configurable retention window (default **18 months**) is no longer used for notifications, except for an explicitly configured list of service owners that are exempt.

Profile ([altinn-profile#940](https://github.com/Altinn/altinn-profile/pull/940), merged) now exposes the per-channel last-touched timestamps and no longer filters by age itself, so this component owns the retention check and the exemption.

## Changes

- New config section `KrrContactInfoRetention` → `KrrContactInfoRetentionSettings` (`Enabled`, `MaxAgeMonths`, `ExemptServiceOwners`), validated on startup.
- Per-channel `EmailLastTouched` / `MobileNumberLastTouched` added to the Profile contact-point DTO/model and mapper.
- `ContactPointService` drops outdated **person** (KRR) contact points **per channel** after lookup, unless disabled or the order's creator is exempt. Multi-channel/preferred orders keep the still-valid channel and only drop the expired one.
- Creator short name is threaded through `IContactPointService` for both registration and processing lookups (covers already-scheduled notifications).

## Behaviour notes

- Scope: persons only (KRR via national identity number).
- Missing last-touched timestamp → kept (fail-open) and logged so the scope can be monitored during rollout.
- Exemption match is case-insensitive; `ExemptServiceOwners` is expected to be set per environment.

## Related

- Internal issue: Altinn/team-core-private#503 (background and rationale)

## Verification

- [x] Builds clean without errors or warnings
- [x] Automated tests added (`ContactPointServiceTests`: exempt/non-exempt, single-channel-expired, both-expired, disabled, null-date fail-open, 18-month boundary)
- [x] Affected unit tests green locally
- [ ] Manual end-to-end test against Profile pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)
