### PR TITLE
Guard against duplicate order processing

### DIFF
--- a/components/api/src/Altinn.Notifications.Core/Persistence/IOrderRepository.cs
+++ b/components/api/src/Altinn.Notifications.Core/Persistence/IOrderRepository.cs
@@ -131,6 +131,16 @@ public interface IOrderRepository
     public Task SetProcessingStatus(Guid orderId, OrderProcessingStatus status);
 
     /// <summary>
+    /// Resets an order that is currently <see cref="OrderProcessingStatus.Processing"/> back to
+    /// <see cref="OrderProcessingStatus.Registered"/> so it can be re-claimed for processing.
+    /// A no-op if the order is no longer in <see cref="OrderProcessingStatus.Processing"/> state
+    /// (for example, if a concurrent/duplicate delivery has already advanced it to a later status),
+    /// preventing an already-completed order from being regressed and reprocessed.
+    /// </summary>
+    /// <param name="orderId">The unique identifier of the order to reset.</param>
+    public Task ResetProcessingToRegistered(Guid orderId);
+
+    /// <summary>
     /// Inserts a status feed entry for the specified order.
     /// </summary>
     /// <param name="orderId">The unique identifier of the order.</param>

--- a/components/api/src/Altinn.Notifications.Core/Services/OrderProcessingService.cs
+++ b/components/api/src/Altinn.Notifications.Core/Services/OrderProcessingService.cs
@@ -97,18 +97,18 @@ public class OrderProcessingService : IOrderProcessingService
     /// </summary>
     private async Task ResetOrdersToRegistered(IEnumerable<NotificationOrder> orders)
     {
-        foreach (var order in orders)
+        foreach (var orderId in orders.Select(order => order.Id))
         {
             try
             {
-                await _orderRepository.ResetProcessingToRegistered(order.Id);
+                await _orderRepository.ResetProcessingToRegistered(orderId);
             }
             catch (Exception ex)
             {
                 _logger.LogError(
                     ex,
                     "Failed to reset order {OrderId} back to Registered after a failed publish attempt. It may remain stuck in Processing until reconciled.",
-                    order.Id);
+                    orderId);
             }
         }
     }

--- a/components/api/src/Altinn.Notifications.Core/Services/OrderProcessingService.cs
+++ b/components/api/src/Altinn.Notifications.Core/Services/OrderProcessingService.cs
@@ -71,10 +71,7 @@ public class OrderProcessingService : IOrderProcessingService
                 cancellationToken.ThrowIfCancellationRequested();
 
                 failedOrders = await _pastDueOrderPublisher.PublishAsync(pastDueOrders, cancellationToken);
-                foreach (var order in failedOrders)
-                {
-                    await _orderRepository.SetProcessingStatus(order.Id, OrderProcessingStatus.Registered);
-                }
+                await ResetOrdersToRegistered(failedOrders);
             }
             catch (OperationCanceledException)
             {
@@ -82,10 +79,7 @@ public class OrderProcessingService : IOrderProcessingService
                 // must not be reset or they will be re-enqueued and processed twice.
                 // If PublishAsync never returned (threw mid-batch), reset all as we cannot tell which were published.
                 var ordersToReset = failedOrders ?? pastDueOrders;
-                foreach (var order in ordersToReset)
-                {
-                    await _orderRepository.SetProcessingStatus(order.Id, OrderProcessingStatus.Registered);
-                }
+                await ResetOrdersToRegistered(ordersToReset);
 
                 throw;
             }
@@ -93,6 +87,30 @@ public class OrderProcessingService : IOrderProcessingService
         while (pastDueOrders.Count >= 50 && stopwatch.ElapsedMilliseconds < 60_000);
 
         stopwatch.Stop();
+    }
+
+    /// <summary>
+    /// Resets each of the given orders back to <see cref="OrderProcessingStatus.Registered"/>, one at a
+    /// time. A failure resetting one order is logged and does not stop the remaining orders from being
+    /// reset — without this, a single transient failure partway through the batch would silently leave
+    /// every subsequent order stuck in <see cref="OrderProcessingStatus.Processing"/> indefinitely.
+    /// </summary>
+    private async Task ResetOrdersToRegistered(IEnumerable<NotificationOrder> orders)
+    {
+        foreach (var order in orders)
+        {
+            try
+            {
+                await _orderRepository.ResetProcessingToRegistered(order.Id);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to reset order {OrderId} back to Registered after a failed publish attempt. It may remain stuck in Processing until reconciled.",
+                    order.Id);
+            }
+        }
     }
 
     /// <inheritdoc/>
