### PR TITLE
Fix flaky unit tests: parallel-safe metrics listeners + invariant test culture

### DIFF
--- a/components/api/src/Altinn.Notifications.Integrations/Telemetry/DeliveryReportMetrics.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Telemetry/DeliveryReportMetrics.cs
@@ -26,6 +26,13 @@ public sealed class DeliveryReportMetrics : IDisposable
     private readonly Counter<long> _deliveryReportStatusCounter;
 
     /// <summary>
+    /// Gets the <see cref="System.Diagnostics.Metrics.Meter"/> owned by this instance.
+    /// Exposed so tests can listen to this exact instance instead of matching on the meter name,
+    /// which would also pick up measurements from other instances in parallel tests.
+    /// </summary>
+    internal Meter Meter => _meter;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="DeliveryReportMetrics"/> class.
     /// </summary>
     public DeliveryReportMetrics()

--- a/components/api/test/Altinn.Notifications.IntegrationTests/Telemetry/DeliveryReportMetricsTests.cs
+++ b/components/api/test/Altinn.Notifications.IntegrationTests/Telemetry/DeliveryReportMetricsTests.cs
@@ -227,14 +227,16 @@ public sealed class DeliveryReportMetricsTests : IDisposable
         Assert.Equal(string.Empty, EmailMaskingHelper.RedactEmailAddressesFromMessage(message, "recipient@example.com"));
     }
 
-    private static MeterListener CreateListener(
+    private MeterListener CreateListener(
         Action<Instrument, long, ReadOnlySpan<KeyValuePair<string, object?>>> onMeasurement)
     {
         var listener = new MeterListener();
 
         listener.InstrumentPublished = (instrument, meterListener) =>
         {
-            if (instrument.Meter.Name == DeliveryReportMetrics.MeterName)
+            // Match on this test's own Meter instance, not the meter name; other tests (or the
+            // application host) create meters with the same name and would otherwise be counted.
+            if (ReferenceEquals(instrument.Meter, _sut.Meter))
             {
                 meterListener.EnableMeasurementEvents(instrument);
             }

--- a/components/api/test/Altinn.Notifications.Tests/Altinn.Notifications.Tests.csproj
+++ b/components/api/test/Altinn.Notifications.Tests/Altinn.Notifications.Tests.csproj
@@ -56,6 +56,9 @@
     <None Update="ttd-org.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <PropertyGroup>

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Wolverine/Handlers/EmailDeliveryReportHandlerTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Wolverine/Handlers/EmailDeliveryReportHandlerTests.cs
@@ -318,14 +318,16 @@ public sealed class EmailDeliveryReportHandlerTests : IDisposable
         return new EmailDeliveryReportCommand(message);
     }
 
-    private static MeterListener CreateListener(
+    private MeterListener CreateListener(
         Action<Instrument, long, ReadOnlySpan<KeyValuePair<string, object?>>> onMeasurement)
     {
         var listener = new MeterListener();
 
         listener.InstrumentPublished = (instrument, meterListener) =>
         {
-            if (instrument.Meter.Name == DeliveryReportMetrics.MeterName)
+            // Match on this test's own Meter instance, not the meter name; other test classes
+            // running in parallel create meters with the same name and would otherwise be counted.
+            if (ReferenceEquals(instrument.Meter, _metrics.Meter))
             {
                 meterListener.EnableMeasurementEvents(instrument);
             }

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Wolverine/Handlers/SmsDeliveryReportHandlerTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Wolverine/Handlers/SmsDeliveryReportHandlerTests.cs
@@ -206,14 +206,16 @@ public sealed class SmsDeliveryReportHandlerTests : IDisposable
         };
     }
 
-    private static MeterListener CreateListener(
+    private MeterListener CreateListener(
         Action<Instrument, long, ReadOnlySpan<KeyValuePair<string, object?>>> onMeasurement)
     {
         var listener = new MeterListener();
 
         listener.InstrumentPublished = (instrument, meterListener) =>
         {
-            if (instrument.Meter.Name == DeliveryReportMetrics.MeterName)
+            // Match on this test's own Meter instance, not the meter name; other test classes
+            // running in parallel create meters with the same name and would otherwise be counted.
+            if (ReferenceEquals(instrument.Meter, _metrics.Meter))
             {
                 meterListener.EnableMeasurementEvents(instrument);
             }

--- a/components/api/test/Altinn.Notifications.Tests/xunit.runner.json
+++ b/components/api/test/Altinn.Notifications.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "culture": "invariant"
+}


### PR DESCRIPTION
## Description

Fixes two sources of intermittent unit-test failures (observed as random CI failures unrelated to the changes under test, e.g. on #1646).

### 1. Metrics tests counted measurements from parallel tests

The `MeterListener` helpers in `EmailDeliveryReportHandlerTests`, `SmsDeliveryReportHandlerTests` and `DeliveryReportMetricsTests` enabled measurement events for **any** meter whose name matched `DeliveryReportMetrics.MeterName`. Test classes run in parallel and each creates its own `DeliveryReportMetrics` instance — and tests that start the application host via `WebApplicationFactory` register yet another — so a listener in one test could count measurements emitted elsewhere. This randomly broke both the "exactly one measurement" and the "zero measurements" assertions.

The listeners now match on the test's **own `Meter` instance** (exposed `internal` for tests via the existing `InternalsVisibleTo`). This keeps full test parallelism — no `[Collection]` serialization needed, so the suite stays fast.

### 2. Validator tests depended on the machine's UI culture

FluentValidation localizes its default messages from the current UI culture, so assertions like `'National Identity Number' must not be empty.` fail on machines with a non-English culture (nb-NO gives `... kan ikke være tom.`). A new `xunit.runner.json` pins the unit-test assembly to the **invariant culture**, making validation messages, formatting and parsing identical on every machine and on CI.

## Verification

- [x] Verified on a nb-NO machine (which reproduced the culture failure): **6 consecutive full-suite runs, 1069/1069 passing, ~1s per run**
- [x] `Altinn.Notifications.IntegrationTests` builds clean (uses the same listener pattern, fixed there too)
- [x] No production behaviour change — the only src change is an `internal` accessor on `DeliveryReportMetrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for telemetry metrics to prevent interference from parallel test execution.
  * Enhanced meter matching logic in test listeners for more reliable metric verification.

* **Chores**
  * Added test runner configuration for consistent test environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->