### PR TITLE
Allow CRLF convention with prettier auto

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,7 +14,6 @@
 *.csproj   text
 *.css      text diff=css
 Dockerfile text
-*.js       text eol=lf
 *.json     text
 *.md       text diff=markdown
 *.msbuild  text

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 *.csproj   text
 *.css      text diff=css
 Dockerfile text
+*.js       text eol=lf
 *.json     text
 *.md       text diff=markdown
 *.msbuild  text

--- a/components/api/test/k6/.prettierrc
+++ b/components/api/test/k6/.prettierrc
@@ -7,7 +7,8 @@
         "semi": true,
         "singleQuote": false,
         "trailingComma": "es5",
-        "printWidth": 80
+        "printWidth": 80,
+        "endOfLine": "auto"
       }
     }
   ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

~~Prettier writes LF during formatting of *.js files. This interrupts the CRLF checkout on Windows machines, causing invisible diffs. This PR enforces LF-only checkouts across operating systems to avoid these ghost diffs.~~

Instead of forcing LF-endings for all operating systems we can simply set auto mode in the prettier config to respect CRLF-endings.

## Related Issue(s)
- #771

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for consistent line ending handling in JavaScript files.

---

**Note:** This is an internal configuration update with no visible impact to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->