@@ -162,7 +180,7 @@ public class OrderProcessingService : IOrderProcessingService
            order!.Id,
            e.IsTransient?.ToString() ?? "Not available");
 
-            await _orderRepository.SetProcessingStatus(order.Id, OrderProcessingStatus.Registered);
+            await _orderRepository.ResetProcessingToRegistered(order.Id);
         }
     }
 

--- a/components/api/src/Altinn.Notifications.Integrations/Wolverine/Publishers/PastDueOrderPublisher.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Wolverine/Publishers/PastDueOrderPublisher.cs
@@ -86,9 +86,10 @@ public class PastDueOrderPublisher(
             await messageBus.SendAsync(new ProcessPastDueOrderCommand { Order = order });
             return null;
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException ex)
         {
             _logger.LogInformation(
+                ex,
                 "PastDueOrderPublisher cancelled before publishing order {OrderId}; reporting as unpublished.",
                 order.Id);
             return order;

--- a/components/api/src/Altinn.Notifications.Integrations/Wolverine/Publishers/PastDueOrderPublisher.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Wolverine/Publishers/PastDueOrderPublisher.cs
@@ -42,9 +42,21 @@ public class PastDueOrderPublisher(
         var failed = new ConcurrentBag<NotificationOrder>();
         using var semaphore = new SemaphoreSlim(_publishConcurrency);
 
+        // None of the per-order work below is allowed to throw — including cancellation while
+        // still queued on the semaphore — so Task.WhenAll always returns normally with a `failed`
+        // list that is a complete and accurate record of every order that was not published.
+        // Callers depend on that guarantee to safely retry only the orders that need it.
         await Task.WhenAll(orders.Select(async order =>
         {
-            await semaphore.WaitAsync(cancellationToken);
+            try
+            {
+                await semaphore.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                failed.Add(order);
+                return;
+            }
 
             try
             {
@@ -73,10 +85,6 @@ public class PastDueOrderPublisher(
             cancellationToken.ThrowIfCancellationRequested();
             await messageBus.SendAsync(new ProcessPastDueOrderCommand { Order = order });
             return null;
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
         }
         catch (Exception ex)
         {

--- a/components/api/src/Altinn.Notifications.Integrations/Wolverine/Publishers/PastDueOrderPublisher.cs
+++ b/components/api/src/Altinn.Notifications.Integrations/Wolverine/Publishers/PastDueOrderPublisher.cs
@@ -86,6 +86,13 @@ public class PastDueOrderPublisher(
             await messageBus.SendAsync(new ProcessPastDueOrderCommand { Order = order });
             return null;
         }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation(
+                "PastDueOrderPublisher cancelled before publishing order {OrderId}; reporting as unpublished.",
+                order.Id);
+            return order;
+        }
         catch (Exception ex)
         {
             _logger.LogError(

--- a/components/api/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
+++ b/components/api/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
@@ -39,6 +39,7 @@ public class OrderRepository : IOrderRepository
     private const string _insertSmsTextSql = "insert into notifications.smstexts(_orderid, sendernumber, body) VALUES ($1, $2, $3)"; // __orderid, _sendernumber, _body
     private const string _setProcessCompleted = "update notifications.orders set processedstatus =$1::orderprocessingstate, processed = CURRENT_TIMESTAMP where alternateid=$2";
     private const string _advanceStatusFromProcessingSql = "update notifications.orders set processedstatus =$1::orderprocessingstate, processed = CURRENT_TIMESTAMP where alternateid=$2 AND processedstatus = 'Processing'::orderprocessingstate";
+    private const string _resetProcessingToRegisteredSql = "update notifications.orders set processedstatus = 'Registered'::orderprocessingstate, processed = CURRENT_TIMESTAMP where alternateid=$1 AND processedstatus = 'Processing'::orderprocessingstate";
     private const string _getOrdersPastSendTimeUpdateStatus = "select notifications.getorders_pastsendtime_updatestatus()";
     private const string _getOrderIncludeStatus = "select * from notifications.getorder_includestatus_v5($1, $2)"; // _alternateid,  creator
     private const string _cancelAndReturnOrder = "select * from notifications.cancelorder_v2($1, $2)"; // _alternateid,  creator
@@ -242,6 +243,14 @@ public class OrderRepository : IOrderRepository
     {
         await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_setProcessCompleted);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, status.ToString());
+        pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, orderId);
+        await pgcom.ExecuteNonQueryAsync();
+    }
+
+    /// <inheritdoc/>
+    public async Task ResetProcessingToRegistered(Guid orderId)
+    {
+        await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_resetProcessingToRegisteredSql);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, orderId);
         await pgcom.ExecuteNonQueryAsync();
     }

--- a/components/api/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/OrderRepositoryTests.cs
+++ b/components/api/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/OrderRepositoryTests.cs
@@ -65,11 +65,11 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
             Id = Guid.NewGuid(),
             Created = DateTime.UtcNow,
             Creator = new("test"),
-            Templates = new List<INotificationTemplate>()
-            {
+            Templates =
+            [
                 new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain),
                 new SmsTemplate("Altinn", "This is the body")
-            }
+            ]
         };
 
         _orderIdsToDelete.Add(order.Id);
@@ -108,10 +108,10 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
             Id = Guid.NewGuid(),
             Created = DateTime.UtcNow,
             Creator = new("test"),
-            Templates = new List<INotificationTemplate>()
-            {
+            Templates =
+            [
                 new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)
-            }
+            ]
         };
 
         _orderIdsToDelete.Add(order.Id);
