### PR TITLE
Upgrade WolverineFx packages to v6

### DIFF
--- a/components/api/src/Altinn.Notifications.Integrations/Altinn.Notifications.Integrations.csproj
+++ b/components/api/src/Altinn.Notifications.Integrations/Altinn.Notifications.Integrations.csproj
@@ -16,8 +16,9 @@
     <PackageReference Include="OpenTelemetry.Api" Version="1.16.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
     <PackageReference Include="Npgsql" Version="10.0.3" />
-    <PackageReference Include="WolverineFx" Version="5.39.5" />
-    <PackageReference Include="WolverineFx.AzureServiceBus" Version="5.39.5" />
+    <PackageReference Include="WolverineFx" Version="6.14.0" />
+    <PackageReference Include="WolverineFx.AzureServiceBus" Version="6.14.0" />
+    <PackageReference Include="WolverineFx.RuntimeCompilation" Version="6.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/components/email-service/src/Altinn.Notifications.Email.Integrations/Altinn.Notifications.Email.Integrations.csproj
+++ b/components/email-service/src/Altinn.Notifications.Email.Integrations/Altinn.Notifications.Email.Integrations.csproj
@@ -11,8 +11,9 @@
   <ItemGroup>
     <PackageReference Include="Azure.Communication.Email" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
-    <PackageReference Include="WolverineFx" Version="5.39.5" />
-    <PackageReference Include="WolverineFx.AzureServiceBus" Version="5.39.5" />
+    <PackageReference Include="WolverineFx" Version="6.14.0" />
+    <PackageReference Include="WolverineFx.AzureServiceBus" Version="6.14.0" />
+    <PackageReference Include="WolverineFx.RuntimeCompilation" Version="6.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/components/shared/src/Altinn.Notifications.Shared/Altinn.Notifications.Shared.csproj
+++ b/components/shared/src/Altinn.Notifications.Shared/Altinn.Notifications.Shared.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
     <PackageReference Include="WolverineFx" Version="6.14.0" />
     <PackageReference Include="WolverineFx.AzureServiceBus" Version="6.14.0" />
-    <PackageReference Include="WolverineFx.RuntimeCompilation" Version="6.14.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/components/shared/src/Altinn.Notifications.Shared/Altinn.Notifications.Shared.csproj
+++ b/components/shared/src/Altinn.Notifications.Shared/Altinn.Notifications.Shared.csproj
@@ -10,8 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageReference Include="WolverineFx" Version="5.39.5" />
-    <PackageReference Include="WolverineFx.AzureServiceBus" Version="5.39.5" />
+    <PackageReference Include="WolverineFx" Version="6.14.0" />
+    <PackageReference Include="WolverineFx.AzureServiceBus" Version="6.14.0" />
+    <PackageReference Include="WolverineFx.RuntimeCompilation" Version="6.14.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/components/shared/test/Altinn.Notifications.Shared.TestInfrastructure/Altinn.Notifications.Shared.TestInfrastructure.csproj
+++ b/components/shared/test/Altinn.Notifications.Shared.TestInfrastructure/Altinn.Notifications.Shared.TestInfrastructure.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Npgsql" Version="10.0.3" />
     <PackageReference Include="Testcontainers" Version="4.12.0" />
     <PackageReference Include="WolverineFx" Version="6.14.0" />
-    <PackageReference Include="WolverineFx.RuntimeCompilation" Version="6.14.0" />
     <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
   </ItemGroup>
 

--- a/components/shared/test/Altinn.Notifications.Shared.TestInfrastructure/Altinn.Notifications.Shared.TestInfrastructure.csproj
+++ b/components/shared/test/Altinn.Notifications.Shared.TestInfrastructure/Altinn.Notifications.Shared.TestInfrastructure.csproj
@@ -15,7 +15,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
     <PackageReference Include="Npgsql" Version="10.0.3" />
     <PackageReference Include="Testcontainers" Version="4.12.0" />
-    <PackageReference Include="WolverineFx" Version="5.39.5" />
+    <PackageReference Include="WolverineFx" Version="6.14.0" />
+    <PackageReference Include="WolverineFx.RuntimeCompilation" Version="6.14.0" />
     <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
   </ItemGroup>
 

--- a/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Altinn.Notifications.Sms.Integrations.csproj
+++ b/components/sms-service/src/Altinn.Notifications.Sms.Integrations/Altinn.Notifications.Sms.Integrations.csproj
@@ -12,8 +12,9 @@
     <PackageReference Include="LinkMobilityNE.PSWin.Client" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageReference Include="WolverineFx" Version="5.39.5" />
-    <PackageReference Include="WolverineFx.AzureServiceBus" Version="5.39.5" />
+    <PackageReference Include="WolverineFx" Version="6.14.0" />
+    <PackageReference Include="WolverineFx.AzureServiceBus" Version="6.14.0" />
+    <PackageReference Include="WolverineFx.RuntimeCompilation" Version="6.14.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The only breaking change that impacts us seems to be [Runtime code generation moved to the WolverineFx.RuntimeCompilation package (BREAKING)](https://wolverinefx.net/guide/migration.html#runtime-code-generation-moved-to-the-wolverinefx-runtimecompilation-package-breaking). Solved here by using migration alternative 1. "_Keep runtime codegen_"