### PR TITLE
Add DlqManager project to the root solution

### DIFF
--- a/Altinn.Notifications.slnx
+++ b/Altinn.Notifications.slnx
@@ -44,6 +44,7 @@
   </Folder>
   <Folder Name="/Tools/" />
   <Folder Name="/Tools/src/">
+    <Project Path="tools/src/Altinn.Notifications.Tools.DlqManager/Altinn.Notifications.Tools.DlqManager.csproj" />
     <Project Path="tools/src/Altinn.Notifications.Tools.RetryDeadDeliveryReports/Altinn.Notifications.Tools.RetryDeadDeliveryReports.csproj" />
     <Project Path="tools/src/Altinn.Notifications.Tools.StatusFeedBackfillTool/Altinn.Notifications.Tools.StatusFeedBackfillTool.csproj" />
   </Folder>


### PR DESCRIPTION
## Description

`Altinn.Notifications.Tools.Tests` references the DlqManager project, but DlqManager was only added to `tools/Altinn.Notifications.Tools.slnx` when the DLQ manager tool was introduced (#1618) — not to the root `Altinn.Notifications.slnx`. Restoring the root solution therefore fails with:

```
NU1105: Unable to find project information for '...\tools\src\Altinn.Notifications.Tools.DlqManager\Altinn.Notifications.Tools.DlqManager.csproj'
```

for anyone opening the root solution in an IDE (Rider/Visual Studio).

One-line fix: add the project to the `/Tools/src/` folder in the root solution. Verified that this was the only project on disk missing from the root solution.

## Verification

- [x] `dotnet restore Altinn.Notifications.slnx` succeeds (previously failed with NU1105)
- [x] `Altinn.Notifications.Tools.Tests` builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