@@ -142,11 +142,11 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
             Id = Guid.NewGuid(),
             Created = DateTime.UtcNow,
             Creator = new("test"),
-            Templates = new List<INotificationTemplate>()
-            {
+            Templates =
+            [
                 new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain),
                 new SmsTemplate("Altinn", "This is the body")
-            },
+            ],
             ConditionEndpoint = new Uri("https://vg.no/condition")
         };
 
@@ -173,11 +173,11 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
             Id = Guid.NewGuid(),
             Created = DateTime.UtcNow,
             Creator = new("test"),
-            Templates = new List<INotificationTemplate>()
-            {
+            Templates =
+            [
                 new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain),
                 new SmsTemplate("Altinn", "This is the body")
-            },
+            ],
             ConditionEndpoint = new Uri("https://vg.no/condition")
         };
 
@@ -214,10 +214,10 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
             Id = Guid.NewGuid(),
             Created = DateTime.UtcNow,
             Creator = new("test"),
-            Templates = new List<INotificationTemplate>()
-            {
+            Templates =
+            [
                 new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)
-            }
+            ]
         };
 
         _orderIdsToDelete.Add(order.Id);
@@ -242,6 +242,82 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ResetProcessingToRegistered_OrderInProcessingState_ResetsToRegistered()
+    {
+        // Arrange
+        OrderRepository repo = (OrderRepository)ServiceUtil
+            .GetServices([typeof(IOrderRepository)])
+            .First(i => i.GetType() == typeof(OrderRepository));
+
+        NotificationOrder order = new()
+        {
+            Id = Guid.NewGuid(),
+            Created = DateTime.UtcNow,
+            Creator = new("test"),
+            Templates =
+            [
+                new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)
+            ]
+        };
+
+        _orderIdsToDelete.Add(order.Id);
+        await repo.Create(order);
+        await repo.SetProcessingStatus(order.Id, OrderProcessingStatus.Processing);
+
+        // Act
+        await repo.ResetProcessingToRegistered(order.Id);
+
+        // Assert
+        string sql = $@"SELECT processedstatus
+                            FROM notifications.orders
+                            WHERE alternateid = '{order.Id}'";
+
+        string? status = await PostgreUtil.RunSqlReturnOutput<string>(sql);
+
+        Assert.Equal(OrderProcessingStatus.Registered.ToString(), status);
+    }
+
+    [Fact]
+    public async Task ResetProcessingToRegistered_OrderAlreadyAdvancedPastProcessing_IsNoOp()
+    {
+        // Arrange
+        OrderRepository repo = (OrderRepository)ServiceUtil
+            .GetServices([typeof(IOrderRepository)])
+            .First(i => i.GetType() == typeof(OrderRepository));
+
+        NotificationOrder order = new()
+        {
+            Id = Guid.NewGuid(),
+            Created = DateTime.UtcNow,
+            Creator = new("test"),
+            Templates =
+            [
+                new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)
+            ]
+        };
+
+        _orderIdsToDelete.Add(order.Id);
+        await repo.Create(order);
+        await repo.SetProcessingStatus(order.Id, OrderProcessingStatus.Processing);
+        await repo.SetProcessingStatus(order.Id, OrderProcessingStatus.Processed);
+
+        // Act
+
+        // Simulates a duplicate/stale reset attempt racing against an order that a concurrent
+        // delivery has already advanced past Processing — must not regress it back to Registered.
+        await repo.ResetProcessingToRegistered(order.Id);
+
+        // Assert
+        string sql = $@"SELECT processedstatus
+                            FROM notifications.orders
+                            WHERE alternateid = '{order.Id}'";
+
+        string? status = await PostgreUtil.RunSqlReturnOutput<string>(sql);
+
+        Assert.Equal(OrderProcessingStatus.Processed.ToString(), status);
+    }
+
+    [Fact]
     public async Task InsertStatusFeedForOrder_WithSendConditionNotMetOrder_InsertsStatusFeedCorrectly()
     {
         // Arrange
@@ -255,10 +331,10 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
             Created = DateTime.UtcNow,
             Creator = new("test"),
             SendersReference = Guid.NewGuid().ToString(),
-            Templates = new List<INotificationTemplate>()
-            {
+            Templates =
+            [
                 new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)
-            },
+            ],
             ConditionEndpoint = new Uri("https://vg.no/condition")
         };
 
