### PR TITLE
InvalidOperationException thrown when processing orders with SendConditionNotMet, Processed, or Completed status due to duplicate message delivery

### DIFF
--- a/components/api/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
+++ b/components/api/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
@@ -904,9 +904,40 @@ public class OrderRepository(NpgsqlDataSource dataSource, ILogger<OrderRepositor
             }
 
             bool isCompleted = IsImmediatelyCompleted(emailNotifications, smsNotifications);
-
             var status = isCompleted ? OrderProcessingStatus.Completed : OrderProcessingStatus.Processed;
-            await SetProcessingStatusAsync(order.Id, status, connection, transaction, cancellationToken);
+
+            await using NpgsqlCommand pgcom = new(_advanceStatusFromProcessingSql, connection, transaction);
+            pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, status.ToString());
+            pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, order.Id);
+            int rowsAffected = await pgcom.ExecuteNonQueryAsync(cancellationToken);
+
+            if (rowsAffected == 0)
+            {
+                await using NpgsqlCommand statusCmd = new(
+                    "SELECT processedstatus FROM notifications.orders WHERE alternateid = $1",
+                    connection,
+                    transaction);
+                statusCmd.Parameters.AddWithValue(NpgsqlDbType.Uuid, order.Id);
+                var currentStatus = (string?)await statusCmd.ExecuteScalarAsync(cancellationToken);
+
+                if (currentStatus is "Completed" or "Processed")
+                {
+                    // Explicit rollback here — duplicate notifications are discarded.
+                    // We return normally so this path never reaches the catch block.
+                    await transaction.RollbackAsync(CancellationToken.None);
+
+                    _logger.LogError(
+                        "Order {OrderId} already had status '{CurrentStatus}' when PersistProcessingResultAsync was called; this order was processed more than once. Duplicate notifications were rolled back.",
+                        order.Id,
+                        currentStatus);
+
+                    return isCompleted;
+                }
+
+                // Throw — the catch block handles the single rollback for this path.
+                throw new InvalidOperationException(
+                    $"Order {order.Id} had unexpected status '{currentStatus ?? "not found"}' when attempting to persist processing result; expected Processing.");
+            }
 
             if (isCompleted)
             {

--- a/components/api/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
+++ b/components/api/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
@@ -1024,18 +1024,6 @@ public class OrderRepository(NpgsqlDataSource dataSource, ILogger<OrderRepositor
         return emailNotifications.All(IsEmailTerminal) && smsNotifications.All(IsSmsTerminal);
     }
 
-    private static async Task SetProcessingStatusAsync(Guid orderId, OrderProcessingStatus status, NpgsqlConnection connection, NpgsqlTransaction transaction, CancellationToken cancellationToken = default)
-    {
-        await using NpgsqlCommand pgcom = new(_advanceStatusFromProcessingSql, connection, transaction);
-        pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, status.ToString());
-        pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, orderId);
-        int rowsAffected = await pgcom.ExecuteNonQueryAsync(cancellationToken);
-        if (rowsAffected == 0)
-        {
-            throw new InvalidOperationException($"Order {orderId} was not in Processing state; transaction rolled back.");
-        }
-    }
-
     private async Task InsertStatusFeedForOrderAsync(
         NotificationOrder order,
         OrderProcessingStatus status,

--- a/components/api/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
+++ b/components/api/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
@@ -46,6 +46,7 @@ public class OrderRepository(NpgsqlDataSource dataSource, ILogger<OrderRepositor
     private const string _insertSmsTextSql = "insert into notifications.smstexts(_orderid, sendernumber, body) VALUES ($1, $2, $3)"; // __orderid, _sendernumber, _body
     private const string _setProcessCompleted = "update notifications.orders set processedstatus =$1::orderprocessingstate, processed = CURRENT_TIMESTAMP where alternateid=$2";
     private const string _advanceStatusFromProcessingSql = "update notifications.orders set processedstatus =$1::orderprocessingstate, processed = CURRENT_TIMESTAMP where alternateid=$2 AND processedstatus = 'Processing'::orderprocessingstate";
+    private const string _advanceStatusToSendConditionNotMetSql = "UPDATE notifications.orders SET processedstatus = 'SendConditionNotMet'::orderprocessingstate, processed = CURRENT_TIMESTAMP WHERE alternateid = $1 AND processedstatus NOT IN ('SendConditionNotMet'::orderprocessingstate, 'Completed'::orderprocessingstate)";
     private const string _resetProcessingToRegisteredSql = "update notifications.orders set processedstatus = 'Registered'::orderprocessingstate, processed = CURRENT_TIMESTAMP where alternateid=$1 AND processedstatus = 'Processing'::orderprocessingstate";
     private const string _getOrdersPastSendTimeUpdateStatus = "select notifications.getorders_pastsendtime_updatestatus()";
     private const string _getOrderIncludeStatus = "select * from notifications.getorder_includestatus_v5($1, $2)"; // _alternateid,  creator
@@ -931,8 +932,21 @@ public class OrderRepository(NpgsqlDataSource dataSource, ILogger<OrderRepositor
 
         try
         {
-            await SetProcessingStatusAsync(order.Id, OrderProcessingStatus.SendConditionNotMet, connection, transaction, cancellationToken);
-            await InsertStatusFeedForOrderAsync(order, OrderProcessingStatus.SendConditionNotMet, [], [], connection, transaction);
+            await using NpgsqlCommand pgcom = new(_advanceStatusToSendConditionNotMetSql, connection, transaction);
+            pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, order.Id);
+            int rowsAffected = await pgcom.ExecuteNonQueryAsync(cancellationToken);
+
+            if (rowsAffected > 0)
+            {
+                await InsertStatusFeedForOrderAsync(order, OrderProcessingStatus.SendConditionNotMet, [], [], connection, transaction);
+            }
+            else
+            {
+                _logger.LogError(
+                    "Order {OrderId} was already in a terminal state when SetOrderSendConditionNotMetAsync was called; this order was processed more than once.",
+                    order.Id);
+            }
+
             await transaction.CommitAsync(cancellationToken);
         }
         catch

--- a/components/api/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
+++ b/components/api/src/Altinn.Notifications.Persistence/Repository/OrderRepository.cs
@@ -46,7 +46,6 @@ public class OrderRepository(NpgsqlDataSource dataSource, ILogger<OrderRepositor
     private const string _insertSmsTextSql = "insert into notifications.smstexts(_orderid, sendernumber, body) VALUES ($1, $2, $3)"; // __orderid, _sendernumber, _body
     private const string _setProcessCompleted = "update notifications.orders set processedstatus =$1::orderprocessingstate, processed = CURRENT_TIMESTAMP where alternateid=$2";
     private const string _advanceStatusFromProcessingSql = "update notifications.orders set processedstatus =$1::orderprocessingstate, processed = CURRENT_TIMESTAMP where alternateid=$2 AND processedstatus = 'Processing'::orderprocessingstate";
-    private const string _advanceStatusToSendConditionNotMetSql = "UPDATE notifications.orders SET processedstatus = 'SendConditionNotMet'::orderprocessingstate, processed = CURRENT_TIMESTAMP WHERE alternateid = $1 AND processedstatus NOT IN ('SendConditionNotMet'::orderprocessingstate, 'Completed'::orderprocessingstate)";
     private const string _resetProcessingToRegisteredSql = "update notifications.orders set processedstatus = 'Registered'::orderprocessingstate, processed = CURRENT_TIMESTAMP where alternateid=$1 AND processedstatus = 'Processing'::orderprocessingstate";
     private const string _getOrdersPastSendTimeUpdateStatus = "select notifications.getorders_pastsendtime_updatestatus()";
     private const string _getOrderIncludeStatus = "select * from notifications.getorder_includestatus_v5($1, $2)"; // _alternateid,  creator
@@ -932,7 +931,8 @@ public class OrderRepository(NpgsqlDataSource dataSource, ILogger<OrderRepositor
 
         try
         {
-            await using NpgsqlCommand pgcom = new(_advanceStatusToSendConditionNotMetSql, connection, transaction);
+            await using NpgsqlCommand pgcom = new(_advanceStatusFromProcessingSql, connection, transaction);
+            pgcom.Parameters.AddWithValue(NpgsqlDbType.Text, OrderProcessingStatus.SendConditionNotMet.ToString());
             pgcom.Parameters.AddWithValue(NpgsqlDbType.Uuid, order.Id);
             int rowsAffected = await pgcom.ExecuteNonQueryAsync(cancellationToken);
 
@@ -942,9 +942,31 @@ public class OrderRepository(NpgsqlDataSource dataSource, ILogger<OrderRepositor
             }
             else
             {
-                _logger.LogError(
-                    "Order {OrderId} was already in a terminal state when SetOrderSendConditionNotMetAsync was called; this order was processed more than once.",
-                    order.Id);
+                await using NpgsqlCommand statusCmd = new(
+                    "SELECT processedstatus FROM notifications.orders WHERE alternateid = $1",
+                    connection,
+                    transaction);
+                statusCmd.Parameters.AddWithValue(NpgsqlDbType.Uuid, order.Id);
+                var currentStatus = (string?)await statusCmd.ExecuteScalarAsync(cancellationToken);
+
+                if (currentStatus is null)
+                {
+                    throw new InvalidOperationException($"Order {order.Id} was not found when attempting to set SendConditionNotMet.");
+                }
+
+                if (currentStatus is "SendConditionNotMet" or "Completed")
+                {
+                    // Expected duplicate delivery — the order was already processed successfully.
+                    _logger.LogError(
+                        "Order {OrderId} already had status '{CurrentStatus}' when SetOrderSendConditionNotMetAsync was called; this order was processed more than once.",
+                        order.Id,
+                        currentStatus);
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"Order {order.Id} had unexpected status '{currentStatus}' when attempting to set SendConditionNotMet; expected Processing.");
+                }
             }
 
             await transaction.CommitAsync(cancellationToken);

--- a/components/api/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/OrderRepositoryTests.cs
+++ b/components/api/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/OrderRepositoryTests.cs
@@ -3607,6 +3607,135 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task PersistProcessingResultAsync_WhenOrderAlreadyCompleted_IsIdempotentNoOp()
+    {
+        // Arrange
+        OrderRepository repo = (OrderRepository)ServiceUtil
+            .GetServices([typeof(IOrderRepository)])
+            .First(i => i.GetType() == typeof(OrderRepository));
+
+        NotificationOrder order = new()
+        {
+            Id = Guid.NewGuid(),
+            Created = DateTime.UtcNow,
+            Creator = new("ttd"),
+            SendersReference = "idempotency-test-already-completed",
+            Type = OrderType.Notification,
+            Templates = [new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)]
+        };
+
+        _orderIdsToDelete.Add(order.Id);
+        await repo.Create(order);
+        await repo.SetProcessingStatus(order.Id, OrderProcessingStatus.Processing);
+
+        var emailResult = new EmailOrderProcessingResult(
+            [new EmailNotification
+        {
+            Id = Guid.NewGuid(),
+            OrderId = order.Id,
+            RequestedSendTime = DateTime.UtcNow,
+            Recipient = new() { ToAddress = "recipient@example.com" },
+            SendResult = new(EmailNotificationResultType.Failed_RecipientNotIdentified, DateTime.UtcNow)
+        }
+            ],
+            ExpirationDateTime: DateTime.UtcNow.AddDays(1));
+        var smsResult = new SmsOrderProcessingResult([], ExpirationDateTime: null);
+
+        // First delivery — completes normally
+        await repo.PersistProcessingResultAsync(order, emailResult, smsResult, TestContext.Current.CancellationToken);
+
+        // Act — second delivery, order is already Completed (real duplicate-delivery race)
+        // New notification GUIDs are generated so there is no unique constraint conflict on insert.
+        var duplicateEmailResult = new EmailOrderProcessingResult(
+            [new EmailNotification
+        {
+            Id = Guid.NewGuid(),
+            OrderId = order.Id,
+            RequestedSendTime = DateTime.UtcNow,
+            Recipient = new() { ToAddress = "recipient@example.com" },
+            SendResult = new(EmailNotificationResultType.Failed_RecipientNotIdentified, DateTime.UtcNow)
+        }
+            ],
+            ExpirationDateTime: DateTime.UtcNow.AddDays(1));
+
+        await repo.PersistProcessingResultAsync(order, duplicateEmailResult, smsResult, TestContext.Current.CancellationToken);
+
+        // Assert — status still Completed, no duplicate notifications persisted
+        string statusSql = $"SELECT processedstatus FROM notifications.orders WHERE alternateid = '{order.Id}'";
+        string actualStatus = await PostgreUtil.RunSqlReturnOutput<string>(statusSql);
+        Assert.Equal(OrderProcessingStatus.Completed.ToString(), actualStatus);
+
+        string notificationCountSql = $@"SELECT count(1) FROM notifications.emailnotifications e
+        JOIN notifications.orders o ON e._orderid = o._id WHERE o.alternateid = '{order.Id}'";
+        int notificationCount = await PostgreUtil.RunSqlReturnOutput<int>(notificationCountSql);
+        Assert.Equal(1, notificationCount); // only from first delivery
+    }
+
+    [Fact]
+    public async Task PersistProcessingResultAsync_WhenOrderAlreadyProcessed_IsIdempotentNoOp()
+    {
+        // Arrange
+        OrderRepository repo = (OrderRepository)ServiceUtil
+            .GetServices([typeof(IOrderRepository)])
+            .First(i => i.GetType() == typeof(OrderRepository));
+
+        NotificationOrder order = new()
+        {
+            Id = Guid.NewGuid(),
+            Created = DateTime.UtcNow,
+            Creator = new("ttd"),
+            SendersReference = "idempotency-test-already-processed",
+            Type = OrderType.Notification,
+            Templates = [new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)]
+        };
+
+        _orderIdsToDelete.Add(order.Id);
+        await repo.Create(order);
+        await repo.SetProcessingStatus(order.Id, OrderProcessingStatus.Processing);
+
+        var emailResult = new EmailOrderProcessingResult(
+            [new EmailNotification
+        {
+            Id = Guid.NewGuid(),
+            OrderId = order.Id,
+            RequestedSendTime = DateTime.UtcNow,
+            Recipient = new() { ToAddress = "recipient@example.com" },
+            SendResult = new(EmailNotificationResultType.New, DateTime.UtcNow)
+        }
+            ],
+            ExpirationDateTime: DateTime.UtcNow.AddDays(1));
+        var smsResult = new SmsOrderProcessingResult([], ExpirationDateTime: null);
+
+        // First delivery — sets order to Processed (notification is New, not terminal)
+        await repo.PersistProcessingResultAsync(order, emailResult, smsResult, TestContext.Current.CancellationToken);
+
+        // Act — second delivery, order is already Processed
+        var duplicateEmailResult = new EmailOrderProcessingResult(
+            [new EmailNotification
+        {
+            Id = Guid.NewGuid(),
+            OrderId = order.Id,
+            RequestedSendTime = DateTime.UtcNow,
+            Recipient = new() { ToAddress = "recipient@example.com" },
+            SendResult = new(EmailNotificationResultType.New, DateTime.UtcNow)
+        }
+            ],
+            ExpirationDateTime: DateTime.UtcNow.AddDays(1));
+
+        await repo.PersistProcessingResultAsync(order, duplicateEmailResult, smsResult, TestContext.Current.CancellationToken);
+
+        // Assert — status still Processed, no duplicate notifications persisted
+        string statusSql = $"SELECT processedstatus FROM notifications.orders WHERE alternateid = '{order.Id}'";
+        string actualStatus = await PostgreUtil.RunSqlReturnOutput<string>(statusSql);
+        Assert.Equal(OrderProcessingStatus.Processed.ToString(), actualStatus);
+
+        string notificationCountSql = $@"SELECT count(1) FROM notifications.emailnotifications e
+        JOIN notifications.orders o ON e._orderid = o._id WHERE o.alternateid = '{order.Id}'";
+        int notificationCount = await PostgreUtil.RunSqlReturnOutput<int>(notificationCountSql);
+        Assert.Equal(1, notificationCount); // only from first delivery
+    }
+
+    [Fact]
     public async Task PersistProcessingResultAsync_SmsNotification_PersistsAllRecipientFields()
     {
         // Arrange

--- a/components/api/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/OrderRepositoryTests.cs
+++ b/components/api/test/Altinn.Notifications.IntegrationTests/Notifications.Persistence/OrderRepositoryTests.cs
@@ -3504,7 +3504,7 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task SetOrderSendConditionNotMetAsync_OrderProcessedTwice_SecondCallIsIdempotentNoOp()
+    public async Task SetOrderSendConditionNotMetAsync_WhenAlreadySendConditionNotMet_IsIdempotentNoOp()
     {
         // Arrange
         OrderRepository repo = (OrderRepository)ServiceUtil
@@ -3516,7 +3516,7 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
             Id = Guid.NewGuid(),
             Created = DateTime.UtcNow,
             Creator = new("ttd"),
-            SendersReference = "tx-test-processed-twice",
+            SendersReference = "idempotency-test-already-not-met",
             Type = OrderType.Notification,
             Templates = [new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)]
         };
@@ -3525,18 +3525,56 @@ public sealed class OrderRepositoryTests : IAsyncLifetime
         await repo.Create(order);
         await repo.SetProcessingStatus(order.Id, OrderProcessingStatus.Processing);
 
-        // Act - first call completes normally
+        // First delivery — normal path
         await repo.SetOrderSendConditionNotMetAsync(order, TestContext.Current.CancellationToken);
 
-        // Simulate the order somehow being reprocessed: reset it back to Processing so the
-        // second call reaches the status feed insert instead of failing on the state guard.
-        await PostgreUtil.RunSql($"UPDATE notifications.orders SET processedstatus = 'Processing' WHERE alternateid = '{order.Id}'");
-
+        // Act — second delivery, order is already SendConditionNotMet (real duplicate-delivery race)
+        // Should not throw and should not write a second status feed entry
         await repo.SetOrderSendConditionNotMetAsync(order, TestContext.Current.CancellationToken);
 
-        // Assert - second call did not throw, and only one status feed entry exists
+        // Assert
+        string statusSql = $"SELECT processedstatus FROM notifications.orders WHERE alternateid = '{order.Id}'";
+        string actualStatus = await PostgreUtil.RunSqlReturnOutput<string>(statusSql);
+        Assert.Equal(OrderProcessingStatus.SendConditionNotMet.ToString(), actualStatus);
+
         int statusFeedCount = await PostgreUtil.SelectStatusFeedEntryCount(order.Id);
-        Assert.Equal(1, statusFeedCount);
+        Assert.Equal(1, statusFeedCount); // only one entry, not two
+    }
+
+    [Fact]
+    public async Task SetOrderSendConditionNotMetAsync_WhenAlreadyCompleted_IsIdempotentNoOp()
+    {
+        // Arrange
+        OrderRepository repo = (OrderRepository)ServiceUtil
+            .GetServices([typeof(IOrderRepository)])
+            .First(i => i.GetType() == typeof(OrderRepository));
+
+        NotificationOrder order = new()
+        {
+            Id = Guid.NewGuid(),
+            Created = DateTime.UtcNow,
+            Creator = new("ttd"),
+            SendersReference = "idempotency-test-already-completed",
+            Type = OrderType.Notification,
+            Templates = [new EmailTemplate("noreply@altinn.no", "Subject", "Body", EmailContentType.Plain)]
+        };
+
+        _orderIdsToDelete.Add(order.Id);
+        await repo.Create(order);
+        await repo.SetProcessingStatus(order.Id, OrderProcessingStatus.Processing);
+        await repo.SetProcessingStatus(order.Id, OrderProcessingStatus.Completed);
+
+        // Act — condition-not-met arrives after the order is already Completed
+        // Should not throw and should not overwrite the Completed status
+        await repo.SetOrderSendConditionNotMetAsync(order, TestContext.Current.CancellationToken);
+
+        // Assert — status stays Completed, no status feed entry written for SendConditionNotMet
+        string statusSql = $"SELECT processedstatus FROM notifications.orders WHERE alternateid = '{order.Id}'";
+        string actualStatus = await PostgreUtil.RunSqlReturnOutput<string>(statusSql);
+        Assert.Equal(OrderProcessingStatus.Completed.ToString(), actualStatus);
+
+        int statusFeedCount = await PostgreUtil.SelectStatusFeedEntryCount(order.Id);
+        Assert.Equal(0, statusFeedCount);
     }
 
     [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #1802 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate requests from changing processed or completed orders.
  - Avoided duplicate notifications and status updates during repeated processing.
  - Added validation for missing or unexpected order statuses.
  - Ensured status history is updated only after successful transitions.
  - Improved handling of orders that cannot be transitioned.

- **Tests**
  - Expanded coverage for repeated updates across processed, completed, and send-condition states.
  - Confirmed duplicate requests leave orders unchanged without creating additional status entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->