### PR TITLE
Add clock skew-check to FailureActionsExtensions

### DIFF
--- a/components/api/src/Altinn.Notifications.Integrations/Wolverine/FailureActionsExtensions.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Wolverine/FailureActionsExtensions.cs
@@ -45,11 +45,22 @@ public static class FailureActionsExtensions
 
                 var deadDeliveryReportService = runtime.Services.GetRequiredService<IDeadDeliveryReportService>();
 
+                var lastAttempt = DateTime.UtcNow;
+
+                // EnqueuedAt reflects the Service Bus send time and may be marginally ahead of
+                // the processing host clock due to clock skew, causing FirstSeen > LastAttempt
+                // on no-retry paths such as NOTIFICATION_EXPIRED. Clamp to preserve the invariant.
+                var firstSeen = innerEnvelope.EnqueuedAt().UtcDateTime;
+                if (firstSeen > lastAttempt)
+                {
+                    firstSeen = lastAttempt;
+                }
+
                 var deadDeliveryReport = new DeadDeliveryReport
                 {
                     Channel = channel,
-                    FirstSeen = innerEnvelope.EnqueuedAt().UtcDateTime,
-                    LastAttempt = DateTime.UtcNow,
+                    FirstSeen = firstSeen,
+                    LastAttempt = lastAttempt,
                     AttemptCount = Math.Max(1, innerEnvelope.Attempts),
                     Resolved = false,
                     DeliveryReport = payload,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #1730 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling for failed deliveries to avoid inconsistencies caused by slight clock differences between systems.
  * Ensured failure reports always show a valid time range, with the first-seen time never later than the last-attempt time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->