@@ -299,10 +375,10 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
             Created = DateTime.UtcNow,
             Creator = new("test"),
             SendersReference = null,
-            Templates = new List<INotificationTemplate>()
-            {
+            Templates =
+            [
                 new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)
-            },
+            ],
             ConditionEndpoint = new Uri("https://vg.no/condition")
         };
 
@@ -383,10 +459,10 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
             Id = Guid.NewGuid(),
             Created = DateTime.UtcNow,
             Creator = new("test"),
-            Templates = new List<INotificationTemplate>()
-            {
+            Templates =
+            [
                 new SmsTemplate("Altinn", "This is the body")
-            },
+            ],
             RequestedSendTime = DateTime.UtcNow.AddMinutes(-1)
         };
 
@@ -420,10 +496,10 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
             Id = Guid.NewGuid(),
             Created = DateTime.UtcNow,
             Creator = new("test"),
-            Templates = new List<INotificationTemplate>()
-            {
+            Templates =
+            [
                 new SmsTemplate("Altinn", "This is the body")
-            },
+            ],
             RequestedSendTime = DateTime.UtcNow.AddMinutes(20)
         };
 

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderProcessingServiceTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderProcessingServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,6 +14,7 @@ using Altinn.Notifications.Core.Models.SendCondition;
 using Altinn.Notifications.Core.Persistence;
 using Altinn.Notifications.Core.Services;
 using Altinn.Notifications.Core.Services.Interfaces;
+using Altinn.Notifications.Core.Shared;
 
 using Microsoft.Extensions.Logging;
 
@@ -87,7 +89,7 @@ public class OrderProcessingServiceTests
 
         foreach (var order in batchOrders)
         {
-            orderRepositoryMock.Verify(e => e.SetProcessingStatus(order.Id, OrderProcessingStatus.Registered), Times.Once);
+            orderRepositoryMock.Verify(e => e.ResetProcessingToRegistered(order.Id), Times.Once);
         }
     }
 
@@ -123,7 +125,7 @@ public class OrderProcessingServiceTests
 
         foreach (var order in firstBatch)
         {
-            repo.Verify(e => e.SetProcessingStatus(order.Id, OrderProcessingStatus.Registered), Times.Never);
+            repo.Verify(e => e.ResetProcessingToRegistered(order.Id), Times.Never);
         }
     }
 
