### PR TITLE
Remove dead statusfeed method

### DIFF
--- a/components/api/src/Altinn.Notifications.Core/Persistence/IOrderRepository.cs
+++ b/components/api/src/Altinn.Notifications.Core/Persistence/IOrderRepository.cs
@@ -141,18 +141,6 @@ public interface IOrderRepository
     public Task ResetProcessingToRegistered(Guid orderId);
 
     /// <summary>
-    /// Inserts a status feed entry for the specified order.
-    /// </summary>
-    /// <param name="orderId">The unique identifier of the order.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    /// <remarks>
-    /// This method retrieves the current shipment tracking information for the order
-    /// and inserts it into the status feed. This is typically used for orders that
-    /// reach terminal states such as failed or where send condition is not met.
-    /// </remarks>
-    public Task InsertStatusFeedForOrder(Guid orderId);
-
-    /// <summary>
     /// Gets an order based on the provided id within the provided creator scope
     /// </summary>
     /// <param name="id">The order id</param>

--- a/components/api/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
+++ b/components/api/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
@@ -13,7 +13,6 @@ using Altinn.Notifications.Core.Persistence;
 using Altinn.Notifications.Core.Shared;
 using Altinn.Notifications.Persistence.Extensions;
 using Altinn.Notifications.Persistence.Mappers;
-using Altinn.Notifications.Persistence.Utils;
 
 using Npgsql;
 using NpgsqlTypes;
@@ -50,8 +49,6 @@ public class OrderRepository : IOrderRepository
     private const string _insertSmsNotificationSql = "call notifications.insertsmsnotification_v2($1, $2, $3, $4, $5, $6, $7, $8, $9)"; // (_orderid, _alternateid, _recipientorgno, _recipientnin, _mobilenumber, _customizedbody, _result, _resulttime, _expirytime)
     private const string _insertEmailNotificationSql = "call notifications.insertemailnotification($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"; // (_orderid, _alternateid, _recipientorgno, _recipientnin, _toaddress, _customizedbody, _customizedsubject, _result, _resulttime, _expirytime)
     private const string _getInstantOrderTrackingInformationSql = "SELECT * FROM notifications.get_instant_order_tracking(_creatorname := @creatorName, _idempotencyid := @idempotencyId)";
-    private const string _getOrderCreatorNameSql = "select creatorname from notifications.orders where alternateid=$1";
-    private const string _getShipmentTrackingSql = "SELECT * FROM notifications.get_shipment_tracking_v3(@alternateid, @creatorname)"; // (_alternateid, _creatorname)
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OrderRepository"/> class.
@@ -253,72 +250,6 @@ public class OrderRepository : IOrderRepository
         await using NpgsqlCommand pgcom = _dataSource.CreateCommand(_resetProcessingToRegisteredSql);
         pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, orderId);
         await pgcom.ExecuteNonQueryAsync();
-    }
-
-    /// <inheritdoc/>
-    public async Task InsertStatusFeedForOrder(Guid orderId)
-    {
-        await using var connection = await _dataSource.OpenConnectionAsync();
-        await using var transaction = await connection.BeginTransactionAsync();
-        List<Core.Models.Status.Recipient> recipients = [];
-
-        try
-        {
-            // Get order details to retrieve creator name
-            await using var getOrderCommand = new NpgsqlCommand(_getOrderCreatorNameSql, connection, transaction);
-            getOrderCommand.Parameters.AddWithValue(NpgsqlDbType.Uuid, orderId);
-
-            var creatorName = await getOrderCommand.ExecuteScalarAsync() as string;
-            if (string.IsNullOrEmpty(creatorName))
-            {
-                throw new InvalidOperationException($"Order with ID {orderId} not found.");
-            }
-
-            // Get shipment tracking information
-            await using var getTrackingCommand = new NpgsqlCommand(_getShipmentTrackingSql, connection, transaction);
-            getTrackingCommand.Parameters.AddWithValue("alternateid", NpgsqlDbType.Uuid, orderId);
-            getTrackingCommand.Parameters.AddWithValue("creatorname", NpgsqlDbType.Text, creatorName);
-
-            await using var reader = await getTrackingCommand.ExecuteReaderAsync();
-            if (await reader.ReadAsync())
-            {
-                // Read order tracking (first row is always the order-level tracking)
-                string? reference = await reader.IsDBNullAsync(reader.GetOrdinal("reference"))
-                    ? null
-                    : await reader.GetFieldValueAsync<string>("reference");
-
-                var statusValue = await reader.GetFieldValueAsync<string>("status");
-                var lastUpdate = await reader.GetFieldValueAsync<DateTime>("last_update");
-                var type = await reader.GetFieldValueAsync<string>("type");
-
-                // Attempt to read recipients
-                await NotificationUtil.ReadRecipientsAsync(recipients, reader, CancellationToken.None);
-
-                await reader.CloseAsync();
-
-                // Build OrderStatus object 
-                // If send condition is not met, the status feed entry will have an empty recipients list
-                var orderStatus = new OrderStatus
-                {
-                    ShipmentId = orderId,
-                    SendersReference = reference,
-                    Status = ProcessingLifecycleMapper.GetOrderLifecycleStage(statusValue),
-                    LastUpdated = lastUpdate,
-                    ShipmentType = type,
-                    Recipients = recipients.ToImmutableArray()
-                };
-
-                // Insert status feed entry
-                await StatusFeedRepository.InsertStatusFeedEntry(orderStatus, connection, transaction);
-            }
-
-            await transaction.CommitAsync();
-        }
-        catch
-        {
-            await transaction.RollbackAsync();
-            throw;
-        }
     }
 
     /// <inheritdoc/>

