### PR TITLE
Use updated dotnet image w/ patched libraries

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,4 +1,4 @@
 vulnerabilities:
-  - id: CVE-2026-45447 # libcrypto3/libssl3
-    statement: The vulnerable code has no reachable execution path in our application
-    expired_at: 2026-06-25 # revisit in 1 week
+  # - id: CVE-2026-45447 # libcrypto3/libssl3
+  #   statement: The vulnerable code has no reachable execution path in our application
+  #   expired_at: 2026-06-25 # revisit in 1 week

--- a/components/api/Dockerfile
+++ b/components/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.301-alpine3.23@sha256:fac7cce841f78faa4bca416fb4c636d1a129c09abd9b50e9b45664b95fd008a0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.301-alpine3.23@sha256:940f919ae84dd92ccd4aab7686fa5b777870b006c9360351039e16bcaad73d89 AS build
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -16,7 +16,7 @@ COPY components/shared/src ./components/shared/src
 RUN dotnet publish -c Release -o out ./components/api/src/Altinn.Notifications/Altinn.Notifications.csproj
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.9-alpine3.23@sha256:72ba73e4bec80e6791a022454b2dda2d6f6f77bdf48d89afb35186deebf73eb9 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.9-alpine3.23@sha256:57bd717ac18ff6c8a39cc0ee4a76c1f15adc46df50434c73eff0c3f1df4c88f0 AS final
 WORKDIR /app
 EXPOSE 5090
 

--- a/components/email-service/Dockerfile
+++ b/components/email-service/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official .NET SDK image with Alpine Linux as a base image
-FROM mcr.microsoft.com/dotnet/sdk:10.0.301-alpine3.23@sha256:fac7cce841f78faa4bca416fb4c636d1a129c09abd9b50e9b45664b95fd008a0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.301-alpine3.23@sha256:940f919ae84dd92ccd4aab7686fa5b777870b006c9360351039e16bcaad73d89 AS build
 
 # Set the working directory in the container
 WORKDIR /app
@@ -20,7 +20,7 @@ RUN dotnet publish -c Release -o out \
     ./components/email-service/src/Altinn.Notifications.Email/Altinn.Notifications.Email.csproj
 
 # Use the official .NET runtime image with Alpine Linux as a base image
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.9-alpine3.23@sha256:72ba73e4bec80e6791a022454b2dda2d6f6f77bdf48d89afb35186deebf73eb9 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.9-alpine3.23@sha256:57bd717ac18ff6c8a39cc0ee4a76c1f15adc46df50434c73eff0c3f1df4c88f0 AS final
 EXPOSE 5091
 WORKDIR /app
 COPY --from=build /app/out ./

--- a/components/sms-service/Dockerfile
+++ b/components/sms-service/Dockerfile
@@ -1,5 +1,5 @@
 #Use the official .NET SDK image with Alpine Linux as a base image
-FROM mcr.microsoft.com/dotnet/sdk:10.0.301-alpine3.23@sha256:fac7cce841f78faa4bca416fb4c636d1a129c09abd9b50e9b45664b95fd008a0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.301-alpine3.23@sha256:940f919ae84dd92ccd4aab7686fa5b777870b006c9360351039e16bcaad73d89 AS build
 
 # Set the working directory in the container
 WORKDIR /app
@@ -21,7 +21,7 @@ RUN dotnet publish -c Release -o out \
 
 
 # Use the official .NET runtime image with Alpine Linux as a base image
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.9-alpine3.23@sha256:72ba73e4bec80e6791a022454b2dda2d6f6f77bdf48d89afb35186deebf73eb9 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.9-alpine3.23@sha256:57bd717ac18ff6c8a39cc0ee4a76c1f15adc46df50434c73eff0c3f1df4c88f0 AS final
 EXPOSE 5092
 WORKDIR /app
 COPY --from=build /app/out ./


### PR DESCRIPTION
Microsoft has released a new digest with updated Docker manifest list. It includes the fixed versions of libcrypto3 and libssl3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base images across backend services to newer pinned versions for more consistent builds and runtime environments.
* **Bug Fixes**
  * Removed an ignored security finding so the affected issue will be reported again during scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->