@@ -162,13 +164,13 @@ public class OrderProcessingServiceTests
 
         foreach (var order in failedOrders)
         {
-            orderRepositoryMock.Verify(e => e.SetProcessingStatus(order.Id, OrderProcessingStatus.Registered), Times.Once);
+            orderRepositoryMock.Verify(e => e.ResetProcessingToRegistered(order.Id), Times.Once);
         }
 
         var succeededOrders = batchOrders.Except(failedOrders).ToList();
         foreach (var order in succeededOrders)
         {
-            orderRepositoryMock.Verify(e => e.SetProcessingStatus(order.Id, OrderProcessingStatus.Registered), Times.Never);
+            orderRepositoryMock.Verify(e => e.ResetProcessingToRegistered(order.Id), Times.Never);
         }
     }
 
@@ -201,7 +203,7 @@ public class OrderProcessingServiceTests
 
         foreach (var order in pastDueOrders)
         {
-            orderRepositoryMock.Verify(e => e.SetProcessingStatus(order.Id, OrderProcessingStatus.Registered), Times.Once);
+            orderRepositoryMock.Verify(e => e.ResetProcessingToRegistered(order.Id), Times.Once);
         }
 
         publisherMock.Verify(e => e.PublishAsync(It.IsAny<IReadOnlyList<NotificationOrder>>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -240,10 +242,10 @@ public class OrderProcessingServiceTests
 
         foreach (var order in failedOrders)
         {
-            orderRepositoryMock.Verify(e => e.SetProcessingStatus(order.Id, OrderProcessingStatus.Registered), Times.Once);
+            orderRepositoryMock.Verify(e => e.ResetProcessingToRegistered(order.Id), Times.Once);
         }
 
-        orderRepositoryMock.Verify(e => e.SetProcessingStatus(It.Is<Guid>(id => !failedOrders.Select(v => v.Id).Contains(id)), OrderProcessingStatus.Registered), Times.Never);
+        orderRepositoryMock.Verify(e => e.ResetProcessingToRegistered(It.Is<Guid>(id => !failedOrders.Select(v => v.Id).Contains(id))), Times.Never);
     }
 
     [Fact]
@@ -305,7 +307,7 @@ public class OrderProcessingServiceTests
         foreach (var orderId in unpublishedOrderIds)
         {
             orderRepositoryMock.Verify(
-                r => r.SetProcessingStatus(orderId, OrderProcessingStatus.Registered),
+                r => r.ResetProcessingToRegistered(orderId),
                 Times.Once);
         }
 
@@ -313,7 +315,7 @@ public class OrderProcessingServiceTests
         foreach (var orderId in publishedOrderIds)
         {
             orderRepositoryMock.Verify(
-                r => r.SetProcessingStatus(orderId, OrderProcessingStatus.Registered),
+                r => r.ResetProcessingToRegistered(orderId),
                 Times.Never);
         }
     }
@@ -342,7 +344,7 @@ public class OrderProcessingServiceTests
 
         foreach (var order in fetchedBatch)
         {
-            orderRepositoryMock.Verify(e => e.SetProcessingStatus(order.Id, OrderProcessingStatus.Registered), Times.Once);
+            orderRepositoryMock.Verify(e => e.ResetProcessingToRegistered(order.Id), Times.Once);
         }
     }
 
