### PR TITLE
Return to version 7 of FluentAssertions

### DIFF
--- a/.github/workflows/build-and-analyze.yml
+++ b/.github/workflows/build-and-analyze.yml
@@ -80,27 +80,32 @@ jobs:
           filters: |
             api:
               - 'global.json'
+              - 'Directory.Packages.props'
               - 'components/api/src/**'
               - 'components/api/Altinn.Notifications.API.slnx'
               - 'components/api/test/Altinn.Notifications.Tests/**'
               - 'components/api/test/Altinn.Notifications.IntegrationTests/**'
               - 'components/api/test/Altinn.Notifications.IntegrationTestsASB/**'
             shared:
+              - 'Directory.Packages.props'
               - 'global.json'
               - 'components/shared/src/**'
               - 'components/shared/test/**'
               - 'components/shared/Altinn.Notifications.Shared.slnx'
             sms:
+              - 'Directory.Packages.props'
               - 'global.json'
               - 'components/sms-service/src/**'
               - 'components/sms-service/test/**'
               - 'components/sms-service/Altinn.Notifications.Sms.slnx'
             email:
+              - 'Directory.Packages.props'
               - 'global.json'
               - 'components/email-service/src/**'
               - 'components/email-service/test/**'
               - 'components/email-service/Altinn.Notifications.Email.slnx'
             tools:
+              - 'Directory.Packages.props'
               - 'global.json'
               - 'tools/src/**'
               - 'tools/test/**'

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -8,6 +8,7 @@ on:
       - 'components/*/Dockerfile'
       - '.trivyignore.yaml'
       - '.github/workflows/container-scan.yml'
+      - 'Directory.Packages.props'
   pull_request:
     branches: [main]
     paths:
@@ -15,6 +16,7 @@ on:
       - 'components/*/Dockerfile'
       - '.trivyignore.yaml'
       - '.github/workflows/container-scan.yml'
+      - 'Directory.Packages.props'
   schedule:
     - cron: '0 8 * * 1,4'
 
@@ -47,18 +49,21 @@ jobs:
               - 'components/shared/src/**'
               - '.trivyignore.yaml'
               - '.github/workflows/container-scan.yml'
+              - 'Directory.Packages.props'
             sms:
               - 'components/shared/src/**'
               - 'components/sms-service/src/**'
               - 'components/sms-service/Dockerfile'
               - '.trivyignore.yaml'
               - '.github/workflows/container-scan.yml'
+              - 'Directory.Packages.props'
             email:
               - 'components/shared/src/**'
               - 'components/email-service/src/**'
               - 'components/email-service/Dockerfile'
               - '.trivyignore.yaml'
               - '.github/workflows/container-scan.yml'
+              - 'Directory.Packages.props'
 
   scan-api:
     name: 'Scan: Notifications API'

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
 
 		<!-- Quality / Testing -->
 		<PackageVersion Include="coverlet.collector" Version="10.0.1" />
-		<PackageVersion Include="FluentAssertions" Version="8.10.0" />
+		<PackageVersion Include="FluentAssertions" Version="7.2.2" />
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageVersion Include="Moq" Version="4.20.72" />
 		<PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />


### PR DESCRIPTION
## Description
Discovered by chance that we've been using version 8 of FluentAssertions. That is a version with a tricky lisence so we're backporting to version 7 while we work on replacing the package completely.

## Related Issue(s)
- Weekly patching

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the centrally managed FluentAssertions package version to 7.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->