### PR TITLE
Extend CVE-2026-45447 suppression by one week

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,4 +1,4 @@
 vulnerabilities:
   - id: CVE-2026-45447 # libcrypto3/libssl3
     statement: The vulnerable code has no reachable execution path in our application
-    expired_at: 2026-06-18 # revisit in 1 week
+    expired_at: 2026-06-25 # revisit in 1 week


### PR DESCRIPTION
## Description
 Extends the expiry of the CVE-2026-45447 suppression in `.trivyignore.yaml` from 2026-06-18 to 2026-06-25.

 The vulnerability (Heap Use-After-Free in OpenSSL `PKCS7_verify()`) is not exploitable in our  application. Neither `10.0.8` nor `10.0.9` of `mcr.microsoft.com/dotnet/aspnet:alpine3.23` ships with the patched `libssl3 3.5.7-r0` yet.

## Related Issue(s)
- #1675

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security vulnerability exception expiration date to extend review timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->