@@ -1623,6 +1625,38 @@ public class OrderProcessingServiceTests
         orderRepositoryMock.Verify(e => e.InsertStatusFeedForOrder(It.IsAny<Guid>()), Times.Never);
 
         orderRepositoryMock.Verify(e => e.SetProcessingStatus(It.IsAny<Guid>(), It.Is<OrderProcessingStatus>(s => s.Equals(OrderProcessingStatus.Completed))), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessOrderRetry_PlatformDependencyExceptionThrown_ResetsOrderToRegisteredWithoutRethrowing()
+    {
+        // Arrange
+        NotificationOrder order = new()
+        {
+            Id = Guid.NewGuid(),
+            NotificationChannel = NotificationChannel.Sms
+        };
+
+        var orderRepositoryMock = new Mock<IOrderRepository>();
+
+        var processingServiceMock = new Mock<ISmsOrderProcessingService>();
+        processingServiceMock
+            .Setup(e => e.ProcessOrderRetry(It.IsAny<NotificationOrder>()))
+            .ThrowsAsync(new PlatformDependencyException("ProfileClient", "GetUserContactPoints", new HttpRequestException("Connection refused")));
+
+        var orderProcessingService = GetTestService(orderRepository: orderRepositoryMock.Object, smsOrderProcessingService: processingServiceMock.Object);
+
+        // Act
+
+        // A platform dependency failure during retry must be swallowed (not rethrown) and the
+        // order rolled back to Registered so it can be re-claimed on the next poll, instead of
+        // being left stuck in Processing.
+        await orderProcessingService.ProcessOrderRetry(order);
+
+        // Assert
+        processingServiceMock.Verify(e => e.ProcessOrderRetry(It.IsAny<NotificationOrder>()), Times.Once);
+        orderRepositoryMock.Verify(e => e.ResetProcessingToRegistered(order.Id), Times.Once);
+        orderRepositoryMock.Verify(e => e.PersistProcessingResultAsync(It.IsAny<NotificationOrder>(), It.IsAny<EmailOrderProcessingResult>(), It.IsAny<SmsOrderProcessingResult>()), Times.Never);
     }
 
     [Fact]

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderProcessingServiceTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Core/TestingServices/OrderProcessingServiceTests.cs
@@ -249,6 +249,44 @@ public class OrderProcessingServiceTests
     }
 
     [Fact]
