### PR TITLE
Revert "Add path filters for migration components in .coderabbit.yaml"

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,0 @@
-reviews:
-  path_filters:
-    - "!components/api/src/Altinn.Notifications.Persistence/Migration/**"
-    - "components/api/src/Altinn.Notifications.Persistence/Migration/FunctionsAndProcedures/**"


### PR DESCRIPTION
The rule excluded more files than expected:
<img width="981" height="1032" alt="image" src="https://github.com/user-attachments/assets/a4c0a821-f765-48fe-a4ac-7bca6552582b" />