--- a/components/api/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/OrderRepositoryTests.cs
+++ b/components/api/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/OrderRepositoryTests.cs
@@ -318,113 +318,6 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task InsertStatusFeedForOrder_WithSendConditionNotMetOrder_InsertsStatusFeedCorrectly()
-    {
-        // Arrange
-        OrderRepository repo = (OrderRepository)ServiceUtil
-            .GetServices([typeof(IOrderRepository)])
-            .First(i => i.GetType() == typeof(OrderRepository));
-
-        NotificationOrder order = new()
-        {
-            Id = Guid.NewGuid(),
-            Created = DateTime.UtcNow,
-            Creator = new("test"),
-            SendersReference = Guid.NewGuid().ToString(),
-            Templates =
-            [
-                new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)
-            ],
-            ConditionEndpoint = new Uri("https://vg.no/condition")
-        };
-
-        _orderIdsToDelete.Add(order.Id);
-        await repo.Create(order);
-        await repo.SetProcessingStatus(order.Id, OrderProcessingStatus.SendConditionNotMet);
-
-        // Act
-        await repo.InsertStatusFeedForOrder(order.Id);
-
-        // Assert
-        int statusFeedCount = await PostgreUtil.SelectStatusFeedEntryCount(order.Id);
-        Assert.Equal(1, statusFeedCount);
-
-        // Additional verification: check that status feed contains SendConditionNotMet status and empty recipients
-        string jsonSql = $@"select sf.orderstatus
-                                from notifications.statusfeed sf
-                                join notifications.orders o on sf.orderid = o._id
-                                where o.alternateid = '{order.Id}'";
-
-        string orderStatusJson = await PostgreUtil.RunSqlReturnOutput<string>(jsonSql);
-        Assert.NotNull(orderStatusJson);
-        Assert.Contains("\"Recipients\": []", orderStatusJson);
-        Assert.Contains("\"Status\": \"Order_SendConditionNotMet\"", orderStatusJson);
-    }
-
-    [Fact]
-    public async Task InsertStatusFeedForOrder_WithSendConditionNotMetOrderAndSendersRefNull_InsertsStatusFeedCorrectly()
-    {
-        // Arrange
-        OrderRepository repo = (OrderRepository)ServiceUtil
-            .GetServices([typeof(IOrderRepository)])
-            .First(i => i.GetType() == typeof(OrderRepository));
-
-        NotificationOrder order = new()
-        {
-            Id = Guid.NewGuid(),
-            Created = DateTime.UtcNow,
-            Creator = new("test"),
-            SendersReference = null,
-            Templates =
-            [
-                new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)
-            ],
-            ConditionEndpoint = new Uri("https://vg.no/condition")
-        };
-
-        _orderIdsToDelete.Add(order.Id);
-        await repo.Create(order);
-        await repo.SetProcessingStatus(order.Id, OrderProcessingStatus.SendConditionNotMet);
-
-        // Act
-        await repo.InsertStatusFeedForOrder(order.Id);
-
-        // Assert
-        int statusFeedCount = await PostgreUtil.SelectStatusFeedEntryCount(order.Id);
-        Assert.Equal(1, statusFeedCount);
-
-        // Additional verification: check that status feed contains SendConditionNotMet status and empty recipients
-        string jsonSql = $@"select sf.orderstatus
-                                from notifications.statusfeed sf
-                                join notifications.orders o on sf.orderid = o._id
-                                where o.alternateid = '{order.Id}'";
-
-        string orderStatusJson = await PostgreUtil.RunSqlReturnOutput<string>(jsonSql);
-        Assert.NotNull(orderStatusJson);
-        Assert.Contains("\"Recipients\": []", orderStatusJson);
-        Assert.Contains("\"Status\": \"Order_SendConditionNotMet\"", orderStatusJson);
-    }
-
-    [Fact]
-    public async Task InsertStatusFeedForOrder_OrderDoesNotExist_ThrowsInvalidOperationException()
-    {
-        // Arrange
-        OrderRepository repo = (OrderRepository)ServiceUtil
-            .GetServices([typeof(IOrderRepository)])
-            .First(i => i.GetType() == typeof(OrderRepository));
-
-        Guid nonExistentOrderId = Guid.NewGuid();
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await repo.InsertStatusFeedForOrder(nonExistentOrderId));
-
-        Assert.Contains("Order with ID", exception.Message);
-        Assert.Contains("not found", exception.Message);
-        Assert.Contains(nonExistentOrderId.ToString(), exception.Message);
-    }
-
-    [Fact]
     public async Task CancelOrder_OrderDoesNotExits_ReturnsCancellationError()
     {
         // Arrange
@@ -3553,6 +3446,44 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
         using var doc = JsonDocument.Parse(statusJson);
         Assert.Equal(0, doc.RootElement.GetProperty("Recipients").GetArrayLength());
         Assert.Equal("Order_SendConditionNotMet", doc.RootElement.GetProperty("Status").GetString());
+    }
+
+    [Fact]
+    public async Task SetOrderSendConditionNotMetAsync_SendersReferenceNull_WritesStatusFeedWithNullReference()
+    {
+        // Arrange
+        OrderRepository repo = (OrderRepository)ServiceUtil
+            .GetServices([typeof(IOrderRepository)])
+            .First(i => i.GetType() == typeof(OrderRepository));
+
+        NotificationOrder order = new()
+        {
+            Id = Guid.NewGuid(),
+            Created = DateTime.UtcNow,
+            Creator = new("ttd"),
+            SendersReference = null,
+            Type = OrderType.Notification,
+            Templates = [new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)]
+        };
+
+        _orderIdsToDelete.Add(order.Id);
+        await repo.Create(order);
+        await repo.SetProcessingStatus(order.Id, OrderProcessingStatus.Processing);
+
+        // Act
+        await repo.SetOrderSendConditionNotMetAsync(order, TestContext.Current.CancellationToken);
+
+        // Assert
+        int statusFeedCount = await PostgreUtil.SelectStatusFeedEntryCount(order.Id);
+        Assert.Equal(1, statusFeedCount);
+
+        string jsonSql = $@"SELECT sf.orderstatus FROM notifications.statusfeed sf
+            JOIN notifications.orders o ON sf.orderid = o._id WHERE o.alternateid = '{order.Id}'";
+        string statusJson = await PostgreUtil.RunSqlReturnOutput<string>(jsonSql);
+        using var doc = JsonDocument.Parse(statusJson);
+        Assert.Equal(0, doc.RootElement.GetProperty("Recipients").GetArrayLength());
+        Assert.Equal("Order_SendConditionNotMet", doc.RootElement.GetProperty("Status").GetString());
+        Assert.False(doc.RootElement.TryGetProperty("SendersReference", out var sendersReferenceProperty) && sendersReferenceProperty.ValueKind != JsonValueKind.Null);
     }
 
     [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Cleaning up dead code after implementing order processing transactions.

## Related Issue(s)
- #1689

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved status-feed handling when an order’s sender reference is unavailable.
  - Status-feed entries now correctly record an empty recipient list and omit the sender reference when no value exists.

- **Tests**
  - Added coverage confirming the updated status-feed behavior.
  - Removed tests for the retired status-feed insertion flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->