+    public async Task StartProcessingPastDueOrders_ResetThrowsForOneOrder_ContinuesResettingRemainingOrders()
+    {
+        // Arrange
+        var batchOrders = CreateOrderBatch(3, "reset-failure");
+
+        var orderRepositoryMock = new Mock<IOrderRepository>();
+        orderRepositoryMock
+            .Setup(e => e.GetPastDueOrdersAndSetProcessingState(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(batchOrders);
+
+        // Simulate a transient failure resetting the first order — the remaining orders in the
+        // batch must still be reset rather than being left stuck in Processing.
+        orderRepositoryMock
+            .Setup(e => e.ResetProcessingToRegistered(batchOrders[0].Id))
+            .ThrowsAsync(new InvalidOperationException("Transient database failure"));
+
+        var publisherMock = new Mock<IPastDueOrderPublisher>();
+        publisherMock
+            .Setup(e => e.PublishAsync(
+                It.Is<IReadOnlyList<NotificationOrder>>(orders => orders.Count == 3),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(batchOrders);
+
+        var service = GetTestService(orderRepository: orderRepositoryMock.Object, publisher: publisherMock.Object);
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        // Act
+        await service.StartProcessingPastDueOrders(cancellationTokenSource.Token);
+
+        // Assert: every order was attempted, including the ones after the one that threw.
+        foreach (var order in batchOrders)
+        {
+            orderRepositoryMock.Verify(e => e.ResetProcessingToRegistered(order.Id), Times.Once);
+        }
+    }
+
+    [Fact]
     public async Task StartProcessingPastDueOrders_CancellationRequestedDuringSecondBatch_UnproducedOrdersRevertedToRegistered()
     {
         // Arrange

--- a/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Wolverine/PastDueOrderPublisherTests.cs
+++ b/components/api/test/Altinn.Notifications.Tests/Notifications.Integrations/Wolverine/PastDueOrderPublisherTests.cs
@@ -85,9 +85,11 @@ public class PastDueOrderPublisherTests
     }
 
     [Fact]
-    public async Task PublishAsync_MessageBusThrowsOperationCanceledException_Rethrows()
+    public async Task PublishAsync_MessageBusThrowsOperationCanceledException_ReturnsFailedOrderWithoutThrowing()
     {
         // Arrange
+        var order = CreateOrder();
+
         var messageBusMock = new Mock<IMessageBus>();
         messageBusMock
             .Setup(m => m.SendAsync(It.IsAny<ProcessPastDueOrderCommand>(), It.IsAny<DeliveryOptions?>()))
@@ -95,9 +97,59 @@ public class PastDueOrderPublisherTests
 
         var publisher = CreatePublisher(messageBusMock);
 
-        // Act & Assert
-        await Assert.ThrowsAsync<OperationCanceledException>(
-            () => publisher.PublishAsync([CreateOrder()], TestContext.Current.CancellationToken));
+        // Act
+
+        // A per-order cancellation must be reported as a failed (unpublished) order rather than
+        // propagating out of PublishAsync — otherwise the caller loses track of which orders in
+        // the batch were actually sent and has to pessimistically reset all of them, even ones
+        // that were already published successfully.
+        var result = await publisher.PublishAsync([order], TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(order.Id, result[0].Id);
+    }
+
+    [Fact]
+    public async Task PublishAsync_CancellationWhileQueuedOnSemaphore_ReturnsQueuedOrderAsFailedWithoutThrowing()
+    {
+        // Arrange
+        var runningOrder = CreateOrder();
+        var queuedOrder = CreateOrder();
+
+        using var cts = new CancellationTokenSource();
+        var releaseRunningOrder = new TaskCompletionSource();
+
+        var messageBusMock = new Mock<IMessageBus>();
+        messageBusMock
+            .Setup(m => m.SendAsync(
+                It.Is<ProcessPastDueOrderCommand>(c => c.Order.Id == runningOrder.Id),
+                It.IsAny<DeliveryOptions?>()))
+            .Returns<ProcessPastDueOrderCommand, DeliveryOptions?>((_, _) => new ValueTask(releaseRunningOrder.Task));
+
+        var publisher = CreatePublisher(messageBusMock, concurrency: 1);
+
+        // Act
+
+        // With concurrency capped at 1, runningOrder takes the only slot and suspends (awaiting
+        // releaseRunningOrder) without releasing it, so queuedOrder is deterministically still
+        // waiting on the semaphore — never having started a send — when cancellation fires.
+        var publishTask = publisher.PublishAsync([runningOrder, queuedOrder], cts.Token);
+
+        await cts.CancelAsync();
+        releaseRunningOrder.SetResult();
+
+        var result = await publishTask;
+
+        // Assert: PublishAsync must not throw, and must report exactly the queued order as
+        // failed — it never got a chance to attempt a send, so it definitely was not published.
+        Assert.Single(result);
+        Assert.Equal(queuedOrder.Id, result[0].Id);
+        messageBusMock.Verify(
+            m => m.SendAsync(
+                It.Is<ProcessPastDueOrderCommand>(c => c.Order.Id == queuedOrder.Id),
+                It.IsAny<DeliveryOptions?>()),
+            Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

### What changed

- `PastDueOrderPublisher` no longer lets cancellation escape as an exception from a per-order send — it's now treated like any other send failure. This means `PublishAsync` always returns a complete, accurate list of which orders were actually not published, even if cancellation fires mid-batch.
- Added `OrderRepository.ResetProcessingToRegistered`, replacing the direct `SetProcessingStatus(..., Registered)` calls. Its SQL only applies `WHERE processedstatus = 'Processing'`, so it can never regress an order that's already advanced past that state.
- Added `OrderProcessingService.ResetOrdersToRegistered`, which resets orders one at a time with a per-order try/catch, so a single failure doesn't stop the rest of the batch from being reset.

### Why this works

`StartProcessingPastDueOrders`'s cancellation handler used to fall back to resetting the *entire* claimed batch whenever it couldn't tell which orders had been published — because `PublishAsync` could throw before returning that information. Now it never throws, so the handler always has an accurate list and only resets orders it can prove weren't published. The guard on the reset SQL is a second line of defense: even if a reset were ever attempted against the wrong order, it's now a no-op instead of silently regressing a completed order back to `Registered`. Together, this removes the path that was causing the same order to be published — and processed — twice.

### Tests

- New/updated tests in `PastDueOrderPublisherTests` and `OrderProcessingServiceTests` covering the fixed cancellation handling.
- New integration tests confirming the reset is a no-op once an order has advanced past `Processing`.

## Related Issue(s)
- #1740

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order processing recovery by rolling back in-progress orders to a registered state, enabling them to be safely re-claimed and retried.
  * Cancellation during sending and while waiting for capacity now results in per-order failure reporting, rather than interrupting the whole batch.
  * Past-due order processing continues for remaining items when an individual order is canceled or fails, and queued cancellations are handled without throwing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->